### PR TITLE
build: move file installation to meson

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
             libjson-c-dev libnuma-dev libprotobuf-c-dev libreadline-dev \
             librtr-dev libsmartcols-dev libtool libyang-dev meson ninja-build \
             patch pkg-config protobuf-c-compiler python3-dev python3-pyelftools \
-            texinfo
+            systemd-dev texinfo
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # force fetch all history

--- a/cli/meson.build
+++ b/cli/meson.build
@@ -23,3 +23,9 @@ if not compiler.has_function(
 endif
 
 cli_inc += include_directories('.')
+
+install_data(
+  files('grcli.bash-completion'),
+  rename: ['grcli'],
+  install_dir: get_option('datadir') / 'bash-completion/completions',
+)

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends:
  patch,
  pkg-config,
  python3-pyelftools,
+ systemd-dev,
 Standards-Version: 4.7.0
 Rules-Requires-Root: no
 Homepage: https://github.com/DPDK/grout

--- a/debian/grout.bash-completion
+++ b/debian/grout.bash-completion
@@ -1,2 +1,0 @@
-main/grout.bash-completion grcli
-cli/grcli.bash-completion grout

--- a/debian/grout.install
+++ b/debian/grout.install
@@ -2,5 +2,8 @@
 /etc/grout.init
 /usr/bin/grcli
 /usr/bin/grout
+/usr/lib/systemd/system/grout.service
+/usr/share/bash-completion/completions/grcli
+/usr/share/bash-completion/completions/grout
 /usr/share/man/man1/grcli.1
 /usr/share/man/man8/grout.8

--- a/debian/grout.service
+++ b/debian/grout.service
@@ -1,1 +1,0 @@
-../main/grout.service

--- a/debian/rules
+++ b/debian/rules
@@ -22,8 +22,6 @@ override_dh_auto_configure:
 
 override_dh_auto_install:
 	meson install -C $(build) --skip-subprojects --destdir=$(dest)
-	install -D -m 644 main/grout.default $(dest)/etc/default/grout
-	install -D -m 644 main/grout.init $(dest)/etc/grout.init
 	install -D -m 0755 subprojects/dpdk/usertools/dpdk-telemetry-exporter.py \
 		$(dest)/usr/bin/grout-telemetry-exporter
 	install -D -m 0644 -t $(dest)/usr/share/dpdk/telemetry-endpoints \

--- a/main/meson.build
+++ b/main/meson.build
@@ -27,3 +27,27 @@ tests += [
     ],
   },
 ]
+
+systemd_dep = dependency('systemd', required: false)
+if systemd_dep.found()
+  systemd_system_unit_dir = systemd_dep.get_variable(
+    pkgconfig: 'systemdsystemunitdir',
+    pkgconfig_define: ['prefix', get_option('prefix')]
+  )
+  install_data(
+    files('grout.service'),
+    install_dir: systemd_system_unit_dir,
+  )
+  install_data(
+    files('grout.default'),
+    rename: ['grout'],
+    install_dir: get_option('sysconfdir') / 'default',
+  )
+  install_data('grout.init', install_dir: get_option('sysconfdir'))
+endif
+
+install_data(
+  files('grout.bash-completion'),
+  rename: ['grout'],
+  install_dir: get_option('datadir') / 'bash-completion/completions',
+)

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -81,11 +81,6 @@ FRR dplane plugin for grout
 %install
 %meson_install --skip-subprojects
 
-install -D -m 0644 main/grout.default %{buildroot}%{_sysconfdir}/default/grout
-install -D -m 0644 main/grout.init %{buildroot}%{_sysconfdir}/grout.init
-install -D -m 0644 main/grout.service %{buildroot}%{_unitdir}/grout.service
-install -D -m 0644 main/grout.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grout
-install -D -m 0644 cli/grcli.bash-completion %{buildroot}%{_datadir}/bash-completion/completions/grcli
 install -D -m 0755 subprojects/dpdk/usertools/dpdk-telemetry-exporter.py %{buildroot}%{_bindir}/grout-telemetry-exporter
 install -D -m 0644 -t %{buildroot}%{_datadir}/dpdk/telemetry-endpoints subprojects/dpdk/usertools/telemetry-endpoints/*
 


### PR DESCRIPTION

Previously, systemd service files, bash completions, and configuration files were installed through package-specific scripts (debian/rules and rpm/grout.spec). This approach required maintaining duplicate installation logic across different packaging systems and made it harder to support other distributions or installation methods.

By moving this logic to meson.build files, the installation becomes uniform across all platforms and packaging systems. The systemd service is now installed using the canonical pkg-config method to determine the correct system unit directory. Bash completions are installed to the standard datadir location. Configuration files are installed to sysconfdir.

Package-specific install files (debian/grout.install) are updated to reference the new meson-installed paths, and manual install commands are removed from packaging scripts since meson handles them now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bash completion for grcli and grout
  * Added telemetry exporter component

* **Chores**
  * Updated packaging and build configuration
  * Added systemd development dependency for builds

* **Packaging**
  * Removed packaged systemd service and legacy init/default installs from the Debian/RPM packages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->