### PR TITLE
ip: never forward broadcast/any addresses

### DIFF
--- a/api/gr_net_types.h
+++ b/api/gr_net_types.h
@@ -73,6 +73,16 @@ static inline bool ip4_addr_same_subnet(ip4_addr_t a, ip4_addr_t b, uint8_t pref
 	return ((a ^ b) & mask) == 0;
 }
 
+#define IPV4_ADDR_BCAST RTE_BE32(0xffffffff)
+
+static inline bool ip4_addr_is_mcast(const ip4_addr_t ip) {
+	const union {
+		ip4_addr_t ip;
+		uint8_t u8[4];
+	} addr = {.ip = ip};
+	return addr.u8[0] >= 224 && addr.u8[0] <= 239;
+}
+
 static inline int ip4_net_parse(const char *s, struct ip4_net *net, bool zero_mask) {
 	char *addr = NULL;
 	int ret = -1;


### PR DESCRIPTION

When receiving broadcast packets, never send them to ip_forward, even if their ethernet destination address was unicast.

Signed-off-by: Robin Jarry <rjarry@redhat.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unspecified IPv4 (0.0.0.0) packets are now detected and dropped early via a dedicated invalid-address path.
  * IPv4 broadcast and multicast packets are classified as local and processed directly, skipping routing lookups.
  * Added detection and a constant for IPv4 broadcast/multicast addresses to improve packet classification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->