### PR TITLE
github: fix cache save procedure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -94,26 +94,22 @@ jobs:
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        if: ${{ !github.event.pull_request }}
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-${{ matrix.conf.compiler }}-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-${{ matrix.conf.compiler }}-refs/heads/main
       - uses: actions/cache/restore@v4
-        if: ${{ github.event.pull_request }}
+        id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-${{ matrix.conf.compiler }}-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-${{ matrix.conf.compiler }}-refs/heads/main
+          key: ccache-x86_64-${{ matrix.conf.compiler }}
       - run: ccache -z
       - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ matrix.conf.rebase && github.event.pull_request.commits }}
       - run: make all unit-tests && sudo smoke/run.sh build
         if: ${{ ! matrix.conf.rebase || ! github.event.pull_request.commits }}
       - run: ccache -sv
+      - uses: actions/cache/save@v4
+        if: ${{ ! github.event.pull_request.commits }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   build-cross-aarch64:
     if: ${{ github.actor != 'grout-bot' }}
@@ -141,26 +137,22 @@ jobs:
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        if: ${{ !github.event.pull_request }}
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-aarch64-${{ github.ref }}
-          restore-keys: |
-            ccache-aarch64-refs/heads/main
       - uses: actions/cache/restore@v4
-        if: ${{ github.event.pull_request }}
+        id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-aarch64-${{ github.ref }}
-          restore-keys: |
-            ccache-aarch64-refs/heads/main
+          key: ccache-aarch64
       - run: ccache -z
       - run: git rebase -x "git --no-pager log --oneline -1 && make" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
       - run: make
         if: ${{ ! github.event.pull_request.commits }}
       - run: ccache -sv
+      - uses: actions/cache/save@v4
+        if: ${{ ! github.event.pull_request.commits }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
 
   lint:
     if: ${{ github.actor != 'grout-bot' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,20 +39,11 @@ jobs:
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        if: ${{ !github.event.pull_request }}
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-deb-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-deb-refs/heads/main
       - uses: actions/cache/restore@v4
-        if: ${{ github.event.pull_request }}
+        id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-deb-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-deb-refs/heads/main
+          key: ccache-x86_64-deb
       - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
@@ -64,6 +55,11 @@ jobs:
           yangmodelsdir: /usr/share/frr-yang
       - run: make deb CC="ccache gcc"
       - run: ccache -sv
+      - uses: actions/cache/save@v4
+        if: ${{ ! github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@v4
         with:
           name: deb-packages
@@ -97,20 +93,11 @@ jobs:
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
       - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        if: ${{ !github.event.pull_request }}
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-rpm-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-rpm-refs/heads/main
       - uses: actions/cache/restore@v4
-        if: ${{ github.event.pull_request }}
+        id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-rpm-${{ github.ref }}
-          restore-keys: |
-            ccache-x86_64-rpm-refs/heads/main
+          key: ccache-x86_64-rpm
       - run: ccache -z
       - uses: ./.github/actions/frr-install
         with:
@@ -122,6 +109,11 @@ jobs:
           yangmodelsdir: /usr/share/frr-yang
       - run: scl run gcc-toolset-13 -- make rpm CC="ccache gcc"
       - run: ccache -sv
+      - uses: actions/cache/save@v4
+        if: ${{ ! github.event.pull_request }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@v4
         with:
           name: rpm-packages


### PR DESCRIPTION
The previous commit was a bit aggressive. It completely prevents cache from being saved.

> Cache hit occurred on the primary key ccache-x86_64-clang-18-refs/heads/main, not saving cache.

Use two separate steps:

- actions/cache/restore@v4: always enabled, on the main branch, and in pull requests.
- actions/cache/save@v4: only enabled on the main branch.

Incidentally, it makes the workflow easier to understand.

Fixes: 75ba8ab74c9e ("github: prevent pull requests from saving ccache")
Link: https://github.com/DPDK/grout/actions/runs/19098927620/job/54565817905#step:23:2
Link: https://github.com/actions/cache/tree/main/restore
Link: https://github.com/actions/cache/tree/main/save


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-visible changes**

These updates are internal infrastructure modifications to build and caching workflows with no direct impact on product functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->