### PR TITLE
logging: fix incorrect vlan trace

### DIFF
--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -67,6 +67,7 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 
 		if (m->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED) {
 			vlan_id = m->vlan_tci & 0xfff;
+			m->ol_flags &= ~RTE_MBUF_F_RX_VLAN_STRIPPED;
 		} else if (eth_type == RTE_BE16(RTE_ETHER_TYPE_VLAN)) {
 			vlan = rte_pktmbuf_mtod_offset(m, struct rte_vlan_hdr *, l2_hdr_size);
 			l2_hdr_size += sizeof(*vlan);


### PR DESCRIPTION

When receiving from a hardware interface that strips VLANs (i.e. the mbuf offload flags have RTE_MBUF_F_RX_VLAN_STRIPPED), we look in the vlan_tci mbuf field to determine which VLAN ID to display in the traces.

When transmitting such packets after forwarding, the trace function will wrongfully assume that the packet has a VLAN to be displayed as well. Even though there is no VLAN header. E.g.:

```
[rx p0] 30:3e:a7:0b:f2:54 > 9e:a8:3f:c8:8f:72 / ...
[tx p0] 9e:a8:3f:c8:8f:72 > 0e:75:e5:da:2b:79 / VLAN id=42 / ...
[rx p1] 46:00:c4:b7:f0:95 > 5a:8d:ed:dc:a5:c8 / VLAN id=43 / ...
[tx p1] 5a:8d:ed:dc:a5:c8 > 30:3e:a7:0b:f2:55 / VLAN id=43 / ...
```

The packet transmitted on p1 does not carry any VLAN header on the wire but the trace displays one anyway.

Clear the RTE_MBUF_F_RX_VLAN_STRIPPED right after reading vlan_tci in eth_input to avoid any confusion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VLAN packet processing to ensure correct handling of virtual LAN-tagged packets during network data transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->