### PR TITLE
smoke: fix running grout in a separate terminal

### DIFF
--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -140,7 +140,9 @@ if [ "$run_grout" = true ]; then
 	taskset -c 0,1 grout -tvvx $grout_extra_options &
 fi
 socat FILE:/dev/null UNIX-CONNECT:$GROUT_SOCK_PATH,retry=10
-grout_pid=$(pgrep -g0 grout)
+if [ "$run_grout" = true ]; then
+	grout_pid=$(pgrep -g0 grout)
+fi
 
 case "$(basename $0)" in
 config_test.sh|graph_svg_test.sh)


### PR DESCRIPTION
When grout is started manually in a separate terminal, pgrep -g0 grout returns nothing and exits with an error status. Indeed, there is no grout process started as a child of the shell script.

Only check for the PID if grout was started by the script.

Fixes: 6a7e9a4bffa2 ("smoke: print stack traces on crashes")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the system attempted to retrieve a process identifier unconditionally, even when the process wasn't configured to run. The retrieval now correctly occurs only when the process is actually started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->