### PR TITLE
github: fix rebase error when pr branch is lagging behind

### DIFF
--- a/.github/workflows/add-trailer.yml
+++ b/.github/workflows/add-trailer.yml
@@ -61,7 +61,12 @@ jobs:
               if (matchingPRs.length === 0) {
                 throw new Error(`No open PR found for ${headBranch}`)
               }
-              pr = matchingPRs[0];
+              const { data: prData } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: matchingPRs[0].number
+              });
+              pr = prData;
 
               const actor = context.payload.workflow_run.triggering_actor.login;
               const req = await fetch(`https://api.github.com/users/${actor}`);
@@ -70,7 +75,7 @@ jobs:
             }
 
             return {
-              base_sha: pr.base.sha,
+              commits: pr.commits,
               head_repo: pr.head.repo.full_name,
               head_ref: pr.head.ref,
               trailer: trailer,
@@ -87,7 +92,7 @@ jobs:
       - name: Amend all pull request commits with the trailer
         env:
           GIT_TRAILER_DEBUG: 1
-          BASE_SHA: ${{ fromJSON(steps.info.outputs.result).base_sha }}
+          COMMITS: ${{ fromJSON(steps.info.outputs.result).commits }}
           HEAD_REF: ${{ fromJSON(steps.info.outputs.result).head_ref }}
           TRAILER: ${{ fromJSON(steps.info.outputs.result).trailer }}
         run: |
@@ -122,7 +127,7 @@ jobs:
           rm -f .git/hooks/commit-msg
           ln -s ../../devtools/commit-msg .git/hooks/commit-msg
 
-          git rebase "$BASE_SHA" \
+          git rebase "HEAD~$COMMITS" \
             --exec "git commit -C HEAD --no-edit --amend --trailer='$TRAILER'"
 
           git push --force origin "$HEAD_REF"


### PR DESCRIPTION

When the pull request branch is lagging behind the latest main branch, `$BASE_SHA` contains a commit ID which is not available in the forked repository. This causes an error when rebasing:

```
+ git rebase 119b782203cc0deaef22f7f18383bc8704a002a2 --exec '....'
fatal: invalid upstream '119b782203cc0deaef22f7f18383bc8704a002a2'
```

Replace the explicit commit ID with the HEAD symbolic ref and the number of commits present in the pull request.

Unfortunately, `github.rest.pulls.list()` returns incomplete pull request objects which are lacking the .commits field. When we found a matching pull request, explicitly call `github.rest.pulls.get()` to fetch the whole object.

Link: https://github.com/DPDK/grout/actions/runs/18775673525/job/53569651853


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow for automated PR trailer handling with more reliable PR data retrieval.
  * Updated downstream rebase behavior to compute and apply the correct range of commits, reducing merge/rebase errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->