### PR TITLE
meson: remove default options in subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -61,7 +61,6 @@ dpdk_dep = dependency(
   version : '>= 24.11.1',
   fallback: ['dpdk', 'dpdk_dep'],
   default_options: [
-    'buildtype=release',
     'c_std=c11',
     'werror=false',
     'enable_kmods=false',


### PR DESCRIPTION
When building the top level project with buildtype=debug, it does not get propagated to the dpdk subproject.

Remove the default options.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the forced "release" build type for the DPDK dependency so dependency resolution no longer assumes a release build by default, allowing more flexibility in chosen build types during compilation and dependency linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->