### PR TITLE
devtools: prevent comments wider than 100 columns

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -127,7 +127,7 @@ lint:
 	@echo '[white-space]'
 	$Q $(all_files) | xargs devtools/check-whitespace
 	@echo '[comments]'
-	$Q $(c_src) | xargs devtools/check-comments
+	$Q $(c_src) '*.sh' meson.build GNUmakefile | xargs devtools/check-comments
 	@echo '[codespell]'
 	$Q codespell *
 

--- a/devtools/check-comments
+++ b/devtools/check-comments
@@ -15,11 +15,11 @@ function color(code, s) {
 }
 function red(s) { return color("31", s) }
 function green(s) { return color("32", s) }
+function yellow(s) { return color("1;33", s) }
 function magenta(s) { return color("35", s) }
 function cyan(s) { return color("36", s) }
-function bg_red(s) { return color("41", s) }
 function hl_ws(s, pattern) {
-	gsub(pattern, bg_red("&"), s)
+	gsub(pattern, yellow("&"), s)
 	# convert tab characters to 8 spaces to allow coloring
 	gsub(/\t/, "        ", s)
 	return s
@@ -35,6 +35,14 @@ function hl_ws(s, pattern) {
 	retcode = 1
 	print magenta(FILENAME) cyan(":") green(FNR) cyan(":") \
 		hl_ws($0, "\\/\\*\\**$") red("<-- C block comment used")
+}
+
+length > 100 && ((FILENAME ~ /\.sh$/ && /#.+ .*$/) || (/\/\/.+ .*$/)) {
+	retcode = 1
+	prefix = substr($0, 1, 100)
+	rest = substr($0, 101)
+	print magenta(FILENAME) cyan(":") green(FNR) cyan(":") \
+		prefix hl_ws(rest, ".+") red("<-- comment too long")
 }
 
 END {

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -124,17 +124,18 @@ port_add() {
 	shift
         if [ "$use_hardware_ports" = true ]; then
 		ip link set "${net_interfaces[$tap_counter]}" name $name
-		# When a namespace is deleted while a renamed kernel interface is inside it
-		# an 'altname' property with the interface original name is created.
-		# This causes an error on attempt to restore the original name. So we need to clear this 'altname' first.
+		# When a namespace is deleted while a renamed kernel interface
+		# is inside it an 'altname' property with the interface original
+		# name is created. This causes an error on attempt to restore
+		# the original name. So we need to clear this 'altname' first.
 		echo "ip link property del dev $name altname ${net_interfaces[$tap_counter]} || :" >> $tmp/restore_interfaces
 		echo "ip link set $name name ${net_interfaces[$tap_counter]}" >> $tmp/restore_interfaces
 		grcli interface add port "$name" devargs "${vfio_pci_ports[$tap_counter]}" "$@"
 	else
 		grcli interface add port "$name" devargs "net_tap$tap_counter,iface=$name" "$@"
-		# Ensure the Linux net device has a different mac address from grout's.
-		# This is required to avoid Linux from wrongfully assuming the packets
-		# sent by grout originated locally.
+		# Ensure the Linux net device has a different mac address from
+		# grout's. This is required to avoid Linux from wrongfully
+		# assuming the packets sent by grout originated locally.
 		local mac=$(echo "$name" | md5sum | sed -E 's/(..)(..)(..)(..)(..).*/02:\1:\2:\3:\4:\5/')
 		ip link set "$name" address "$mac"
 	fi

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -160,7 +160,7 @@ EOF
 	# --- wait until grout has the localsid ---------------------------------
 	# Expected "grcli route show" output pattern:
 	# VRF  DESTINATION        NEXT_HOP
-	# 0    fd00:202::100/128  type=SRv6-local id=12 iface=gr-loop0 vrf=0 origin=zebra behavior=end.dt4 out_vrf=0
+	# 0    fd00:202::100/128  type=SRv6-local id=12 .... behavior=end.dt4 ...
 	local grep_pattern="\\<${sid_local}/128[[:space:]]+type=SRv6-local\\>.*\\<behavior=${grout_behavior}\\>"
 	while ! grcli route show | grep -qE "${grep_pattern}"; do
 		if [ "$count" -ge "$max_tries" ]; then


### PR DESCRIPTION

Raise an error if a comment line is longer than 100 characters. Make an exception if the comment does not contain any whitespace (e.g. URLs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened comment and lint checks to include shell scripts and build files.
  * Updated comment-checking tool with new highlighting and a rule to flag overly long comments.
  * Minor comment formatting updates in smoke test scripts (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->