### PR TITLE
tests: initialize cpu_set_t in string_test

### DIFF
--- a/api/string_test.c
+++ b/api/string_test.c
@@ -36,7 +36,7 @@
 	} while (0)
 
 static void format(void **) {
-	cpu_set_t set;
+	cpu_set_t set = {};
 	char buf[256];
 
 	assert_errno_equal(cpuset_format(buf, sizeof(buf), NULL), EINVAL);


### PR DESCRIPTION
Fix compilation warning about uninitialized variable in the format() test function.