### PR TITLE
frr: Rename CMD to `docker-start`

### DIFF
--- a/Containerfile.frr
+++ b/Containerfile.frr
@@ -13,11 +13,11 @@ RUN mkdir -p /tmp/null/var/run/frr
 RUN chroot /tmp/null chown -R frr:frr /etc/frr /var/run/frr
 # not packaged in centos, download from upstream
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tmp/null/sbin/tini
-ADD https://raw.githubusercontent.com/FRRouting/frr/refs/tags/frr-10.4.1/docker/ubi8-minimal/docker-start /tmp/null/sbin/frr-start
-RUN chmod +x /tmp/null/sbin/tini /tmp/null/sbin/frr-start
+ADD https://raw.githubusercontent.com/FRRouting/frr/refs/tags/frr-10.4.1/docker/ubi8-minimal/docker-start /tmp/null/sbin/docker-start
+RUN chmod +x /tmp/null/sbin/tini /tmp/null/sbin/docker-start
 
 FROM scratch
 COPY --from=builder /tmp/null/ /
 STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/sbin/tini", "--"]
-CMD ["/sbin/frr-start"]
+CMD ["/sbin/docker-start"]


### PR DESCRIPTION
The `Container.frr` image is supposed to be a replacement of an FRR container. If the deployment command has been replaced, it is useful to have the same script name as the origin FRR image.

Avoid renaming `docker-start` -> `frr-start` in Containerfile.frr

Refs:
- https://github.com/FRRouting/frr/blob/10c1994d241ce12c73abd400841180d46d788d16/docker/centos-8/Dockerfile#L67
- https://github.com/openperouter/openperouter/blob/1e23239ee3a9c16f470fc424e51876d90143da5a/operator/bindata/deployment/openperouter/templates/router.yaml#L165C1-L166C1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container startup to use the upstream startup command and aligned startup steps with upstream layout.
  * Installed the new startup helper inside the container and set appropriate permissions.
  * Adjusted container run configuration; entrypoint behavior remains unchanged.

* **Notes**
  * No configuration changes required for users.
  * No changes to public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->