### PR TITLE
dpdk: vendor 25.11 patch for ipv6 ll addr compliance

### DIFF
--- a/subprojects/dpdk.wrap
+++ b/subprojects/dpdk.wrap
@@ -6,7 +6,8 @@ diff_files =
 	dpdk/0001-net-tap-add-netlink-helpers.patch,
 	dpdk/0002-net-tap-replace-ioctl-with-netlink.patch,
 	dpdk/0003-net-tap-detect-namespace-change.patch,
-	dpdk/0004-net-tap-configure-link-carrier.patch
+	dpdk/0004-net-tap-configure-link-carrier.patch,
+	dpdk/net-ipv6-link-local-compliance-with-rfc-4291.diff
 
 [provide]
 dependency_names = libdpdk

--- a/subprojects/packagefiles/dpdk/net-ipv6-link-local-compliance-with-rfc-4291.diff
+++ b/subprojects/packagefiles/dpdk/net-ipv6-link-local-compliance-with-rfc-4291.diff
@@ -1,0 +1,35 @@
+diff --git a/app/test/test_net_ip6.c b/app/test/test_net_ip6.c
+index cfc550940306..e4642c9a39d9 100644
+--- a/app/test/test_net_ip6.c
++++ b/app/test/test_net_ip6.c
+@@ -160,7 +160,7 @@ test_ipv6_llocal_from_ethernet(void)
+ {
+ 	const struct rte_ether_addr local_mac = {{0x04, 0x7b, 0xcb, 0x5c, 0x08, 0x44}};
+ 	const struct rte_ipv6_addr local_ip =
+-		RTE_IPV6(0xfe80, 0, 0, 0, 0x047b, 0xcbff, 0xfe5c, 0x0844);
++		RTE_IPV6(0xfe80, 0, 0, 0, 0x067b, 0xcbff, 0xfe5c, 0x0844);
+ 	struct rte_ipv6_addr ip;
+ 
+ 	rte_ipv6_llocal_from_ethernet(&ip, &local_mac);
+diff --git a/lib/net/rte_ip6.h b/lib/net/rte_ip6.h
+index 98bcac3f4dff..93e858b803a9 100644
+--- a/lib/net/rte_ip6.h
++++ b/lib/net/rte_ip6.h
+@@ -393,7 +393,7 @@ rte_ipv6_mc_scope(const struct rte_ipv6_addr *ip)
+ 
+ /*
+  * Generate a link-local IPv6 address from an Ethernet address as specified in
+- * RFC 2464, section 5.
++ * RFC 4291, section 2.5.1.
+  *
+  * @param[out] ip
+  *   The link-local IPv6 address to generate.
+@@ -406,7 +406,7 @@ rte_ipv6_llocal_from_ethernet(struct rte_ipv6_addr *ip, const struct rte_ether_a
+ 	ip->a[0] = 0xfe;
+ 	ip->a[1] = 0x80;
+ 	memset(&ip->a[2], 0, 6);
+-	ip->a[8] = mac->addr_bytes[0];
++	ip->a[8] = mac->addr_bytes[0] ^ 0x02;
+ 	ip->a[9] = mac->addr_bytes[1];
+ 	ip->a[10] = mac->addr_bytes[2];
+ 	ip->a[11] = 0xff;


### PR DESCRIPTION
As specified in RFC 4291 section 2.5.1, link local addresses must be generated based on a modified EUI-64 interface identifier.

Until this release is available, include this patch in grout.

Link: https://patches.dpdk.org/project/dpdk/list/?series=36703

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IPv6 link-local address generation to comply with RFC 4291 standards.

* **Documentation**
  * Updated documentation to reference RFC 4291, section 2.5.1 for IPv6 link-local compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->