### PR TITLE
rpm: fix build on recent fedora

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -86,7 +86,7 @@ rpm:
 	$Q arch=`rpm --eval '%{_arch}'` && \
 	version="$(rpmversion)-$(rpmrelease)" && \
 	mv -vf ~/rpmbuild/RPMS/noarch/grout-devel-$$version.noarch.rpm grout-devel.noarch.rpm && \
-	for name in grout grout-debuginfo grout-debugsource; do \
+	for name in grout grout-debuginfo; do \
 		mv -vf ~/rpmbuild/RPMS/$$arch/$$name-$$version.$$arch.rpm \
 			$$name.$$arch.rpm || exit; \
 	done

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Robin Jarry
 
+%undefine _debugsource_packages
 %global _lto_cflags %nil
 %global branch main
 %global __meson_wrap_mode default
-%if "%toolset" != ""
+%if %{defined toolset}
 %global __meson /usr/bin/scl run %toolset -- /usr/bin/meson
 %endif
 
@@ -17,7 +18,7 @@ Version: %{version}
 Release: %{release}
 Source0: https://github.com/DPDK/grout/archive/%{branch}.tar.gz#/%{name}-%{version}-%{release}.tar.gz
 
-%if "%toolset" == ""
+%if %{undefined toolset}
 BuildRequires: gcc >= 13
 %else
 BuildRequires: %toolset
@@ -54,7 +55,9 @@ It comes with a client library to configure it over a standard UNIX socket and
 a CLI that uses that library. The CLI can be used as an interactive shell, but
 also in scripts one command at a time, or by batches.
 
+%if %{undefined fedora}
 %debug_package
+%endif
 
 %package devel
 Summary: Development headers for building %{name} API clients
@@ -69,7 +72,6 @@ This package contains the development headers to build %{grout} API clients.
 %meson_build
 
 %install
-rm -rf %{buildroot}
 %meson_install --skip-subprojects
 
 install -D -m 0644 main/grout.default %{buildroot}%{_sysconfdir}/default/grout
@@ -77,9 +79,6 @@ install -D -m 0644 main/grout.init %{buildroot}%{_sysconfdir}/grout.init
 install -D -m 0644 main/grout.service %{buildroot}%{_unitdir}/grout.service
 install -D -m 0644 main/grout.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grout
 install -D -m 0644 cli/grcli.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grcli
-
-%clean
-rm -rf %{buildroot} %{_vpath_builddir}
 
 %post
 %systemd_post %{name}.service


### PR DESCRIPTION
Recent Fedora rpmbuild automatically include %debug_package in the spec definition. However, older distros (RHEL, CentOS) did/do not. Since we explicitly invoke %debug_package, we have a duplicate grout-debuginfo package declaration on Fedora. Only invoke %debug_package when *not* on Fedora.

Additionally, the -debugsource package generation has changed extensively and is broken for --build-in-place on Fedora. There is no way around it and we don't really need these packages. Disable them completely.

Finally, when undefined, %toolset will expand to the %toolset literal string. When building on Fedora, this is undefined and the following tests "%toolset" != "" or "%toolset" == "" produce incorrect results. Check if the variable is {,un}defined instead.

For good measure, remove extraneous folder cleanups.

## Summary by Sourcery

Fix RPM build failures on recent Fedora by avoiding duplicate and broken debug packages, correcting toolset detection, and cleaning up spec and Makefile.

Bug Fixes:
- Invoke %debug_package only on non-Fedora builds to prevent duplicate debug-info packages
- Disable broken -debugsource package generation by undefining _debugsource_packages
- Correct %toolset detection using defined/undefined RPM macros instead of string comparisons
- Remove redundant %clean section and manual buildroot cleanup from spec file
- Update GNUmakefile RPM target to stop moving the removed grout-debugsource package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging process to exclude the debugsource package from RPM output.
  * Improved conditional handling for build requirements and debug package generation, especially for Fedora builds.
  * Adjusted cleanup steps during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->