### PR TITLE
port: disable hardware vlan filter for bifurcated drivers

### DIFF
--- a/modules/infra/control/gr_port.h
+++ b/modules/infra/control/gr_port.h
@@ -23,11 +23,16 @@ struct port_mac {
 	struct rte_ether_addr mac;
 };
 
+typedef enum : uint8_t {
+	PORT_F_VLAN_FILTER = GR_BIT8(0),
+} port_features_t;
+
 GR_IFACE_INFO(GR_IFACE_TYPE_PORT, iface_info_port, {
 	BASE(__gr_iface_info_port_base);
 
 	uint16_t port_id;
 	bool started;
+	port_features_t features;
 	struct rte_mempool *pool;
 	char *devargs;
 	uint32_t pool_size;


### PR DESCRIPTION
When using grout with mlx5 VFs, asking to offload VLAN filter does not return an error but it causes all unicast packets to be steered to the kernel net device RXQs instead of the ones configured for grout.

Disabling VLAN filter offload fixes the issue. Unfortunately, there is no way of knowing whether a given device is using a "bifurcated" driver in a generic way. For now, rely on the driver name containing "mlx5". It is the only driver that we know of that has this limitation so far.

Add a new features field on the iface_info_port structure. Store a PORT_F_VLAN_FILTER flag when the port was successfully configured with RTE_ETH_RX_OFFLOAD_VLAN_FILTER offload.

If PORT_F_VLAN_FILTER isn't available, skip adding/removing any VLAN filter in the hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added VLAN filtering capability detection and management for network ports.

* **Bug Fixes**
  * Improved hardware VLAN offload handling for better device compatibility.
  * Added validation to prevent VLAN filter operations on unsupported devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->