### PR TITLE
infra: fill eth dst mac address

### DIFF
--- a/modules/infra/datapath/loop_output.c
+++ b/modules/infra/datapath/loop_output.c
@@ -38,11 +38,15 @@ static uint16_t loopback_output_process(
 			goto next;
 		}
 
+		eth->dst_addr = eth_data->dst;
 		eth->ether_type = eth_data->ether_type;
 
 		co = control_output_mbuf_data(mbuf);
 		co->callback = loopback_tx;
 next:
+		if (gr_mbuf_is_traced(mbuf)) {
+			gr_mbuf_trace_add(mbuf, node, 0);
+		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 	return nb_objs;


### PR DESCRIPTION
There is no guarantee that the data in pkt_mbuf_prepend is valid. Yet, the content of the dst address is checked in "control/loopback.c".

Fixes: a501eb2dd730 ("infra: transform loopback netdev from tun to tap")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected destination address assignment for forwarded network packets to ensure addresses are set before enqueueing.

* **Improvements**
  * Added conditional trace logging so traced packets record their processing node for improved visibility during troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->