### PR TITLE
infra: fix crash when changing port configuration

### DIFF
--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -106,7 +106,7 @@ static struct api_out iface_set(const void *request, void ** /*response*/) {
 	const struct gr_infra_iface_set_req *req = request;
 	int ret;
 
-	ret = iface_reconfig(req->iface.id, req->set_attrs, &req->iface, NULL);
+	ret = iface_reconfig(req->iface.id, req->set_attrs, &req->iface, req->iface.info);
 	if (ret < 0)
 		return api_out(errno, 0);
 

--- a/smoke/config_test.sh
+++ b/smoke/config_test.sh
@@ -12,6 +12,8 @@ grcli add ip route 0.0.0.0/0 via 10.0.0.2
 grcli add ip6 address 2345::1/24 iface p0
 grcli add ip6 address 2346::1/24 iface p1
 grcli add ip6 route ::/0 via 2345::2
+grcli set interface port p0 rxqs 2
+grcli set interface port p1 rxqs 2
 grcli show interface
 grcli show ip route
 grcli show ip nexthop


### PR DESCRIPTION
When changing any interface type specific configuration, a NULL pointer dereferences happens. Example when changing the number of RXQs of a port:

```
 grout> set interface port p0 rxqs 2

 ==566931==ERROR: AddressSanitizer: SEGV on unknown address
 ==566931==The signal is caused by a READ memory access.
 ==566931==Hint: address points to the zero page.
     #0 0x455ad5 in iface_port_reconfig ../modules/infra/control/port.c:166
     #1 0x42fbcd in iface_reconfig ../modules/infra/control/iface.c:136
     #2 0x40ee3e in iface_set ../modules/infra/api/iface.c:109
     #3 0x406549 in read_cb ../main/api.c:287

 Thread 1 "grout" hit Breakpoint 2, iface_port_reconfig
  (iface=0x7ff7f39f7f00, set_attrs=4294967296, conf=0x513000008e00,
  api_info=0x0) at ../modules/infra/control/port.c:154
 154             struct iface_info_port *p = (struct iface_info_port *)iface->info;
 (gdb) p api_info
 $1 = (const void *) 0x0
```

The same error may happen when changing the configuration of a vlan or ipip interface.

Make sure to pass the type specific information down to iface_reconfig as it is done for iface_create.

Update the config smoke test to ensure it works.

Fixes: d221e115343e ("infra: rework iface creation reconfig apis")