### PR TITLE
github: allow changing subprojects mid-series

### DIFF
--- a/.github/workflows/check.sh
+++ b/.github/workflows/check.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025 Robin Jarry
+
+set -eu
+
+echo ===========================================================================
+git --no-pager log --oneline -1
+echo ===========================================================================
+
+# If there was any modification on .wrap files, delete the whole subproject
+# folder to ensure it is prepared again by meson.
+for wrap in subprojects/*.wrap; do
+	if ! git diff --quiet HEAD^ $wrap; then
+		rm -rf "${wrap%.wrap}"
+	fi
+done
+
+# Always check compilation.
+make "$@"
+
+if [ "$#" -eq 0 ] && ! echo "$MESON_EXTRA_OPTS" | grep -q -- --cross-file; then
+	# If the script was invoked without any argument (e.g. not with "lint")
+	# and if we are not cross compiling, run unit and smoke tests.
+	echo -------------------------------------------------------------------
+	echo unit-tests
+	echo -------------------------------------------------------------------
+	make unit-tests
+	echo -------------------------------------------------------------------
+	echo smoke-tests
+	echo -------------------------------------------------------------------
+	sudo make smoke-tests
+fi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,9 +102,9 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-x86_64-${{ matrix.conf.compiler }}
       - run: ccache -z
-      - run: git rebase -x "git --no-pager log --oneline -1 && make all unit-tests && sudo smoke/run.sh build" "HEAD~${{ github.event.pull_request.commits }}"
+      - run: git rebase -x .github/workflows/check.sh "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ matrix.conf.rebase && github.event.pull_request.commits }}
-      - run: make all unit-tests && sudo smoke/run.sh build
+      - run: .github/workflows/check.sh
         if: ${{ ! matrix.conf.rebase || ! github.event.pull_request.commits }}
       - run: ccache -sv
       - uses: actions/cache/save@v4
@@ -145,9 +145,9 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ccache-aarch64
       - run: ccache -z
-      - run: git rebase -x "git --no-pager log --oneline -1 && make" "HEAD~${{ github.event.pull_request.commits }}"
+      - run: git rebase -x .github/workflows/check.sh "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
-      - run: make
+      - run: .github/workflows/check.sh
         if: ${{ ! github.event.pull_request.commits }}
       - run: ccache -sv
       - uses: actions/cache/save@v4
@@ -169,9 +169,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - run: git config --global --add safe.directory $PWD
       - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
-      - run: git rebase -x "git --no-pager log --oneline -1 && make lint" "HEAD~${{ github.event.pull_request.commits }}"
+      - run: git rebase -x ".github/workflows/check.sh lint" "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ github.event.pull_request.commits }}
-      - run: make lint
+      - run: .github/workflows/check.sh lint
         if: ${{ ! github.event.pull_request.commits }}
 
   commits:


### PR DESCRIPTION

When a pull request contains multiple patches each patch is compiled tested and linted using `git rebase --exec`.

If one of the patches updates the version of a subproject or introduces a patch, the change will not be taken into account because meson has already processed the wrap files.

Add a script that is called during the rebase operation and that will delete the subproject folders when there was any change to its corresponding wrap file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized CI/CDE command execution into a shared workflow script to simplify build, test and lint steps across jobs.
  * Script prints the latest commit, prunes outdated subproject directories when manifests differ, and forwards arguments to the build system.
  * Default invocation runs unit and smoke tests (smoke tests may run with elevated privileges) while preserving existing conditional gating.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->