### PR TITLE
overhead stats

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -125,8 +125,8 @@ struct gr_port_rxq_map {
 struct gr_infra_stat {
 	char name[64];
 	uint64_t topo_order;
-	uint64_t objs;
-	uint64_t calls;
+	uint64_t packets;
+	uint64_t batches;
 	uint64_t cycles;
 };
 

--- a/modules/infra/cli/stats.c
+++ b/modules/infra/cli/stats.c
@@ -33,9 +33,9 @@ static int stats_order_packets(const void *sa, const void *sb) {
 	const struct gr_infra_stat *a = sa;
 	const struct gr_infra_stat *b = sb;
 
-	if (a->objs == b->objs)
+	if (a->packets == b->packets)
 		return 0;
-	if (a->objs > b->objs)
+	if (a->packets > b->packets)
 		return -1;
 	return 1;
 }
@@ -96,16 +96,16 @@ static cmd_status_t stats_get(struct gr_api_client *c, const struct ec_pnode *p)
 		for (size_t i = 0; i < resp->n_stats; i++) {
 			const struct gr_infra_stat *s = &resp->stats[i];
 			if (req.flags & GR_INFRA_STAT_F_HW || brief)
-				printf("%s %lu\n", s->name, s->objs);
+				printf("%s %lu\n", s->name, s->packets);
 		}
 	} else {
 		struct libscols_table *table = scols_new_table();
 
 		scols_table_new_column(table, "NODE", 0, 0);
-		scols_table_new_column(table, "CALLS", 0, SCOLS_FL_RIGHT);
+		scols_table_new_column(table, "BATCHES", 0, SCOLS_FL_RIGHT);
 		scols_table_new_column(table, "PACKETS", 0, SCOLS_FL_RIGHT);
-		scols_table_new_column(table, "PKTS/CALL", 0, SCOLS_FL_RIGHT);
-		scols_table_new_column(table, "CYCLES/CALL", 0, SCOLS_FL_RIGHT);
+		scols_table_new_column(table, "PKTS/BATCH", 0, SCOLS_FL_RIGHT);
+		scols_table_new_column(table, "CYCLES/BATCH", 0, SCOLS_FL_RIGHT);
 		scols_table_new_column(table, "CYCLES/PKT", 0, SCOLS_FL_RIGHT);
 		scols_table_set_column_separator(table, "  ");
 
@@ -116,16 +116,16 @@ static cmd_status_t stats_get(struct gr_api_client *c, const struct ec_pnode *p)
 			double pkt_call = 0, cycles_pkt = 0, cycles_call = 0;
 			const struct gr_infra_stat *s = &resp->stats[i];
 
-			if (s->calls != 0) {
-				pkt_call = ((double)s->objs) / ((double)s->calls);
-				cycles_call = ((double)s->cycles) / ((double)s->calls);
+			if (s->batches != 0) {
+				pkt_call = ((double)s->packets) / ((double)s->batches);
+				cycles_call = ((double)s->cycles) / ((double)s->batches);
 			}
-			if (s->objs != 0)
-				cycles_pkt = ((double)s->cycles) / ((double)s->objs);
+			if (s->packets != 0)
+				cycles_pkt = ((double)s->cycles) / ((double)s->packets);
 
 			scols_line_sprintf(line, 0, "%s", s->name);
-			scols_line_sprintf(line, 1, "%lu", s->calls);
-			scols_line_sprintf(line, 2, "%lu", s->objs);
+			scols_line_sprintf(line, 1, "%lu", s->batches);
+			scols_line_sprintf(line, 2, "%lu", s->packets);
 			scols_line_sprintf(line, 3, "%.01f", pkt_call);
 			scols_line_sprintf(line, 4, "%.01f", cycles_call);
 			scols_line_sprintf(line, 5, "%.01f", cycles_pkt);

--- a/modules/infra/control/gr_worker.h
+++ b/modules/infra/control/gr_worker.h
@@ -25,8 +25,8 @@ struct queue_map {
 struct node_stats {
 	rte_node_t node_id;
 	uint16_t topo_order;
-	uint64_t objs;
-	uint64_t calls;
+	uint64_t packets;
+	uint64_t batches;
 	uint64_t cycles;
 };
 

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -43,8 +43,8 @@ static int node_stats_callback(
 	ctx->last_count += objs_incr;
 	index = ctx->node_to_index[stats->id];
 	s = &ctx->w_stats->stats[index];
-	s->objs += objs_incr;
-	s->calls += stats->calls - stats->prev_calls;
+	s->packets += objs_incr;
+	s->batches += stats->calls - stats->prev_calls;
 	s->cycles += stats->cycles - stats->prev_cycles;
 
 	return 0;
@@ -53,8 +53,8 @@ static int node_stats_callback(
 static inline void stats_reset(struct worker_stats *stats) {
 	for (unsigned i = 0; i < stats->n_stats; i++) {
 		struct node_stats *s = &stats->stats[i];
-		s->objs = 0;
-		s->calls = 0;
+		s->packets = 0;
+		s->batches = 0;
 		s->cycles = 0;
 	}
 	stats->sleep_cycles = 0;


### PR DESCRIPTION
* **stats: add overhead cycles accounting**
* **main-loop: move reset stats to ensure consistency**
* **stats: always expose idle and overhead stats**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added an “Overhead” runtime stat to show non-node processing time.
  - Per-worker loop and cycle counters added for finer performance insight.

- Refactor
  - Stats now report packets and batches (replacing previous object/call metrics); UI/CLI columns updated accordingly.
  - Unified zero-value stat filtering for consistent display.
  - Standardized periodic housekeeping to stabilize stats windows and aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->