### PR TITLE
tests: use tap prefix when using hw ports

### DIFF
--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -123,13 +123,13 @@ port_add() {
 	local name="$1"
 	shift
         if [ "$use_hardware_ports" = true ]; then
-		ip link set "${net_interfaces[$tap_counter]}" name $name
+		ip link set "${net_interfaces[$tap_counter]}" name "x-$name"
 		# When a namespace is deleted while a renamed kernel interface
 		# is inside it an 'altname' property with the interface original
 		# name is created. This causes an error on attempt to restore
 		# the original name. So we need to clear this 'altname' first.
-		echo "ip link property del dev $name altname ${net_interfaces[$tap_counter]} || :" >> $tmp/restore_interfaces
-		echo "ip link set $name name ${net_interfaces[$tap_counter]}" >> $tmp/restore_interfaces
+		echo "ip link property del dev x-$name altname ${net_interfaces[$tap_counter]} || :" >> $tmp/restore_interfaces
+		echo "ip link set x-$name name ${net_interfaces[$tap_counter]}" >> $tmp/restore_interfaces
 		grcli interface add port "$name" devargs "${vfio_pci_ports[$tap_counter]}" "$@"
 	else
 		grcli interface add port "$name" devargs "net_tap$tap_counter,iface=x-$name" "$@"


### PR DESCRIPTION
Commit 19042ff changed port_add() and tests to use "x-" prefix with tap interfaces.
We should align second part of port_add() to this change in order to fix tests execution when using hardware ports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized hardware-port naming: renamed hardware interfaces now use a consistent prefixed device name across rename and restore operations, improving predictability and reliability of port restoration during tests and infrastructure management. No control flow or other functional behavior was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->