### PR TITLE
ctlplane: handle interface renaming

### DIFF
--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -383,9 +383,17 @@ err:
 }
 
 static void cp_update(struct iface *iface) {
+	char current_name[IFNAMSIZ];
 	struct rte_ether_addr mac;
 	struct ifreq ifr = {0};
 	int ioctl_sock;
+
+	if (iface->cp_id > 0) {
+		if (if_indextoname(iface->cp_id, current_name) != NULL
+		    && strcmp(current_name, iface->name) != 0) {
+			netlink_link_set_name(iface->cp_id, iface->name);
+		}
+	}
 
 	if ((ioctl_sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
 		LOG(ERR, "socket(SOCK_DGRAM): %s", strerror(errno));

--- a/modules/infra/control/gr_netlink.h
+++ b/modules/infra/control/gr_netlink.h
@@ -9,6 +9,7 @@
 
 int netlink_link_set_admin_state(const char *ifname, bool up);
 int netlink_link_set_master(const char *ifname, const char *master_ifname);
+int netlink_link_set_name(uint32_t ifindex, const char *ifname);
 int netlink_link_add_vrf(const char *vrf_name, uint32_t table_id);
 int netlink_link_del_iface(const char *ifname);
 int netlink_add_route(const char *ifname, uint32_t table);

--- a/modules/infra/control/netlink.c
+++ b/modules/infra/control/netlink.c
@@ -328,6 +328,25 @@ int netlink_set_ifalias(const char *ifname, const char *ifalias) {
 	return netlink_send_req(nlh);
 }
 
+int netlink_link_set_name(uint32_t ifindex, const char *ifname) {
+	char buf[NLMSG_SPACE(sizeof(struct ifinfomsg) + NLA_SPACE(IFNAMSIZ))];
+	struct ifinfomsg *ifm;
+	struct nlmsghdr *nlh;
+
+	memset(buf, 0, sizeof(buf));
+	nlh = mnl_nlmsg_put_header(buf);
+	nlh->nlmsg_type = RTM_SETLINK;
+	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+
+	ifm = mnl_nlmsg_put_extra_header(nlh, sizeof(*ifm));
+	ifm->ifi_family = AF_UNSPEC;
+	ifm->ifi_index = ifindex;
+
+	mnl_attr_put_strz(nlh, IFLA_IFNAME, ifname);
+
+	return netlink_send_req(nlh);
+}
+
 static void netlink_init(struct event_base *) {
 	nl_sock = mnl_socket_open(NETLINK_ROUTE);
 	if (!nl_sock)


### PR DESCRIPTION

When a grout interface is renamed, rename its control plane counterpart.
