### PR TITLE
nexthop: reset before putting back in pool

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -181,7 +181,7 @@ struct nexthop *nexthop_lookup(struct nh_pool *nhp, uint16_t vrf_id, const void 
 
 void nexthop_decref(struct nexthop *nh) {
 	if (nh->ref_count <= 1) {
-		struct nh_pool *nhp = nh->pool;
+		struct rte_mempool *pool = nh->pool->mp;
 		// Flush all held packets.
 		struct rte_mbuf *m = nh->held_pkts_head;
 		while (m != NULL) {
@@ -189,8 +189,8 @@ void nexthop_decref(struct nexthop *nh) {
 			rte_pktmbuf_free(m);
 			m = next;
 		}
-		rte_mempool_put(nhp->mp, nh);
 		memset(nh, 0, sizeof(*nh));
+		rte_mempool_put(pool, nh);
 	} else {
 		nh->ref_count--;
 	}


### PR DESCRIPTION
It feels weird to reset the nexthop to 0 *after* putting it back into the available nexthops mempool.

It is working at the moment because we only have a single thread processing them but let's change that to make it cleaner.

Fixes: 6271221275a9 ("infra: implement generic nexthop pool")
Reported-by: David Marchand <david.marchand@redhat.com>