### PR TITLE
ctlplane: avoid compilation error on ancient toolchains

### DIFF
--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -331,10 +331,14 @@ static void cp_delete(struct iface *iface) {
 }
 
 static void cp_set_carrier(struct iface *iface) {
+#ifdef TUNSETCARRIER
 	int carrier = iface->flags & GR_IFACE_S_RUNNING ? 1 : 0;
 	if (ioctl(iface->cp_fd, TUNSETCARRIER, &carrier) < 0) {
 		LOG(ERR, "ioctl(TUNSETCARRIER): %s", strerror(errno));
 	}
+#else
+	(void)iface;
+#endif
 }
 
 static void cp_set_speed(struct iface *iface) {


### PR DESCRIPTION

TUNSETCARRIER is available since Linux 4.20 which is rather "old". But grout may be built on ancient toolchains that lack this symbol.

Since it is not critical to the operation of grout itself, disable the configuration of the carrier signal for the tap interfaces on these platforms.
