### PR TITLE
address: fix assert error when mcast cannot be configured

### DIFF
--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -220,6 +220,7 @@ iface6_addr_add(const struct iface *iface, const struct rte_ipv6_addr *ip, uint8
 	rte_ipv6_solnode_from_addr(&solicited_node, ip);
 	if (mcast6_addr_add(iface, &solicited_node) < 0) {
 		if (errno != EOPNOTSUPP && errno != EEXIST) {
+			nexthop_incref(nh);
 			nexthop_decref(nh);
 			return errno_set(errno);
 		}


### PR DESCRIPTION

When starting grout as a non-root user and configuring a dummy net_null port, on a debug build, grout aborts with an assertion error:

```
+ grcli inteface add port p0 devargs net_null
```

```
ERR: GROUT: iface_loopback_init: ioctl(TUNSETIFF): Operation not permitted
WARN: GROUT: vrf_incref: loopback for vrf 0 cannot be created: Operation not permitted
ERR: GROUT: cp_create: ioctl(TUNSETIFF): Operation not permitted
ERR: GROUT: cp_update: ioctl(SIOCSIFMTU) Operation not permitted
grout: ../modules/infra/control/nexthop.c:543: nexthop_decref: Assertion `nh->ref_count > 0' failed.
```

While the errors are expected since grout has no permission to create nor configure tap interfaces, it shouldn't cause a crash.

The nexthop was just created with refcount = 0. Calling decref directly is an invalid operation. Add an artificial incref before decref so that the nexthop is freed.

Fixes: 9d8684d3dff7 ("ip6: factorize solicited node mcast address config")
