### PR TITLE
port: always enable vlan 0 filter

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -456,6 +456,8 @@ static int iface_port_init(struct iface *iface, const void *api_info) {
 	}
 
 	ret = iface_port_reconfig(iface, IFACE_SET_ALL, NULL, api_info);
+	if (ret == 0)
+		ret = port_vlan_add(iface, 0);
 	if (ret < 0) {
 		iface_port_fini(iface);
 		errno = -ret;


### PR DESCRIPTION

Depending on DPDK drivers and their managed hardware, when creating a VLAN sub interface and enabling its corresponding VLAN filter, untagged packets (no VLAN) are not received by the port anymore.

Always enable VLAN 0 filter (synonym for "no vlan") on port init to ensure untagged packets can get through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port configuration to properly initialize VLAN filtering upon reconfiguration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->