### PR TITLE
Rxtx offload

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -77,6 +77,9 @@ static struct rte_eth_conf default_port_config = {
 	.rxmode = {
 		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM | RTE_ETH_RX_OFFLOAD_VLAN,
 	},
+	.txmode = {
+		.offloads = RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE,
+	},
 };
 
 int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
@@ -126,6 +129,7 @@ int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
 	else
 		conf.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
 	conf.rxmode.offloads &= info.rx_offload_capa;
+	conf.txmode.offloads &= info.tx_offload_capa;
 	if (info.dev_flags != NULL && *info.dev_flags & RTE_ETH_DEV_INTR_LSC) {
 		conf.intr_conf.lsc = 1;
 	}


### PR DESCRIPTION
* Only configure multiqueue rss mode with more than 1 rxq.
* Enable mbuf fast-free offload when available


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Fixed TX offload configuration to improve packet transmission reliability
  * Corrected single receive queue handling for better consistency
  * Enhanced TX offload capability compatibility to ensure proper feature negotiation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->