### PR TITLE
treewide: remove extraneous asserts

### DIFF
--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -62,7 +62,6 @@ int icmp_local_send(
 	msg->ttl = ttl;
 	msg->dst = dst;
 
-	assert(gw->type == GR_NH_T_L3);
 	l3 = nexthop_info_l3(gw);
 
 	if ((local = addr4_get_preferred(gw->iface_id, l3->ipv4)) == NULL) {
@@ -70,7 +69,6 @@ int icmp_local_send(
 		return -errno;
 	}
 
-	assert(local->type == GR_NH_T_L3);
 	l3 = nexthop_info_l3(local);
 	msg->src = l3->ipv4;
 

--- a/modules/ip/datapath/ip_error.c
+++ b/modules/ip/datapath/ip_error.c
@@ -67,7 +67,6 @@ ip_error_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 			goto next;
 		}
 
-		assert(local->type == GR_NH_T_L3);
 		l3 = nexthop_info_l3(local);
 
 		ip_data = ip_local_mbuf_data(mbuf);

--- a/modules/policy/api/dnat44.c
+++ b/modules/policy/api/dnat44.c
@@ -10,13 +10,8 @@
 #include <gr_vec.h>
 
 static bool dnat44_nh_equal(const struct nexthop *a, const struct nexthop *b) {
-	struct nexthop_info_dnat *ad, *bd;
-
-	assert(a->type == GR_NH_T_DNAT);
-	assert(b->type == GR_NH_T_DNAT);
-
-	ad = nexthop_info_dnat(a);
-	bd = nexthop_info_dnat(b);
+	struct nexthop_info_dnat *ad = nexthop_info_dnat(a);
+	struct nexthop_info_dnat *bd = nexthop_info_dnat(b);
 
 	return ad->match == bd->match && ad->replace == bd->replace;
 }

--- a/modules/srv6/control/localsid.c
+++ b/modules/srv6/control/localsid.c
@@ -10,13 +10,8 @@
 #include <gr_srv6_nexthop.h>
 
 static bool srv6_local_nh_equal(const struct nexthop *a, const struct nexthop *b) {
-	struct nexthop_info_srv6_local *ad, *bd;
-
-	assert(a->type == GR_NH_T_SR6_LOCAL);
-	assert(b->type == GR_NH_T_SR6_LOCAL);
-
-	ad = nexthop_info_srv6_local(a);
-	bd = nexthop_info_srv6_local(b);
+	struct nexthop_info_srv6_local *ad = nexthop_info_srv6_local(a);
+	struct nexthop_info_srv6_local *bd = nexthop_info_srv6_local(b);
 
 	return ad->behavior == bd->behavior && ad->out_vrf_id == bd->out_vrf_id
 		&& ad->flags == bd->flags;


### PR DESCRIPTION

nexthop_info_* macros already contain an assert.
