### PR TITLE
icmp6: replace endian-dependent bitfields with flag enums

### DIFF
--- a/modules/infra/datapath/gr_icmp6.h
+++ b/modules/infra/datapath/gr_icmp6.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <gr_bitops.h>
 #include <gr_macro.h>
 
 #include <rte_byteorder.h>
@@ -74,14 +75,15 @@ struct icmp6_router_solicit {
 	uint32_t __reserved;
 } __rte_packed;
 
+typedef enum : uint8_t {
+	ICMP6_RA_F_MANAGED_ADDR = GR_BIT8(0),
+	ICMP6_RA_F_OTHER_CONFIG = GR_BIT8(1),
+} icmp6_ra_flags_t;
+
 // ICMP6_TYPE_ROUTER_ADVERT
 struct icmp6_router_advert {
 	uint8_t cur_hoplim;
-#if BYTE_ORDER == BIG_ENDIAN
-	uint8_t managed_addr : 1, other_config : 1, __unused_flags : 6;
-#else
-	uint8_t __unused_flags : 6, managed_addr : 1, other_config : 1;
-#endif
+	icmp6_ra_flags_t flags;
 	rte_be16_t lifetime;
 	rte_be32_t reachable_time;
 	rte_be32_t retrans_timer;
@@ -93,13 +95,15 @@ struct icmp6_neigh_solicit {
 	struct rte_ipv6_addr target;
 } __rte_packed;
 
+typedef enum : uint8_t {
+	ICMP6_NA_F_ROUTER = GR_BIT8(0),
+	ICMP6_NA_F_SOLICITED = GR_BIT8(1),
+	ICMP6_NA_F_OVERRIDE = GR_BIT8(2),
+} icmp6_na_flags_t;
+
 // ICMP6_TYPE_NEIGH_ADVERT
 struct icmp6_neigh_advert {
-#if BYTE_ORDER == BIG_ENDIAN
-	uint8_t router : 1, solicited : 1, override : 1, __unused_flags : 5;
-#else
-	uint8_t __unused_flags : 5, override : 1, solicited : 1, router : 1;
-#endif
+	icmp6_na_flags_t flags;
 	uint8_t __reserved;
 	uint16_t __reserved2;
 	struct rte_ipv6_addr target;

--- a/modules/infra/datapath/trace.c
+++ b/modules/infra/datapath/trace.c
@@ -266,7 +266,13 @@ int trace_icmp6_format(char *buf, size_t len, const struct icmp6 *icmp6, size_t 
 		const struct icmp6_neigh_advert *na = PAYLOAD(icmp6);
 		payload_len -= sizeof(*na);
 		inet_ntop(AF_INET6, &na->target, dst, sizeof(dst));
-		SAFE_BUF(snprintf, len, "neigh advert %s is at (solicited=%u)", dst, na->solicited);
+		SAFE_BUF(
+			snprintf,
+			len,
+			"neigh advert %s is at (solicited=%u)",
+			dst,
+			(na->flags & ICMP6_NA_F_SOLICITED) != 0
+		);
 		opt = PAYLOAD(na);
 		break;
 	}

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -132,8 +132,7 @@ static void build_ra_packet(struct rte_mbuf *m, const struct rte_ipv6_addr *src)
 	icmp6->code = 0;
 	ra = (struct icmp6_router_advert *)rte_pktmbuf_append(m, sizeof(*ra));
 	ra->cur_hoplim = IP6_DEFAULT_HOP_LIMIT; // Default TTL for this network
-	ra->managed_addr = 0; // DHCPv6 is available
-	ra->other_config = 0; // DNS available, ...
+	ra->flags = 0;
 	ra->lifetime = rte_cpu_to_be_16(ra_conf[iface_id].lifetime);
 	ra->reachable_time = RTE_BE16(0);
 	ra->retrans_timer = RTE_BE16(0);

--- a/modules/ip6/datapath/ndp_na_input.c
+++ b/modules/ip6/datapath/ndp_na_input.c
@@ -70,7 +70,7 @@ static uint16_t ndp_na_input_process(
 		ASSERT_NDP(!rte_ipv6_addr_is_mcast(&na->target));
 		// - If the IP Destination Address is a multicast address the
 		//   Solicited flag is zero.
-		ASSERT_NDP(!rte_ipv6_addr_is_mcast(&d->dst) || na->solicited == 0);
+		ASSERT_NDP(!rte_ipv6_addr_is_mcast(&d->dst) || !(na->flags & ICMP6_NA_F_SOLICITED));
 
 		// https://www.rfc-editor.org/rfc/rfc4861.html#section-7.2.5
 		//
@@ -162,9 +162,7 @@ static void init_default_na_mbuf(struct fake_ndp_na_mbuf *ndp_mbuf) {
 	ndp_mbuf->icmp6_hdr.code = 0;
 
 	// NA specific packet headers
-	ndp_mbuf->na_hdr.router = 0;
-	ndp_mbuf->na_hdr.solicited = 1;
-	ndp_mbuf->na_hdr.override = 1;
+	ndp_mbuf->na_hdr.flags = ICMP6_NA_F_SOLICITED | ICMP6_NA_F_OVERRIDE;
 	ndp_mbuf->na_hdr.target = (struct rte_ipv6_addr)
 		RTE_IPV6(0xfe80, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x00aa);
 

--- a/modules/ip6/datapath/ndp_na_output.c
+++ b/modules/ip6/datapath/ndp_na_output.c
@@ -78,9 +78,9 @@ static uint16_t ndp_na_output_process(
 		icmp6->type = ICMP6_TYPE_NEIGH_ADVERT;
 		icmp6->code = 0;
 		na = PAYLOAD(icmp6);
-		na->override = 1;
-		na->router = 1;
-		na->solicited = remote != NULL;
+		na->flags = ICMP6_NA_F_OVERRIDE | ICMP6_NA_F_ROUTER;
+		if (remote != NULL)
+			na->flags |= ICMP6_NA_F_SOLICITED;
 		na->target = l3->ipv6;
 		opt = PAYLOAD(na);
 		opt->type = ICMP6_OPT_TARGET_LLADDR;


### PR DESCRIPTION

The `icmp6_router_advert` and `icmp6_neigh_advert` structures used bitfields to represent flag bits. The order of bitfield members in memory is implementation-defined and requires `#ifdef BYTE_ORDER` guards to ensure correctness across different architectures.

Replace bitfields with `uint8_t` flag members and define flag constants as typed enums using the `GR_BIT8()` macro. This approach is portable, explicit, and does not rely on compiler-specific behavior.

Update all code accessing these flags to use bitwise operations instead of direct member access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * IPv6 router and neighbor advertisement flag handling consolidated: individual boolean flag fields replaced by a single explicit flags field for clarity and consistency across components.
  * Internal flag sourcing consolidated where diagnostics/trace output report solicited status.
  * No change to observable packet semantics; behavior preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->