### PR TITLE
github: prevent pull requests from saving ccache

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,13 +95,20 @@ jobs:
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
       - uses: actions/cache@v4
+        if: ${{ !github.event.pull_request }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-x86_64-${{ matrix.conf.compiler }}-${{ github.ref }}
           restore-keys: |
             ccache-x86_64-${{ matrix.conf.compiler }}-refs/heads/main
-            ccache-x86_64-${{ matrix.conf.compiler }}-
-      - run: ccache -sv
+      - uses: actions/cache/restore@v4
+        if: ${{ github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-${{ matrix.conf.compiler }}-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-${{ matrix.conf.compiler }}-refs/heads/main
+      - run: ccache -z
       - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ matrix.conf.rebase && github.event.pull_request.commits }}
       - run: make all unit-tests && sudo smoke/run.sh build
@@ -135,13 +142,20 @@ jobs:
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
       - uses: actions/cache@v4
+        if: ${{ !github.event.pull_request }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-aarch64-${{ github.ref }}
           restore-keys: |
             ccache-aarch64-refs/heads/main
-            ccache-aarch64-
-      - run: ccache -sv
+      - uses: actions/cache/restore@v4
+        if: ${{ github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-aarch64-${{ github.ref }}
+          restore-keys: |
+            ccache-aarch64-refs/heads/main
+      - run: ccache -z
       - run: git rebase -x "git --no-pager log --oneline -1 && make" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
       - run: make

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,12 +40,19 @@ jobs:
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
       - uses: actions/cache@v4
+        if: ${{ !github.event.pull_request }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-x86_64-deb-${{ github.ref }}
           restore-keys: |
             ccache-x86_64-deb-refs/heads/main
-            ccache-x86_64-deb-
+      - uses: actions/cache/restore@v4
+        if: ${{ github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-deb-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-deb-refs/heads/main
       - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
@@ -91,12 +98,19 @@ jobs:
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
       - uses: actions/cache@v4
+        if: ${{ !github.event.pull_request }}
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-x86_64-rpm-${{ github.ref }}
           restore-keys: |
             ccache-x86_64-rpm-refs/heads/main
-            ccache-x86_64-rpm-
+      - uses: actions/cache/restore@v4
+        if: ${{ github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-x86_64-rpm-${{ github.ref }}
+          restore-keys: |
+            ccache-x86_64-rpm-refs/heads/main
       - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:


### PR DESCRIPTION

Pull request builds were creating their own ccache entries in GitHub's cache storage, leading to cache bloat and potentially filling the cache quota with ephemeral data from feature branches that will never be reused.

Use actions/cache/restore (read-only) for pull request workflows to restore the main branch cache without saving new entries. Only main branch builds use actions/cache (read-write) to update the canonical cache that all subsequent builds can benefit from.

This ensures pull requests still get the performance benefit of the cached main branch build artifacts while preventing them from polluting the cache with their own entries that would only be useful if the exact same PR builds again with the same git ref.

Additionally, remove the overly broad fallback restore-keys that would match any ref. The main branch cache is sufficient for warming the cache. Also switch from ccache -sv to ccache -z to reset statistics at the start of each build for clearer per-build metrics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline efficiency by optimizing cache management for different build contexts, ensuring faster and more reliable builds across all architectures and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->