### PR TITLE
smoke: point to point peering for ospf

### DIFF
--- a/smoke/ospf6_frr_test.sh
+++ b/smoke/ospf6_frr_test.sh
@@ -40,6 +40,7 @@ ipv6 forwarding
 interface p0
 	ipv6 ospf6 area 0.0.0.1
 	ipv6 ospf6 hello-interval 1
+	ipv6 ospf6 network point-to-point
 exit
 !
 router ospf6
@@ -63,6 +64,7 @@ exit
 interface x-p0
 	ipv6 ospf6 area 0.0.0.1
 	ipv6 ospf6 hello-interval 1
+	ipv6 ospf6 network point-to-point
 exit
 !
 router ospf6

--- a/smoke/ospf_frr_test.sh
+++ b/smoke/ospf_frr_test.sh
@@ -42,6 +42,7 @@ exit
 !
 interface p0
 	ip ospf hello-interval 1
+	ip ospf network point-to-point
 exit
 !
 !
@@ -67,6 +68,7 @@ exit
 interface x-p0
 	ip address 172.16.0.2/24
 	ip ospf hello-interval 1
+	ip ospf network point-to-point
 exit
 !
 router ospf


### PR DESCRIPTION
Stabilize the CI by specifying 'point to point' peers for OSPF and OSPF6 tests. While this doesn't test as much as before, this should be enough for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated OSPF and OSPFv6 test configurations: interfaces p0 and x-p0 now use point-to-point network type, improving adjacency behavior and making routing protocol simulations more accurate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->