### PR TITLE
frr: log errors on grout_notif_subscribe failure

### DIFF
--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -52,7 +52,7 @@ static int grout_notif_subscribe(
 
 	*pgr_client = gr_api_client_connect(gr_sock_path);
 	if (*pgr_client == NULL) {
-		gr_log_debug(
+		gr_log_err(
 			"connect failed on grout sock %s error: %s", gr_sock_path, strerror(errno)
 		);
 		return -1;
@@ -66,7 +66,7 @@ static int grout_notif_subscribe(
 			    *pgr_client, GR_MAIN_EVENT_SUBSCRIBE, sizeof(req), &req, NULL
 		    )
 		    < 0) {
-			gr_log_debug(
+			gr_log_err(
 				"subscribe on event failed on grout sock %s error: %s",
 				gr_sock_path,
 				strerror(errno)


### PR DESCRIPTION
Debug logging entries are not enabled by default.
If the grout_dplane plugin is unable to write to
the grout socket, there is no indication in the FRR logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased error logging severity for failed socket connections and subscription attempts to improve diagnostic visibility in grout-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->