### PR TITLE
trace: fix error when count is not specified

### DIFF
--- a/modules/infra/cli/trace.c
+++ b/modules/infra/cli/trace.c
@@ -58,7 +58,7 @@ static cmd_status_t trace_show(struct gr_api_client *c, const struct ec_pnode *p
 	void *resp_ptr = NULL;
 	int ret;
 
-	if (arg_u16(p, "COUNT", &max_packets) < 0)
+	if (arg_u16(p, "COUNT", &max_packets) < 0 && errno != ENOENT)
 		return CMD_ERROR;
 
 	do {


### PR DESCRIPTION

When running trace show without specifying the count the CLI returns an error:

    grout# trace show
    error: command failed: No such file or directory (ENOENT)

The count argument is optional, do not fail if it was not specified.

Fixes: 0edd9956e7cc ("trace: return packets by batches")
