### PR TITLE
stats ordering

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -124,6 +124,7 @@ struct gr_port_rxq_map {
 
 struct gr_infra_stat {
 	char name[64];
+	uint64_t topo_order;
 	uint64_t objs;
 	uint64_t calls;
 	uint64_t cycles;

--- a/modules/infra/api/stats.c
+++ b/modules/infra/api/stats.c
@@ -51,6 +51,7 @@ static gr_vec struct gr_infra_stat *graph_stats(uint16_t cpu_id) {
 					.objs = n->objs,
 					.calls = n->calls,
 					.cycles = n->cycles,
+					.topo_order = n->topo_order,
 				};
 				memccpy(stat.name, name, 0, sizeof(stat.name));
 				gr_vec_add(stats, stat);
@@ -65,6 +66,7 @@ static gr_vec struct gr_infra_stat *graph_stats(uint16_t cpu_id) {
 				.objs = 0,
 				.calls = w_stats->n_sleeps,
 				.cycles = w_stats->sleep_cycles,
+				.topo_order = UINT64_MAX,
 			};
 			memccpy(stat.name, "idle", 0, sizeof(stat.name));
 			gr_vec_add(stats, stat);

--- a/modules/infra/cli/stats.c
+++ b/modules/infra/cli/stats.c
@@ -40,6 +40,17 @@ static int stats_order_packets(const void *sa, const void *sb) {
 	return 1;
 }
 
+static int stats_order_topo(const void *sa, const void *sb) {
+	const struct gr_infra_stat *a = sa;
+	const struct gr_infra_stat *b = sb;
+
+	if (a->topo_order == b->topo_order)
+		return 0;
+	if (a->topo_order > b->topo_order)
+		return 1;
+	return -1;
+}
+
 static cmd_status_t stats_get(struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_infra_stats_get_req req = {.flags = 0, .cpu_id = UINT16_MAX};
 	bool brief = arg_str(p, "brief") != NULL;
@@ -73,6 +84,8 @@ static cmd_status_t stats_get(struct gr_api_client *c, const struct ec_pnode *p)
 		sort_func = stats_order_cycles;
 	else if (strcmp(order, "packets") == 0)
 		sort_func = stats_order_packets;
+	else if (strcmp(order, "graph") == 0)
+		sort_func = stats_order_topo;
 	else if (req.flags & GR_INFRA_STAT_F_HW || brief)
 		sort_func = stats_order_name;
 	else
@@ -161,6 +174,10 @@ static int ctx_init(struct ec_node *root) {
 				with_help(
 					"Sort by decreasing number of packets.",
 					ec_node_str(EC_NO_ID, "packets")
+				),
+				with_help(
+					"Sort by graph topological order.",
+					ec_node_str(EC_NO_ID, "graph")
 				),
 				with_help(
 					"Sort by decreasing number of cycles.",

--- a/modules/infra/control/gr_worker.h
+++ b/modules/infra/control/gr_worker.h
@@ -24,6 +24,7 @@ struct queue_map {
 
 struct node_stats {
 	rte_node_t node_id;
+	uint16_t topo_order;
 	uint64_t objs;
 	uint64_t calls;
 	uint64_t cycles;

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -103,6 +103,7 @@ static int stats_reload(const struct rte_graph *graph, struct stats_context *ctx
 		rte_graph_foreach_node (count, off, graph, node) {
 			ctx->node_to_index[node->id] = count;
 			ctx->w_stats->stats[count].node_id = node->id;
+			ctx->w_stats->stats[count].topo_order = count;
 		}
 	}
 


### PR DESCRIPTION
- **stats: fix crash when dumping interface stats without interfaces**
- **stats: factorize gathering**
- **stats: allow filtering by cpu id**
- **stats: use common structure**
- **cli: allow specifying stats sort order**
- **stats: allow sorting by graph topological order**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Per-CPU filtering for stats (defaults to all CPUs).
  - New sorting options: by packets, graph topology, name, or cycles; applied across brief/detailed and HW/SW views.
  - Stats output now includes graph topology order for each node.

- Documentation
  - CLI help updated to describe CPU and ORDER options, including available sort modes and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->