### PR TITLE
smoke: print stack traces on crashes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,8 +66,8 @@ jobs:
           set -xe
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
-            make gcc ccache ninja-build meson git go-md2man libibverbs-dev \
-            libasan8 libcmocka-dev libedit-dev libarchive-dev \
+            make gcc gdb ccache ninja-build meson git go-md2man \
+            libibverbs-dev libasan8 libcmocka-dev libedit-dev libarchive-dev \
             libevent-dev libsmartcols-dev libnuma-dev python3-pyelftools \
             socat tcpdump traceroute graphviz iproute2 iputils-ping ndisc6 jq
           if echo $MESON_EXTRA_OPTS | grep -q frr=enabled ; then

--- a/README.md
+++ b/README.md
@@ -281,13 +281,13 @@ In order to run the `smoke-tests`, `lint`, `check-patches` and `update-graph`
 targets, you'll need additional packages:
 
 ```sh
-dnf install gawk clang-tools-extra jq codespell curl traceroute graphviz ndisc6
+dnf install gawk gdb clang-tools-extra jq codespell curl traceroute graphviz ndisc6
 ```
 
 or
 
 ```sh
-apt install gawk clang-format jq codespell curl traceroute graphviz ndisc6
+apt install gawk gdb clang-format jq codespell curl traceroute graphviz ndisc6
 ```
 
 ### Build


### PR DESCRIPTION
The smoke tests suite does not provide any information when grout crashes with a signal. This makes debugging very hard, especially in CI environments.

Capture the grout PID at startup with `pgrep` to be able to use it later in the cleanup trap function. Set `ulimit` to allow core dumps, even when ASAN is enabled. Configure the kernel core pattern to write core dump files in the temporary test folder.

In the cleanup `EXIT` trap, save the current script exit status into a variable to avoid it being trampled by subsequent commands. When waiting for the grout process, inspect the returned status code to detect if it was terminated by a signal.

If a core dump is available, use `gdb` to extract stack traces from all threads. As a fallback, when no custom core pattern could be set, use `systemd-coredumpctl` to gather information about the crash.

Restore the trap exit status after all cleanup has been done to preserve the original script exit status and avoid marking failed tests as successful.

This requires adding `gdb` as a dependency for running the smoke tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated installation guides for RPM and Debian/Ubuntu to include gdb for easier local debugging.

- Tests
  - Improved smoke test reliability and diagnostics: preserves exit statuses, uses PID-based shutdown, enhanced core-dump collection with automatic stack traces, and more consistent temporary directory cleanup.

- Chores/CI
  - Continuous integration environment now installs gdb alongside existing system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->