### PR TITLE
clang-format: strip extra parentheses and semicolons

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -139,6 +139,8 @@ QualifierAlignment: Leave
 ReferenceAlignment: Pointer
 ReflowComments: false
 RemoveBracesLLVM: false
+RemoveParentheses: ReturnStatement
+RemoveSemicolon: true
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes: CaseSensitive

--- a/modules/ip/api/dnat44.c
+++ b/modules/ip/api/dnat44.c
@@ -16,7 +16,7 @@ static bool dnat44_data_priv_equal(const struct nexthop *a, const struct nexthop
 	ad = dnat44_nh_data(a);
 	bd = dnat44_nh_data(b);
 
-	return (ad->replace == bd->replace);
+	return ad->replace == bd->replace;
 }
 
 static int dnat44_data_priv_add(

--- a/modules/srv6/control/localsid.c
+++ b/modules/srv6/control/localsid.c
@@ -20,8 +20,8 @@ static bool srv6_localsid_priv_equal(const struct nexthop *a, const struct nexth
 	ad = srv6_localsid_nh_priv(a);
 	bd = srv6_localsid_nh_priv(b);
 
-	return (ad->behavior == bd->behavior && ad->out_vrf_id == bd->out_vrf_id
-		&& ad->flags == bd->flags);
+	return ad->behavior == bd->behavior && ad->out_vrf_id == bd->out_vrf_id
+		&& ad->flags == bd->flags;
 }
 
 static struct api_out srv6_localsid_add(const void *request, void ** /*response*/) {

--- a/modules/srv6/datapath/srv6_local.c
+++ b/modules/srv6/datapath/srv6_local.c
@@ -71,7 +71,7 @@ static int ip6_fill_infos(struct rte_mbuf *m, struct ip6_info *ip6_info) {
 	ip6_info->ext_offset = sizeof(*ip6);
 
 	// advance through IPv6 extension headers until we find a proto supported by SRv6
-	while ((!proto_supported[ip6_info->proto])) {
+	while (!proto_supported[ip6_info->proto]) {
 		size_t ext_size = 0;
 		const uint8_t *ext;
 		uint8_t _ext[2];
@@ -259,7 +259,7 @@ static int process_behav_end(
 	if (sr == NULL || sr->segments_left == 0) {
 		// 4.16.3 USD
 		// this packet could be decapsulated and forwarded
-		if ((sr_d->flags & GR_SR_FL_FLAVOR_USD))
+		if (sr_d->flags & GR_SR_FL_FLAVOR_USD)
 			return process_behav_decap(m, sr_d, ip6_info);
 
 		// process locally
@@ -378,7 +378,7 @@ next:
 
 static void srv6_node_init(void) {
 	ip6_input_register_nexthop_type(GR_NH_T_SR6_LOCAL, "sr6_local");
-};
+}
 
 static struct rte_node_register srv6_local_node = {
 	.name = "sr6_local",


### PR DESCRIPTION
Make the code more consistent.