### PR TITLE
nexthop: reduce info size

### DIFF
--- a/modules/infra/control/gr_nh_control.h
+++ b/modules/infra/control/gr_nh_control.h
@@ -24,8 +24,11 @@ struct __rte_cache_aligned nexthop {
 
 	uint32_t ref_count; // number of routes referencing this nexthop
 
-	uint8_t info[128] __rte_aligned(alignof(void *));
+	uint8_t info
+		[RTE_CACHE_LINE_MIN_SIZE * 2 - sizeof(struct gr_nexthop_base)
+		 - sizeof(uint32_t)] __rte_aligned(alignof(void *));
 };
+static_assert(sizeof(struct nexthop) <= (RTE_CACHE_LINE_MIN_SIZE * 2));
 
 #define GR_NH_TYPE_INFO(type_id, type_name, fields)                                                \
 	struct type_name fields __attribute__((__may_alias__, aligned(alignof(void *))));          \


### PR DESCRIPTION
Reduce the size of the info field as we don't have any structure using the whole 128 bytes.
Cap the size of the whole "struct nexthop" to a cacheline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal per-item memory layout and added a structural size check to enforce bounds and improve cache alignment. No changes to functionality, APIs, or user interface.

Note: Internal infrastructure optimization only — no direct user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->