### PR TITLE
nexthop: introduce explicit destroy operation

### DIFF
--- a/modules/infra/control/gr_nh_control.h
+++ b/modules/infra/control/gr_nh_control.h
@@ -110,8 +110,11 @@ void nexthop_routes_cleanup(struct nexthop *);
 void nexthop_incref(struct nexthop *);
 
 // Decrement the reference counter of a nexthop.
-// When the counter drops to 0, the nexthop is marked as available in the global pool.
+// When the counter drops to 0, the nexthop is destroyed and returned to the global pool.
 void nexthop_decref(struct nexthop *);
+
+// Return the nexthop to the global pool regardless of its refcount.
+void nexthop_destroy(struct nexthop *);
 
 // Callback for nh_iter().
 typedef void (*nh_iter_cb_t)(struct nexthop *nh, void *priv);

--- a/modules/ip6/control/address.c
+++ b/modules/ip6/control/address.c
@@ -220,8 +220,7 @@ iface6_addr_add(const struct iface *iface, const struct rte_ipv6_addr *ip, uint8
 	rte_ipv6_solnode_from_addr(&solicited_node, ip);
 	if (mcast6_addr_add(iface, &solicited_node) < 0) {
 		if (errno != EOPNOTSUPP && errno != EEXIST) {
-			nexthop_incref(nh);
-			nexthop_decref(nh);
+			nexthop_destroy(nh);
 			return errno_set(errno);
 		}
 	}


### PR DESCRIPTION

When creating a nexthop, it has refcount=0. If we need to destroy it before its refcount has been incremented we need to do the awkward incref, decref combo.

This is confusing and we will surely forget why this is even there in a couple of months.

Add an explicit nexthop_destroy() function and call it from within nexthop_decref() and in the IPv6 address code.
