### PR TITLE
github: change apply workflow to use pull request labels

### DIFF
--- a/.github/workflows/apply.sh
+++ b/.github/workflows/apply.sh
@@ -4,40 +4,29 @@
 
 set -e -o pipefail
 
-: ${PULL_REQUEST?PULL_REQUEST}
-: ${LOGIN?LOGIN}
-
-# get the full URL pointing to the current github action job
-job_url() {
-	local run_id="$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-	local job_id=$(gh api "repos/$run_id/jobs" --jq ".jobs[] | select(.name==\"$GITHUB_JOB\") | .id")
-	echo "https://github.com/$run_id/job/$job_id"
-}
+# default variables exported by github actions
+: ${GITHUB_ACTOR?GITHUB_ACTOR}
+: ${GITHUB_BASE_REF?GITHUB_BASE_REF}
+: ${GITHUB_HEAD_REF?GITHUB_HEAD_REF}
+: ${GITHUB_REPOSITORY?GITHUB_REPOSITORY}
+# custom variables defined in apply.yml
+: ${CLONE_URL?CLONE_URL}
+: ${GH_TOKEN?GH_TOKEN}
+: ${PR_NUMBER?PR_NUMBER}
 
 # post an error message on the pull request
-fail() {
+die() {
 	set +e
-	gh pr comment $PR_NUMBER -b "error: $1
-
-$JOB_URL"
-	exit 1
-}
-
-# error trap handler
-err() {
-	set +e
-	gh pr comment $PR_NUMBER -b "error: command \`$BASH_COMMAND\` failed
-
-$JOB_URL"
-	exit 1
+	echo "error: $*" >&2
+	return 1
 }
 
 # get the full name of the given github account (may not be available)
 user_name() {
-	local login=$1
-	local name=$(gh api users/$login --jq '.name')
+	local login=$1 name
+	name=$(gh api users/$login --jq '.name')
 	if [ -z "$name" ] || [ "$name" = null ]; then
-		fail "user $login does not expose their full name"
+		die "user $login does not expose their full name"
 	fi
 	echo "$name"
 }
@@ -56,13 +45,12 @@ email_from_git() {
 
 # get the email from a github account (fallback to looking at github history)
 user_email() {
-	local login=$1
-	local name=$2
-	local email=$(email_from_gh "$login")
+	local login=$1 name=$2 email
+	email=$(email_from_gh "$login")
 	if [ -z "$email" ] || [ "$email" = null ]; then
 		email=$(email_from_git "$name")
 		if [ -z "$email" ]; then
-			fail "user $login does not expose their email and is unknown from git history"
+			die "user $login does not expose their email and is unknown from git history"
 		fi
 	fi
 	echo "$email"
@@ -70,29 +58,15 @@ user_email() {
 
 trap err ERR
 
-# gather pull request details
-PR_JSON=$(gh api "$PULL_REQUEST")
-PR_NUMBER=$(echo "$PR_JSON" | jq -r .number)
-BASE_REF=$(echo "$PR_JSON" | jq -r .base.ref)
-HEAD_REF=$(echo "$PR_JSON" | jq -r .head.ref)
-NUM_COMMITS=$(echo "$PR_JSON" | jq -r .commits)
-HEAD_URL=$(echo "$PR_JSON" | jq -r .head.repo.clone_url)
-JOB_URL=$(job_url)
 tmp=$(mktemp -d)
 trap "rm -rf -- $tmp" EXIT
 
 set -x
 
-# ensure that the person that posted the '/apply' comment has push access
-perm=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$LOGIN/permission" --jq '.permission')
-if ! [ "$perm" = admin ] && ! [ "$perm" = write ]; then
-	fail "user $LOGIN does not have permission to apply PRs (permission: $perm)"
-fi
-
 # configure git identity to the person that posted the '/apply' comment
 # they will be "committer" of all the rebased commits
-GIT_COMMITTER_NAME=$(user_name "$LOGIN")
-GIT_COMMITTER_EMAIL=$(user_email "$LOGIN" "$GIT_COMMITTER_NAME")
+GIT_COMMITTER_NAME=$(user_name "$GITHUB_ACTOR")
+GIT_COMMITTER_EMAIL=$(user_email "$GITHUB_ACTOR" "$GIT_COMMITTER_NAME")
 git config set user.name "$GIT_COMMITTER_NAME"
 git config set user.email "$GIT_COMMITTER_EMAIL"
 export GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL
@@ -101,23 +75,19 @@ ln -s ../../devtools/commit-msg .git/hooks/commit-msg
 
 base_sha=$(git log -1 --pretty=%H HEAD)
 
-git remote add head "$HEAD_URL"
+gh auth setup-git
+git remote add head "$CLONE_URL"
 git fetch head
-git checkout -b "$HEAD_REF" "head/$HEAD_REF"
-git branch --set-upstream-to="origin/$BASE_REF"
+git checkout -b "$GITHUB_HEAD_REF" "head/$GITHUB_HEAD_REF"
+git branch --set-upstream-to="origin/$GITHUB_BASE_REF"
 
 # fast forward merge the pull request branch on top of the base one
-if ! git rebase "origin/$BASE_REF" >"$tmp/rebase" 2>&1; then
-	fail "rebase failed:
-\`\`\`
-$(cat $tmp/rebase)
-\`\`\`"
-fi
+git rebase "origin/$GITHUB_BASE_REF"
 
 # ensure at least one commit was applied
 rebased_sha=$(git log -1 --pretty=%H HEAD)
 if [ "$rebased_sha" = "$base_sha" ]; then
-	fail "branch commits already merged"
+	die "branch commits already merged"
 fi
 
 # add a Reviewed-by trailer for every "approved" review
@@ -146,21 +116,20 @@ done < "$tmp/trailers-uniq"
 if [ -n "$trailers" ]; then
 	# rewrite all commit messages, appending trailers
 	# hooks/commit-msg will remove duplicates and ensure correct ordering
-	GIT_TRAILER_DEBUG=1 git rebase "origin/$BASE_REF" \
+	GIT_TRAILER_DEBUG=1 git rebase "origin/$GITHUB_BASE_REF" \
 		--exec "git commit -C HEAD --no-edit --amend $trailers"
-	git log --pretty=fuller "origin/$BASE_REF.."
+	git log --pretty=fuller "origin/$GITHUB_BASE_REF.."
 fi
 
 # fast-forward merge the rebased branch with added trailers and push it manually
-git checkout "$BASE_REF"
-git merge --ff-only "$HEAD_REF"
-git push origin "$BASE_REF"
+git checkout "$GITHUB_BASE_REF"
+git merge --ff-only "$GITHUB_HEAD_REF"
+git push origin "$GITHUB_BASE_REF"
 
-# post a comment to identify the new HEAD commit id
-sha=$(git log -1 --pretty=%H "origin/$BASE_REF")
-gh pr comment "$PR_NUMBER" -b "Pull request applied with git trailers: $sha
-
-$(job_url)"
+gh pr comment "$PR_NUMBER" -b "Pull request applied with git trailers:
+\`\`\`
+$(cat $tmp/trailers-uniq)
+\`\`\`"
 
 # 'gh pr merge --rebase' will do nothing since the branch was already pushed
 # bypass the check and invoke the API endpoint directly

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Robin Jarry
 ---
-name: Apply PR
+name: Apply
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request_target:
+    types: [labeled]
 
 permissions:
   contents: write
@@ -13,20 +13,56 @@ permissions:
 
 jobs:
   apply:
-    if: github.event.issue.pull_request != null && github.event.comment.body == '/apply'
+    if: github.event.label.name == 'applied'
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-      PULL_REQUEST: ${{ github.event.issue.pull_request.url }}
-      LOGIN: ${{ github.event.comment.user.login }}
-
     steps:
-      - run: gh auth setup-git
+      - name: Ensure actor has required permissions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.pull_request.number;
+            const actor = context.actor;
+            const { data: collab } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: actor
+            });
+            if (!['admin', 'write'].includes(collab.permission)) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                name: 'applied',
+              });
+              const label = `https://github.com/${context.repo.owner}/${context.repo.repo}/labels/applied`;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                body: `@${actor}, you are not allowed to add the ${label} label. It has been removed. Only users with write/admin can trigger this workflow.`
+              });
+              core.setFailed(`@${actor} does not have permissions to trigger this workflow`);
+              process.exit(1);
+            }
 
       - uses: actions/checkout@v4
+        if: success()
         with:
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
 
+      - name: Generate grout-bot app token
+        if: success()
+        uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_PRIVATE_KEY }}
+
       - run: .github/workflows/apply.sh
+        if: success()
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION

Instead of triggering on issue comments containing "/apply", the workflow now triggers when the "applied" label is added to a pull request. This approach is more idiomatic for GitHub Actions and allows for better integration with GitHub's permission system.

The workflow uses a GitHub app token (grout-bot) instead of the default GITHUB_TOKEN. This is required to bypass branch protection rules that would otherwise prevent the workflow from pushing directly to the main branch. The app must be configured with appropriate repository permissions (Contents: write, Pull requests: write).

This change is designed to enforce a consistent merge workflow and prevent maintainers from manually clicking the "Rebase and merge" button on pull requests. By requiring the "applied" label to trigger the automated merge with git trailers, we ensure that all merged commits follow the same process: rebasing on top of the base branch, adding Reviewed-by trailers from approved reviews, and validating commit messages through the commit-msg hook.

We will rely on this GitHub app https://github.com/apps/grout-bot to have necessary permissions to bypass branch protection rules that prevent humans from merging.

The permission check is now performed as a dedicated workflow step using the actions/github-script action. If the actor does not have write/admin permissions, the label is automatically removed and a comment is posted explaining why.

The shell script has been simplified by relying on standard GitHub Actions environment variables (GITHUB_ACTOR, GITHUB_BASE_REF, GITHUB_HEAD_REF) instead of parsing the pull request JSON via API calls. Error handling has been streamlined by removing the job URL generation and error trap handler.
