### PR TITLE
github: fix rebase error when pr branch is lagging behind

### DIFF
--- a/.github/workflows/add-trailer.yml
+++ b/.github/workflows/add-trailer.yml
@@ -70,7 +70,7 @@ jobs:
             }
 
             return {
-              base_sha: pr.base.sha,
+              base_ref: pr.base.ref,
               head_repo: pr.head.repo.full_name,
               head_ref: pr.head.ref,
               trailer: trailer,
@@ -87,7 +87,7 @@ jobs:
       - name: Amend all pull request commits with the trailer
         env:
           GIT_TRAILER_DEBUG: 1
-          BASE_SHA: ${{ fromJSON(steps.info.outputs.result).base_sha }}
+          BASE_REF: ${{ fromJSON(steps.info.outputs.result).base_ref }}
           HEAD_REF: ${{ fromJSON(steps.info.outputs.result).head_ref }}
           TRAILER: ${{ fromJSON(steps.info.outputs.result).trailer }}
         run: |
@@ -122,7 +122,7 @@ jobs:
           rm -f .git/hooks/commit-msg
           ln -s ../../devtools/commit-msg .git/hooks/commit-msg
 
-          git rebase "$BASE_SHA" \
+          git rebase "origin/$BASE_REF" \
             --exec "git commit -C HEAD --no-edit --amend --trailer='$TRAILER'"
 
           git push --force origin "$HEAD_REF"


### PR DESCRIPTION
When the pull request branch is lagging behind the latest main branch, `$BASE_SHA` contains a commit ID which is not available in the forked repository. This causes an error when rebasing:

```
+ git rebase 119b782203cc0deaef22f7f18383bc8704a002a2 --exec '....'
fatal: invalid upstream '119b782203cc0deaef22f7f18383bc8704a002a2'
```

Replace the explicit commit ID with a symbolic base branch name which will be available in the forked repository.

Link: https://github.com/DPDK/grout/actions/runs/18775673525/job/53569651853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pull request workflow updated to use branch references instead of commit SHAs for PR metadata and rebase targets.
  * Environment variable name changed from BASE_SHA to BASE_REF to reflect branch-based handling.
  * Rebase operations now target the corresponding remote-tracking branch (origin/BASE_REF) for more consistent rebasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->