### PR TITLE
Allow skipping smoke tests

### DIFF
--- a/smoke/run.sh
+++ b/smoke/run.sh
@@ -2,10 +2,40 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Robin Jarry
 
+set -eu
+
 here=$(dirname $0)
-builddir=${1-}
+skip_patterns=()
 log=$(mktemp)
 result=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-s|--skip)
+		shift
+		skip_patterns+=("$1")
+		;;
+	-*)
+		echo "error: invalid option: $1" >&2
+		exit 1
+		;;
+	*)
+		builddir="$1"
+	esac
+	shift
+done
+
+skip_test() {
+	local name=$1
+	for pattern in "${skip_patterns[@]}"; do
+		case "$name" in
+		$pattern)
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
 
 test_frr=false
 # running test frr is only supported when grout is built, not installed
@@ -24,6 +54,10 @@ for script in $here/*_test.sh; do
 	esac
 
 	printf "%s ... " "$name"
+	if skip_test "$name"; then
+		echo "SKIPPED"
+		continue
+	fi
 	start=$(date +%s)
 	res=OK
 


### PR DESCRIPTION
Allow skipping individual tests with:

    ./smoke/run.sh -s bgp6_srv6_frr_test.sh build/

Or test patterns with:

    ./smoke/run.sh -s '*srv6*' -s '*bgp*' build/