### PR TITLE
main-loop: fix maximum sleep time overflow

### DIFF
--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -196,7 +196,7 @@ reconfig:
 			cycles = timestamp_tmp - timestamp;
 			max_sleep_us = atomic_load(&w->max_sleep_us);
 			if (ctx.last_count == 0 && max_sleep_us > 0) {
-				sleep = sleep == max_sleep_us ? sleep : (sleep + 1);
+				sleep = sleep >= max_sleep_us ? max_sleep_us : (sleep + 1);
 				usleep(sleep);
 				ctx.w_stats->sleep_cycles += rte_rdtsc() - timestamp_tmp;
 				ctx.w_stats->n_sleeps += 1;


### PR DESCRIPTION
When max_sleep_us is updated by the control plane thread from a large value to a lower one, the main loop may never take the new maximum into account until it sees one packet.

Change the logic to ensure the sleep time can never be longer than the configured maximum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted backoff timing to cap sleep increases at a maximum, ensuring steadier loop timing.
  - Reduces unnecessary wakeups under low activity, improving idle CPU utilization and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->