### PR TITLE
frr: update version to 10.5.0

### DIFF
--- a/.github/actions/frr-install/run.sh
+++ b/.github/actions/frr-install/run.sh
@@ -17,7 +17,6 @@ frr_tag=$(sed -n 's/revision = //p' subprojects/frr.wrap)
 
 git clone --depth=1 --branch="$frr_tag" "$frr_url" frr_build
 cd frr_build
-curl -L https://github.com/FRRouting/frr/pull/19351.diff | patch -p1
 autoreconf -ivf
 ./configure \
 	--prefix="$PREFIX" \

--- a/Containerfile.frr
+++ b/Containerfile.frr
@@ -13,7 +13,7 @@ RUN mkdir -p /tmp/null/var/run/frr
 RUN chroot /tmp/null chown -R frr:frr /etc/frr /var/run/frr
 # not packaged in centos, download from upstream
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tmp/null/sbin/tini
-ADD https://raw.githubusercontent.com/FRRouting/frr/refs/tags/frr-10.4.1/docker/ubi8-minimal/docker-start /tmp/null/sbin/docker-start
+ADD https://raw.githubusercontent.com/FRRouting/frr/refs/tags/frr-10.5.0/docker/ubi8-minimal/docker-start /tmp/null/sbin/docker-start
 RUN chmod +x /tmp/null/sbin/tini /tmp/null/sbin/docker-start
 
 FROM scratch

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -6,7 +6,7 @@ if frr_opt.disabled()
   subdir_done()
 endif
 
-frr_dep = dependency('frr', version: '>= 10.4', required: false)
+frr_dep = dependency('frr', version: '>= 10.5', required: false)
 if not frr_dep.found()
   if get_option('frr').enabled()
     sp = subproject('frr')

--- a/subprojects/frr.wrap
+++ b/subprojects/frr.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/FRRouting/frr
-revision = frr-10.4.1
+revision = frr-10.5.0
 depth = 1
 diff_files =
 	frr/meson-add-dependency-definition.patch

--- a/subprojects/packagefiles/frr/meson-add-dependency-definition.patch
+++ b/subprojects/packagefiles/frr/meson-add-dependency-definition.patch
@@ -52,7 +52,7 @@ index 0000000000..1db51d4b58
 +# SPDX-License-Identifier: BSD-3-Clause
 +# Copyright (c) 2025 Maxime Leroy, Free Mobile
 +
-+project('frr', 'c', version: '10.4.1', license: 'GPL-2.0-or-later', meson_version: '>= 0.63.0')
++project('frr', 'c', version: '10.5.0', license: 'GPL-2.0-or-later', meson_version: '>= 0.63.0')
 +
 +srcdir = meson.current_source_dir()
 +builddir = meson.current_build_dir()


### PR DESCRIPTION
We don't need to patch FRR to build our out of tree plugin anymore. We just need a local patch when building FRR for our local tests.

Hopefully soon, we'll have frr-headers packages that we can install from Fedora and we'll be able to use them instead of building.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded FRR (Free Range Routing) dependency to 10.5.0 across builds, packaging, and container sources.
  * Removed an unnecessary patch-application step from the install/build flow.
  * Bumped Meson/external dependency checks to require the newer FRR version and aligned packaging metadata accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->