### PR TITLE
port: remove hardware vlan filter

### DIFF
--- a/modules/infra/control/bond.c
+++ b/modules/infra/control/bond.c
@@ -141,34 +141,6 @@ static int bond_promisc_set(struct iface *iface, bool enabled) {
 	return bond_all_members_set_flag(iface, GR_IFACE_F_PROMISC, enabled, iface_set_promisc);
 }
 
-static int bond_vlan_add(struct iface *iface, uint16_t vlan_id) {
-	struct iface_info_bond *bond = iface_info_bond(iface);
-	const struct iface *member;
-	int ret;
-
-	for (uint8_t i = 0; i < bond->n_members; i++) {
-		member = bond->members[i].iface;
-		if ((ret = iface_add_vlan(member->id, vlan_id)) < 0)
-			return ret;
-	}
-
-	return 0;
-}
-
-static int bond_vlan_del(struct iface *iface, uint16_t vlan_id) {
-	struct iface_info_bond *bond = iface_info_bond(iface);
-	const struct iface *member;
-	int ret;
-
-	for (uint8_t i = 0; i < bond->n_members; i++) {
-		member = bond->members[i].iface;
-		if ((ret = iface_del_vlan(member->id, vlan_id)) < 0)
-			return ret;
-	}
-
-	return 0;
-}
-
 static int bond_init_new_members(const struct iface *iface, const struct gr_iface_info_bond *new) {
 	struct iface_info_bond *bond = iface_info_bond(iface);
 	struct iface_info_port *port;
@@ -437,8 +409,6 @@ static struct iface_type iface_type_bond = {
 	.del_eth_addr = bond_mac_del,
 	.set_mtu = bond_mtu_set,
 	.set_promisc = bond_promisc_set,
-	.add_vlan = bond_vlan_add,
-	.del_vlan = bond_vlan_del,
 	.to_api = bond_to_api,
 };
 

--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -52,8 +52,6 @@ struct iface_type {
 	int (*set_up_down)(struct iface *, bool up);
 	int (*set_mtu)(struct iface *, uint16_t mtu);
 	int (*set_promisc)(struct iface *, bool enabled);
-	int (*add_vlan)(struct iface *, uint16_t vlan_id);
-	int (*del_vlan)(struct iface *, uint16_t vlan_id);
 	void (*to_api)(void *api_info, const struct iface *);
 	const char *name;
 	STAILQ_ENTRY(iface_type) next;
@@ -79,8 +77,6 @@ int iface_del_eth_addr(uint16_t ifid, const struct rte_ether_addr *);
 int iface_set_mtu(uint16_t ifid, uint16_t mtu);
 int iface_set_up_down(uint16_t ifid, bool up);
 int iface_set_promisc(uint16_t ifid, bool enabled);
-int iface_add_vlan(uint16_t ifid, uint16_t vlan_id);
-int iface_del_vlan(uint16_t ifid, uint16_t vlan_id);
 uint16_t ifaces_count(gr_iface_type_t type_id);
 struct iface *iface_next(gr_iface_type_t type_id, const struct iface *prev);
 

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -392,36 +392,6 @@ int iface_set_promisc(uint16_t ifid, bool enabled) {
 	return 0;
 }
 
-int iface_add_vlan(uint16_t ifid, uint16_t vlan_id) {
-	struct iface *iface = iface_from_id(ifid);
-	const struct iface_type *type;
-
-	if (iface == NULL)
-		return -errno;
-
-	type = iface_type_get(iface->type);
-	assert(type != NULL);
-	if (type->add_vlan == NULL)
-		return errno_set(EOPNOTSUPP);
-
-	return type->add_vlan(iface, vlan_id);
-}
-
-int iface_del_vlan(uint16_t ifid, uint16_t vlan_id) {
-	struct iface *iface = iface_from_id(ifid);
-	const struct iface_type *type;
-
-	if (iface == NULL)
-		return -errno;
-
-	type = iface_type_get(iface->type);
-	assert(type != NULL);
-	if (type->del_vlan == NULL)
-		return errno_set(EOPNOTSUPP);
-
-	return type->del_vlan(iface, vlan_id);
-}
-
 int iface_destroy(uint16_t ifid) {
 	struct iface *iface = iface_from_id(ifid);
 	const struct iface_type *type;

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -75,7 +75,7 @@ static struct rte_eth_conf default_port_config = {
 		},
 	},
 	.rxmode = {
-		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM | RTE_ETH_RX_OFFLOAD_VLAN,
+		.offloads = RTE_ETH_RX_OFFLOAD_CHECKSUM | RTE_ETH_RX_OFFLOAD_VLAN_STRIP,
 	},
 };
 
@@ -254,34 +254,6 @@ static int port_mtu_set(struct iface *iface, uint16_t mtu) {
 	gr_vec_foreach (struct iface *s, iface->subinterfaces)
 		s->mtu = iface->mtu;
 
-	return 0;
-}
-
-static int port_vlan_add(struct iface *iface, uint16_t vlan_id) {
-	struct iface_info_port *p = iface_info_port(iface);
-	int ret = rte_eth_dev_vlan_filter(p->port_id, vlan_id, true);
-	switch (ret) {
-	case 0:
-	case -ENOSYS:
-	case -EOPNOTSUPP:
-		break;
-	default:
-		return errno_log(-ret, "rte_eth_dev_vlan_filter");
-	}
-	return 0;
-}
-
-static int port_vlan_del(struct iface *iface, uint16_t vlan_id) {
-	struct iface_info_port *p = iface_info_port(iface);
-	int ret = rte_eth_dev_vlan_filter(p->port_id, vlan_id, false);
-	switch (ret) {
-	case 0:
-	case -ENOSYS:
-	case -EOPNOTSUPP:
-		break;
-	default:
-		return errno_log(-ret, "rte_eth_dev_vlan_filter");
-	}
 	return 0;
 }
 
@@ -734,8 +706,6 @@ static struct iface_type iface_type_port = {
 	.set_mtu = port_mtu_set,
 	.set_up_down = port_up_down,
 	.set_promisc = port_promisc_set,
-	.add_vlan = port_vlan_add,
-	.del_vlan = port_vlan_del,
 	.to_api = port_to_api,
 };
 

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -72,13 +72,8 @@ static int iface_vlan_reconfig(
 
 			rte_hash_del_key(vlan_hash, &cur_key);
 			iface_del_subinterface(cur_parent, iface);
-
-			// remove previous vlan filter (ignore errors)
-			iface_del_vlan(cur->parent_id, cur->vlan_id);
 		}
 
-		if (iface_add_vlan(next->parent_id, next->vlan_id) < 0)
-			return -errno;
 		cur->parent_id = next->parent_id;
 		cur->vlan_id = next->vlan_id;
 		iface_add_subinterface(next_parent, iface);
@@ -110,9 +105,6 @@ static int iface_vlan_fini(struct iface *iface) {
 	int ret, status = 0;
 
 	rte_hash_del_key(vlan_hash, &(struct vlan_key) {vlan->parent_id, vlan->vlan_id});
-
-	if ((ret = iface_del_vlan(vlan->parent_id, vlan->vlan_id)) < 0)
-		status = ret;
 
 	if ((ret = iface_del_eth_addr(vlan->parent_id, &vlan->mac)) < 0)
 		status = status ?: ret;


### PR DESCRIPTION
Depending on drivers, adding a VLAN filter can cause all other traffic (e.g. traffic not tagged with that precise VLAN) to be dropped before it even reaches the RX queues.

Grout has VLAN sub interfaces and needs to receive both tagged and untagged traffic.

Since there is no generic way of knowing how the hardware/driver will behave, remove VLAN filter offload completely. Grout will now receive *all* traffic and the VLAN filter will be done in software. This is acceptable since the switches should do their job and steer traffic in a sensible way.

Keep RTE_ETH_RX_OFFLOAD_VLAN_STRIP which isn't affected by VLAN filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed VLAN management from bond and port interfaces and from the public API; VLANs must be managed via alternative methods.
  * Port default RX offload adjusted for VLAN strip behavior.
  * VLAN reconfiguration and teardown no longer perform automatic per-parent VLAN add/delete operations, changing how VLAN filters are maintained.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->