### PR TITLE
api: ignore SIGPIPE when client disconnects

### DIFF
--- a/main/signals.c
+++ b/main/signals.c
@@ -28,12 +28,8 @@ static void signal_cb(evutil_socket_t sig, short /*what*/, void *priv) {
 static struct event *ev_sigint;
 static struct event *ev_sigquit;
 static struct event *ev_sigterm;
-static struct event *ev_sigchld;
-static struct event *ev_sigpipe;
 
 int register_signals(struct event_base *base) {
-	unregister_signals();
-
 	ev_sigint = evsignal_new(base, SIGINT, signal_cb, base);
 	if (ev_sigint == NULL || event_add(ev_sigint, NULL) < 0)
 		return errno_set(ENOMEM);
@@ -46,30 +42,19 @@ int register_signals(struct event_base *base) {
 	if (ev_sigquit == NULL || event_add(ev_sigquit, NULL) < 0)
 		return errno_set(ENOMEM);
 
-	ev_sigchld = evsignal_new(base, SIGCHLD, signal_cb, base);
-	if (ev_sigchld == NULL || event_add(ev_sigchld, NULL) < 0)
-		return errno_set(ENOMEM);
-
-	ev_sigpipe = evsignal_new(base, SIGPIPE, signal_cb, base);
-	if (ev_sigpipe == NULL || event_add(ev_sigpipe, NULL) < 0)
-		return errno_set(ENOMEM);
+	signal(SIGCHLD, SIG_IGN);
+	signal(SIGPIPE, SIG_IGN);
 
 	return 0;
 }
 
 void unregister_signals(void) {
-	if (ev_sigpipe != NULL)
-		event_free(ev_sigpipe);
-	if (ev_sigchld != NULL)
-		event_free(ev_sigchld);
 	if (ev_sigint != NULL)
 		event_free(ev_sigint);
 	if (ev_sigquit != NULL)
 		event_free(ev_sigquit);
 	if (ev_sigterm != NULL)
 		event_free(ev_sigterm);
-	ev_sigpipe = NULL;
-	ev_sigchld = NULL;
 	ev_sigterm = NULL;
 	ev_sigquit = NULL;
 	ev_sigint = NULL;


### PR DESCRIPTION
When a client disconnects while grout is sending data to the API socket, the daemon may be signaled with a SIGPIPE signal.

```
NOTICE: GROUT: signal_cb: received signal SIGPIPE
ERR: GROUT: event_cb: bufferevent error on fd=16: Broken pipe
```

There is no guarantee which thread will execute the signal handler. To avoid interrupting datapath threads, completely ignore the SIGPIPE (and SIGCHLD) signals.

The write() calls will still return an error and errno will contain EPIPE. Handle this in event_cb() and make sure to disconnect clients when EPIPE is received.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer logs: errors now reference the client process, improving traceability.
- Bug Fixes
  - Broken pipe errors are treated as clean disconnects, reducing noisy error states and ensuring graceful client cleanup.
- Refactor
  - Simplified signal handling by ignoring SIGCHLD and SIGPIPE, removing custom event management.
- Chores
  - Removed unused internal signal handlers and related cleanup code to reduce maintenance overhead and improve stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->