### PR TITLE
smoke: allow external debugging of network namespaces

### DIFF
--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -112,10 +112,10 @@ builddir=${1-}
 
 netns_add() {
 	local ns="$1"
-	ip netns add "$ns"
+	nsenter -t 1 -n -m ip netns add "$ns"
 	cat >> $tmp/cleanup <<EOF
-ip netns pids "$ns" | xargs -r kill --timeout 500 KILL
-ip netns del "$ns"
+nsenter -t 1 -n -m ip netns pids "$ns" | xargs -r kill --timeout 500 KILL
+nsenter -t 1 -n -m ip netns del "$ns"
 EOF
 	ip -n "$ns" link set lo up
 }

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -266,14 +266,14 @@ EOF
 	fi
 	tailpid=$(pgrep -g0 tail | tail -n1)
 
-	ip netns add $namespace
+	nsenter -t 1 -n -m ip netns add $namespace
 	frrinit.sh start $namespace
 
 	cat >> $tmp/cleanup <<EOF
 frrinit.sh stop $namespace
 kill $tailpid
-ip netns pids $namespace | xargs -r kill --timeout 500 KILL
-ip netns del $namespace
+nsenter -t 1 -n -m ip netns pids $namespace | xargs -r kill --timeout 500 KILL
+nsenter -t 1 -n -m ip netns del $namespace
 EOF
 
 	SECONDS=0


### PR DESCRIPTION

Since recently, the smoke tests are executed in a "grout" netns which is reused across test runs.

Smoke tests do create additional namespaces to act as routers connected to grout.

The issue is that creating "nested" network namespaces with iproute2 is not possible. The file created in /run/netns has a reference which is unusable outside of the process that has created it.

```
~# ip netns
Error: Peer netns reference is invalid.
Error: Peer netns reference is invalid.
grout
ns-a
ns-b

~# ip netns exec ns-b ip link show
setting the network namespace "ns-b" failed: Invalid argument
```

The only way to have namespaces which are visible/accessible from everywhere is to create them from the base namespace (the netns of PID 1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure to run network namespace operations in the host init namespace, ensuring creation, inspection, and cleanup execute in a consistent execution context for improved reliability and more robust teardown across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->