### PR TITLE
main,smoke: run in private netns

### DIFF
--- a/main/grout.service
+++ b/main/grout.service
@@ -13,6 +13,7 @@ EnvironmentFile=-/etc/default/grout
 ExecStartPre=/usr/bin/udevadm settle
 ExecStart=/usr/bin/grout $GROUT_OPTS
 ExecStartPost=/usr/bin/grcli -xef /etc/grout.init
+PrivateNetwork=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION

Since commits c561b28b70f6 ("infra: sync iface addresses to per-VRF gr-loopX so kernel can bind") and 391f9fa03204 ("infra: create VRF and default route for each loopback interface"), addresses and default routes are synchronized on the gr-loop0 Linux tun interface.

These elements can clash with local addresses in the default namespace.

To ensure smooth operation, always run grout in its own namespace. Update the systemd service and smoke tests accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test execution now runs inside a dedicated, isolated network namespace.
  * Test invocation is sandboxed via the namespace and legacy per-test core-dump collection and opaque backtrace logic were removed.
  * Timing and result reporting remain unchanged.

* **Chores**
  * Service configured to run with a private network namespace for isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->