### PR TITLE
modules/infra: avoid ID allocation for interface-address nexthops

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -107,6 +107,9 @@ static int nexthop_id_get(struct nexthop *nh) {
 		nh->nh_id = 0;
 		return 0;
 	}
+	// don't allocate nh id for address, else will conflict with zebra nexthop address
+	if (nh->nh_id == 0 && nh->origin == GR_NH_ORIGIN_LINK)
+		return 0;
 
 	// if no id allocate one
 	if (nh->nh_id == 0) {


### PR DESCRIPTION
Grout assigns IDs to all nexthops (except internal), including those tied to connected routes. In the kernel, connected routes come only from interface addresses; their nexthop is embedded in the route and has no separate nexthop object. Zebra recreates these on IFA events and ignores the matching RTM_NEWROUTE to avoid duplicates [1][2].

With Grout, emitting nexthop events for connected routes creates duplicates: one from Grout and one from Zebra. On interface-nhg reinstall [3], Zebra re-sends the Grout-created nexthop, overwriting neighbor (L2) state because Grout merges nexthop and neighbor concepts unlike the kernel.

To fix, skip ID allocation for interface-address nexthops. Since Zebra can still create nexthops with `origin link`, the nexthop ID is not reset to ero when its provided.

[1] https://github.com/FRRouting/frr/blob/rc/10.4.1/zebra/zebra_rib.c#L4587
[2] https://github.com/FRRouting/frr/blob/rc/10.4.1/zebra/zebra_rib.c#L4575
[3] https://github.com/FRRouting/frr/blob/rc/10.4.1/zebra/zebra_rib.c#L4587