### PR TITLE
l4: fix UDP port registration and lookup

### DIFF
--- a/modules/l4/l4_input_local.c
+++ b/modules/l4/l4_input_local.c
@@ -29,8 +29,7 @@ void l4_input_register_port(uint8_t proto, rte_be16_t port, const char *next_nod
 	case IPPROTO_UDP:
 		if (udp_edges[port] != MANAGEMENT)
 			ABORT("next node already registered for udp port=%hu", p);
-		udp_edges[proto] = gr_node_attach_parent("ip_input_local", next_node);
-		gr_node_attach_parent("ip6_input_local", next_node);
+		udp_edges[port] = gr_node_attach_parent("l4_input_local", next_node);
 		break;
 	default:
 		ABORT("proto not supported %hhu", proto);


### PR DESCRIPTION
The l4_input_register_port() function had multiple critical bugs that prevented UDP port-based routing from working correctly:

First, when storing the edge mapping, it used proto (17 for UDP) as the array index instead of the port number. This caused all registered UDP ports to overwrite the same array slot.

Second, the edge was attached to "ip_input_local" instead of "l4_input_local", returning edge IDs that don't exist in the l4_input_local node's edge table, causing segmentation faults when packets were enqueued.

Third, in l4_input_local_process(), the destination port from the UDP header was used directly as array index without converting from network byte order to host byte order. For port 68, this looked up index 17408 (0x4400) instead of 68 (0x0044).

The combination of these bugs meant that no UDP port registration actually worked, and all UDP packets were routed to the default MANAGEMENT edge (l4_loopback_output) regardless of registration.

This fix enables proper L4 port-based routing for any UDP protocol handler that calls l4_input_register_port(), including DHCP client, DNS resolvers, or any future UDP-based protocol implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UDP port registration and destination lookup so packets are indexed by destination port and routed through the correct input processing path.
  * Centralized UDP destination wiring to the appropriate processing entry, improving reliability and correctness of UDP routing and destination resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->