### PR TITLE
ipv6: use input interface for responding to neigh solicitations

### DIFF
--- a/modules/ip6/datapath/ndp_na_output.c
+++ b/modules/ip6/datapath/ndp_na_output.c
@@ -29,6 +29,7 @@ static uint16_t ndp_na_output_process(
 	struct ip6_local_mbuf_data *d;
 	struct icmp6_neigh_advert *na;
 	struct icmp6_opt_lladdr *ll;
+	const struct iface *iface;
 	struct icmp6_opt *opt;
 	struct rte_mbuf *mbuf;
 	uint16_t payload_len;
@@ -39,6 +40,7 @@ static uint16_t ndp_na_output_process(
 
 		local = ndp_na_output_mbuf_data(mbuf)->local;
 		remote = ndp_na_output_mbuf_data(mbuf)->remote;
+		iface = ndp_na_output_mbuf_data(mbuf)->iface;
 
 		rte_pktmbuf_trim(mbuf, rte_pktmbuf_pkt_len(mbuf));
 
@@ -60,7 +62,7 @@ static uint16_t ndp_na_output_process(
 
 		// Fill in IP local data
 		d = ip6_local_mbuf_data(mbuf);
-		d->iface = iface_from_id(local->iface_id);
+		d->iface = iface;
 		d->src = local->ipv6;
 		if (remote == NULL) {
 			// If the source of the solicitation is the unspecified address, the


### PR DESCRIPTION
When receiving a neighbor solicitation, if grout owns the requested IPv6
address, we generate a neighbor advertisement for this address. If the
address is not assigned to any interface (e.g. for local SIDs),
iface_from_id(GR_IFACE_ID_UNDEF); returns NULL and it causes
a segmentation fault in icmp6_output when trying to access that
interface vrf_id.

Use the same pattern than in IPv4 output, use the input interface as
output interface.

Signed-off-by: Robin Jarry <rjarry@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined how the network interface is determined during IPv6 Neighbor Advertisement processing by using packet metadata, reducing lookup overhead.
  * Improves efficiency and consistency under load without altering behavior.

* **Notes**
  * No user-facing changes, configuration updates, or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->