### PR TITLE
deb,rpm: enable lto

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 # Hardening
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all reproducible=+all optimize=-lto
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all reproducible=+all optimize=+lto
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
@@ -10,6 +10,7 @@ meson_opts += --auto-features=enabled
 meson_opts += -Ddpdk:platform=generic
 meson_opts += -Dfrr=enabled
 meson_opts += -Ddpdk_static=true
+meson_opts += -Db_lto=true
 
 build = $(CURDIR)/debian/_build
 dest = $(CURDIR)/debian/tmp
@@ -26,6 +27,9 @@ override_dh_auto_install:
 		$(dest)/usr/bin/grout-telemetry-exporter
 	install -D -m 0644 -t $(dest)/usr/share/dpdk/telemetry-endpoints \
 		subprojects/dpdk/usertools/telemetry-endpoints/*
+
+override_dh_auto_test:
+	@:
 
 override_dh_installsystemd:
 	dh_installsystemd --no-start --no-stop-on-upgrade

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,7 @@ dpdk_dep = dependency(
     'tests=false',
     'enable_drivers=net/virtio,net/vhost,net/i40e,net/ice,common/iavf,net/iavf,net/ixgbe,net/null,net/tap,common/mlx5,net/mlx5,bus/auxiliary,net/vmxnet3',
     'enable_libs=graph,hash,fib,rib,pcapng,gso,vhost,cryptodev,dmadev,security',
+    'c_args=-Wno-stringop-overflow',
     'disable_apps=*',
     'enable_docs=false',
     'developer_mode=disabled',

--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -2,7 +2,6 @@
 # Copyright (c) 2024 Robin Jarry
 
 %undefine _debugsource_packages
-%global _lto_cflags %nil
 %global branch main
 %global __meson_wrap_mode default
 
@@ -76,7 +75,7 @@ Requires: frr = %(sed -n "s/revision = frr-//p" subprojects/frr.wrap)
 FRR dplane plugin for grout
 
 %build
-%meson -Ddpdk:platform=generic -Dfrr=enabled -Ddpdk_static=true
+%meson -Ddpdk:platform=generic -Dfrr=enabled -Ddpdk_static=true -Db_lto=true
 %meson_build
 
 %install


### PR DESCRIPTION

Try and improve performance and binary size slightly by enabling link time optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled link-time optimization during the build process.
  * Added a compiler option to suppress specific string-operation overflow warnings.
  * Made the automatic test invocation a no-op during package build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->