### PR TITLE
infra/nexthop: validate VRF before creating nexthop, and drop nh ID if nexthop creation fails

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -390,6 +390,9 @@ int nexthop_update(struct nexthop *nh, const struct gr_nexthop_base *base, const
 			goto err;
 		}
 		nh->vrf_id = iface->vrf_id;
+	} else if (get_vrf_iface(nh->vrf_id) == NULL) {
+		ret = -errno;
+		goto err;
 	}
 
 	// Import type-specific info using callback

--- a/modules/infra/control/vrf.c
+++ b/modules/infra/control/vrf.c
@@ -24,6 +24,11 @@ struct vrf_info {
 static struct vrf_info vrfs[GR_MAX_VRFS];
 
 struct iface *get_vrf_iface(uint16_t vrf_id) {
+	if (vrf_id >= GR_MAX_VRFS)
+		return errno_set_null(EOVERFLOW);
+	if (vrfs[vrf_id].iface == NULL)
+		return errno_set_null(ENONET);
+
 	return vrfs[vrf_id].iface;
 }
 


### PR DESCRIPTION
nexthop_new() didn’t verify whether the provided VRF or interface IDs were valid.

This could result in creating a nexthop with an invalid interface, causing Grout to crash when routing packets through it.

This patch adds checks to ensure the VRF and interface exist before allocating the nexthop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of VRF and network interface lookups to detect invalid configurations earlier and return clearer errors.
  * Centralized error handling to ensure resources are released on failure, preventing leaks while preserving existing success behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->