### PR TITLE
smoke: wait for VF link ready before sending packets

### DIFF
--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -111,6 +111,22 @@ EOF
 	ip -n "$ns" link set lo up
 }
 
+move_to_netns() {
+	local iface="$1"
+	local netns="$2"
+
+	ip link set "$iface" netns "$netns"
+	ip -n "$netns" link set "$iface" up
+
+	SECONDS=0 # will be automatically incremented by bash
+	while ! ip -n "$netns" link show "$iface" | grep -qw LOWER_UP; do
+		if [ "$SECONDS" -gt 5 ]; then
+			fail "$iface link was not LOWER_UP after 5 seconds"
+		fi
+		sleep 0.2
+	done
+}
+
 tap_counter=0
 port_add() {
 	local name="$1"

--- a/smoke/bgp6_srv6_frr_test.sh
+++ b/smoke/bgp6_srv6_frr_test.sh
@@ -49,8 +49,7 @@ netns_add ns-a
 netns_add ns-b
 
 # Configure Host-B
-ip link set x-p1 netns ns-b
-ip -n ns-b link set x-p1 up
+move_to_netns x-p1 ns-b
 ip -n ns-b addr add 16.1.0.2/24 dev x-p1
 ip -n ns-b route add default via 16.1.0.1
 ip -n ns-b addr show
@@ -69,7 +68,6 @@ ip -n ns-a link set to-host-a up
 ip -n ns-a link set eth0 up
 
 # Configure Host-A
-ip -n ns-a link set eth0 up
 ip -n ns-a addr add 16.0.0.2/24 dev eth0
 ip -n ns-a route
 ip -n ns-a addr show

--- a/smoke/cross_vrf_forward_frr_test.sh
+++ b/smoke/cross_vrf_forward_frr_test.sh
@@ -11,8 +11,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	ip -n $ns addr add 16.$n.0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$n.1

--- a/smoke/cross_vrf_forward_test.sh
+++ b/smoke/cross_vrf_forward_test.sh
@@ -23,8 +23,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	ip -n $ns addr add 16.$n.0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$n.1

--- a/smoke/dhcp_test.sh
+++ b/smoke/dhcp_test.sh
@@ -10,9 +10,7 @@ netns_add dhcp-server
 
 port_add p0 mode l3
 
-ip link set x-p0 netns dhcp-server
-
-ip -n dhcp-server link set x-p0 up
+move_to_netns x-p0 dhcp-server
 ip -n dhcp-server addr add 192.168.100.1/24 dev x-p0
 
 cat > $tmp/dnsmasq.conf <<EOF

--- a/smoke/dnat44_test.sh
+++ b/smoke/dnat44_test.sh
@@ -16,8 +16,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 done
 
 ip -n n0 addr add 172.16.0.2/24 dev x-p0

--- a/smoke/ip6_builtin_icmp_test.sh
+++ b/smoke/ip6_builtin_icmp_test.sh
@@ -13,8 +13,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add fd00:ba4:$n::2/64 dev $p
 	ip -n $ns route add fd00:ba4::/62 via fd00:ba4:$n::1 dev $p
 done

--- a/smoke/ip6_forward_frr_test.sh
+++ b/smoke/ip6_forward_frr_test.sh
@@ -11,8 +11,7 @@ for n in 1 2; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add fd00:ba4:$n::2/64 dev $p
 	if [[ $n -eq 1 ]]; then
 		ip -n $ns addr add fd00:f00:$n::2/64 dev lo

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -16,8 +16,7 @@ for n in 1 2; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add fd00:ba4:$n::2/64 dev $p
 	if [[ $n -eq 1 ]]; then
 		ip -n $ns addr add fd00:f00:$n::2/64 dev lo

--- a/smoke/ip6_rs_ra_test.sh
+++ b/smoke/ip6_rs_ra_test.sh
@@ -10,8 +10,7 @@ port_add p1
 grcli address add fd00:ba4:1::1/64 iface p1
 
 netns_add n1
-ip link set x-p1 netns n1
-ip -n n1 link set x-p1 up
+move_to_netns x-p1 n1
 ip -n n1 addr add fd00:ba4:1::2/64 dev x-p1
 
 sleep 3  # wait for DAD

--- a/smoke/ip6_same_peer_test.sh
+++ b/smoke/ip6_same_peer_test.sh
@@ -14,8 +14,7 @@ for n in 1 2; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add fd00:ba4:$n::2/64 dev $p
 	ip -n $ns route add default via fd00:ba4:$n::1
 done

--- a/smoke/ip_builtin_icmp_test.sh
+++ b/smoke/ip_builtin_icmp_test.sh
@@ -14,8 +14,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	ip -n $ns route add default via 172.16.$n.1
 done

--- a/smoke/ip_forward_frr_test.sh
+++ b/smoke/ip_forward_frr_test.sh
@@ -11,8 +11,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	if [[ $n -eq 0 ]]; then
 		ip -n $ns addr add 16.$n.0.1/16 dev lo

--- a/smoke/ip_forward_test.sh
+++ b/smoke/ip_forward_test.sh
@@ -16,8 +16,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	if [[ $n -eq 0 ]]; then
 		ip -n $ns addr add 16.$n.0.1/16 dev lo

--- a/smoke/ip_fragment_test.sh
+++ b/smoke/ip_fragment_test.sh
@@ -16,8 +16,7 @@ for n in 0 1; do
 	ns=n$n
 	netns_add $ns
 	ip link set $p mtu 1500
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	ip -n $ns route add default via 172.16.$n.1
 	# Clear PMTU cache to ensure kernel uses interface MTU

--- a/smoke/ip_loadbalance_frr_test.sh
+++ b/smoke/ip_loadbalance_frr_test.sh
@@ -14,18 +14,15 @@ create_interface p1
 create_interface p2
 
 netns_add n0
-ip link set x-p0 netns n0
-ip -n n0 link set x-p0 up
+move_to_netns x-p0 n0
 ip -n n0 addr add 172.16.0.2/24 dev x-p0
 ip -n n0 route add default via 172.16.0.1
 
 netns_add n1
-ip link set x-p1 netns n1
-ip link set x-p2 netns n1
+move_to_netns x-p1 n1
+move_to_netns x-p2 n1
 ip -n n1 addr add 192.0.0.2/32 dev lo
-ip -n n1 link set x-p1 up
 ip -n n1 addr add 172.16.1.2/24 dev x-p1
-ip -n n1 link set x-p2 up
 ip -n n1 addr add 172.16.2.2/24 dev x-p2
 
 set_ip_address p0 172.16.0.1/24

--- a/smoke/ip_loadbalance_test.sh
+++ b/smoke/ip_loadbalance_test.sh
@@ -14,12 +14,10 @@ port_add p1
 port_add p2
 
 netns_add n0
-ip link set x-p0 netns n0
-ip link set x-p1 netns n0
+move_to_netns x-p0 n0
+move_to_netns x-p1 n0
 ip -n n0 addr add 192.200.0.2/24 dev lo
-ip -n n0 link set x-p0 up
 ip -n n0 addr add 172.16.0.2/24 dev x-p0
-ip -n n0 link set x-p1 up
 ip -n n0 addr add 172.16.1.2/24 dev x-p1
 ip -n n0 nexthop add id 1601 via 172.16.0.1 dev x-p0
 ip -n n0 nexthop add id 1611 via 172.16.1.1 dev x-p1
@@ -27,8 +25,7 @@ ip -n n0 nexthop add id 1620 group 1601/1611
 ip -n n0 route add 172.16.2.0/24 nhid 1620
 
 netns_add n1
-ip link set x-p2 netns n1
-ip -n n1 link set x-p2 up
+move_to_netns x-p2 n1
 ip -n n1 addr add 172.16.2.2/24 dev x-p2
 ip -n n1 route add default via 172.16.2.1
 

--- a/smoke/ipip_encap_test.sh
+++ b/smoke/ipip_encap_test.sh
@@ -12,14 +12,12 @@ grcli interface add ipip tun1 local 172.16.1.1 remote 172.16.1.2
 grcli address add 10.98.0.1/24 iface tun1
 
 netns_add n0
-ip link set x-p0 netns n0
-ip -n n0 link set x-p0 up
+move_to_netns x-p0 n0
 ip -n n0 addr add 10.99.0.2/24 dev x-p0
 ip -n n0 route add default via 10.99.0.1
 
 netns_add n1
-ip link set x-p1 netns n1
-ip -n n1 link set x-p1 up
+move_to_netns x-p1 n1
 ip -n n1 addr add 172.16.1.2/24 dev x-p1
 ip -n n1 tunnel add tun1 mode ipip local 172.16.1.2 remote 172.16.1.1
 ip -n n1 link set tun1 up

--- a/smoke/nexthop_ageing_test.sh
+++ b/smoke/nexthop_ageing_test.sh
@@ -36,8 +36,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$n.2/24 dev $p
 	ip -n $ns route add default via 172.16.$n.1
 done

--- a/smoke/snat44_test.sh
+++ b/smoke/snat44_test.sh
@@ -17,8 +17,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 done
 
 ip -n n0 addr add 172.16.0.2/24 dev x-p0

--- a/smoke/srv6_frr_test.sh
+++ b/smoke/srv6_frr_test.sh
@@ -11,8 +11,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 done
 ip -n n0 addr add 192.168.61.2/24 dev x-p0
 ip -n n1 addr add fd00:102::2/32 dev x-p1

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -13,8 +13,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 done
 ip -n n0 addr add 192.168.61.2/24 dev x-p0
 ip -n n1 addr add fd00:102::2/32 dev x-p1

--- a/smoke/vrf_forward_frr_test.sh
+++ b/smoke/vrf_forward_frr_test.sh
@@ -13,8 +13,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$((n % 2)).2/24 dev $p
 	ip -n $ns addr add 16.$((n % 2)).0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$((n % 2)).1
@@ -28,8 +27,7 @@ for n in 2 3; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$((n % 2)).2/24 dev $p
 	ip -n $ns addr add 16.$((n % 2)).0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$((n % 2)).1

--- a/smoke/vrf_forward_test.sh
+++ b/smoke/vrf_forward_test.sh
@@ -21,8 +21,7 @@ for n in 0 1; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$((n % 2)).2/24 dev $p
 	ip -n $ns addr add 16.$((n % 2)).0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$((n % 2)).1
@@ -34,8 +33,7 @@ for n in 2 3; do
 	p=x-p$n
 	ns=n$n
 	netns_add $ns
-	ip link set $p netns $ns
-	ip -n $ns link set $p up
+	move_to_netns $p $ns
 	ip -n $ns addr add 172.16.$((n % 2)).2/24 dev $p
 	ip -n $ns addr add 16.$((n % 2)).0.1/16 dev lo
 	ip -n $ns route add default via 172.16.$((n % 2)).1


### PR DESCRIPTION
Physical iavf VF interfaces are not immediately ready to receive packets after being moved to a network namespace. The first packet sent triggers initialization but gets lost, causing ARP timeouts.

Add wait_for_link() helper that waits for the LOWER_UP flag before configuring addresses. This fixes test failures where first ARP requests would timeout, causing 400ms+ delays or test failures.

Update all smoke tests that move interfaces to network namespaces.

Closes: https://github.com/DPDK/grout/issues/406
Closes: https://github.com/DPDK/grout/issues/407
Closes: https://github.com/DPDK/grout/issues/434