### PR TITLE
ci: fix frr install

### DIFF
--- a/.github/actions/frr-install/run.sh
+++ b/.github/actions/frr-install/run.sh
@@ -5,7 +5,7 @@
 set -xe -o pipefail
 
 : ${PREFIX:=/usr}
-: ${SYSCONFDIR:=/etc/frr}
+: ${SYSCONFDIR:=/etc}
 : ${LIBDIR:=/usr/lib64}
 : ${SBINDIR:=/usr/lib/frr}
 : ${LIBEXECDIR:=/usr/libexec}
@@ -20,10 +20,10 @@ cd frr_build
 curl -L https://github.com/FRRouting/frr/pull/19351.diff | patch -p1
 autoreconf -ivf
 ./configure \
-	--prefix=/usr \
+	--prefix="$PREFIX" \
 	--sysconfdir="$SYSCONFDIR" \
-	--libdir="$LIBDIR/frr" \
-	--libexecdir="$LIBEXECDIR/frr" \
+	--libdir="$LIBDIR" \
+	--libexecdir="$LIBEXECDIR" \
 	--localstatedir="$LOCALSTATEDIR" \
 	--sbindir="$SBINDIR" \
 	--with-moduledir="$LIBDIR/frr/modules" \
@@ -35,4 +35,3 @@ autoreconf -ivf
 	--disable-fabricd --disable-vrrpd --disable-pathd --disable-ospfapi \
 	--disable-ospfclient --disable-bfdd --disable-python-runtime
 make -j install
-install -Dm 0644 pkgconfig/frr.pc "$LIBDIR/pkgconfig/frr.pc"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,9 +48,9 @@ jobs:
       - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
-          sysconfdir: /etc/frr
+          sysconfdir: /etc
           libdir: /usr/lib/x86_64-linux-gnu
-          libexecdir: /usr/libexec
+          libexecdir: /usr/libexec/frr
           sbindir: /usr/lib/frr
           localstatedir: /run/frr
           yangmodelsdir: /usr/share/frr-yang
@@ -100,7 +100,7 @@ jobs:
         with:
           sysconfdir: /etc
           libdir: /usr/lib64
-          libexecdir: /usr/libexec
+          libexecdir: /usr/libexec/frr
           sbindir: /usr/lib64/frr
           localstatedir: /var
           yangmodelsdir: /usr/share/frr-yang


### PR DESCRIPTION
The upstream (still pending) pull request on FRR has changed the path of this file and it now installs it in the correct location. No need to manually install it anymore.

Link: https://github.com/FRRouting/frr/pull/19351


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated installation/build defaults for system and library directories (sysconf, lib, libexec, local state, and YANG model locations).
  * Adjusted packaging workflow to reflect the new install defaults.
  * Removed installation of an auxiliary pkg-config file from the install process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->