### PR TITLE
subprojects: update to libecoli v0.9.1

### DIFF
--- a/cli/ec_node_devargs.c
+++ b/cli/ec_node_devargs.c
@@ -10,6 +10,8 @@
 #include <libgen.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 EC_LOG_TYPE_REGISTER(node_devargs);

--- a/cli/interact.c
+++ b/cli/interact.c
@@ -74,7 +74,7 @@ int interact(struct gr_api_client *client, struct ec_node *cmdlist) {
 	ec_editline_set_node(edit, shlex);
 
 	for (;;) {
-		ec_free(line);
+		free(line);
 		errno = 0;
 		if ((line = ec_editline_gets(edit)) == NULL) {
 			switch (errno) {
@@ -107,7 +107,7 @@ int interact(struct gr_api_client *client, struct ec_node *cmdlist) {
 exit_ok:
 	ret = 0;
 end:
-	ec_free(line);
+	free(line);
 	ec_node_free(shlex);
 	ec_editline_free(edit);
 	return ret;

--- a/subprojects/ecoli.wrap
+++ b/subprojects/ecoli.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/rjarry/libecoli
-revision = v0.8.0
+revision = v0.9.1
 depth = 1
 
 [provide]


### PR DESCRIPTION

This is the latest release. The malloc/free wrappers have been removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added required standard library includes for compatibility.
  * Updated libecoli dependency from v0.8.0 to v0.9.1.

* **Refactor**
  * Streamlined memory-management handling to use standard allocation APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->