### PR TITLE
Frr no kernel sync

### DIFF
--- a/frr/if_grout.h
+++ b/frr/if_grout.h
@@ -9,12 +9,6 @@
 #include <stdbool.h>
 #include <zebra/zebra_dplane.h>
 
-// ugly hack to avoid collision with ifindex kernel
-// Don't use 1<<32, because ietf-interfaces.yang defined int32, not uint32
-// else it triggers assert in
-// `libyang: Unsatisfied raInge - value "-2147483647" is out of the allowed range`
-#define GROUT_INDEX_OFFSET (1000000000) // 1<<30 , round-up to lower decimal numbers
-
 enum zebra_dplane_result grout_add_del_address(struct zebra_dplane_ctx *ctx);
 
 void grout_interface_addr_dplane(struct gr_nexthop *gr_nh, bool new);

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -202,11 +202,7 @@ static int grout_gr_nexthop_to_frr_nexthop(
 		gr_log_err("sync nexthop not L3 from grout is not supported");
 		return -1;
 	}
-	if (gr_nh->iface_id)
-		nh->ifindex = gr_nh->iface_id + GROUT_INDEX_OFFSET;
-	else
-		nh->ifindex = 0;
-
+	nh->ifindex = gr_nh->iface_id;
 	nh->vrf_id = gr_nh->vrf_id;
 	nh->weight = 1;
 
@@ -840,11 +836,7 @@ enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx) {
 		gr_log_err("impossible to add/del nexthop in grout that does not have an ifindex");
 		return ZEBRA_DPLANE_REQUEST_FAILURE;
 	}
-	if (nh->ifindex < GROUT_INDEX_OFFSET) {
-		gr_log_err("impossible to add/del nexthop on interface not managed by grout");
-		return ZEBRA_DPLANE_REQUEST_FAILURE;
-	}
-	gr_nh->iface_id = nh->ifindex - GROUT_INDEX_OFFSET;
+	gr_nh->iface_id = nh->ifindex;
 
 	switch (nh->type) {
 	case NEXTHOP_TYPE_IPV4:

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -474,8 +474,23 @@ static int zd_grout_process(struct zebra_dplane_provider *prov) {
 
 static void zd_grout_ns(struct event *t) {
 	struct event_loop *dg_master = dplane_get_thread_master();
+	struct vrf *default_vrf;
 
 	zebra_ns_disabled(ns_get_default());
+
+	// Delete all vrfs including the default one
+	vrf_terminate();
+
+	default_vrf = vrf_get(VRF_DEFAULT, VRF_DEFAULT_NAME);
+	if (!default_vrf) {
+		gr_log_err("failed to recreate the default VRF!");
+		exit(1);
+	}
+	// Enable the default VRF
+	if (!vrf_enable(default_vrf)) {
+		gr_log_err("failed to re-enable the default VRF!");
+		exit(1);
+	}
 
 	// Add timer to connect on grout socket to get events
 	event_add_timer(dg_master, dplane_grout_connect, NULL, 0, NULL);


### PR DESCRIPTION
Disable kernel object synchronization in zebra, destroy all ifaces/routes/nexthop sync at startup.

## Summary by Sourcery

Stop syncing kernel objects in zebra's grout provider by tearing down all VRFs at startup, recreate the default VRF, and streamline interface handling by dropping the artificial offset and enforcing index sanity checks

Bug Fixes:
- Add validation for interface indices in address add/del operations to prevent invalid index usage

Enhancements:
- Disable kernel object synchronization at startup and flush all VRFs before reconnecting the data-plane provider sockets
- Remove GROUT_INDEX_OFFSET hack and use raw interface indices consistently in if_grout and rt_grout modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for interface indices during address operations, preventing invalid interface index usage.
  * Eliminated the use of a constant offset for interface indices, ensuring direct and accurate mapping of interface IDs.

* **Refactor**
  * Streamlined internal handling of interface indices by removing unnecessary offset logic.
  * Updated the startup sequence for network namespace and VRF initialization, improving reliability of connection setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->