### PR TITLE
ip_error: trim mbuf to avoid fragmentation loop

### DIFF
--- a/smoke/ip_fragment_test.sh
+++ b/smoke/ip_fragment_test.sh
@@ -40,3 +40,6 @@ ip netns exec n0 ping -i0.01 -c3 -s 1260 -M do -n 172.16.1.2 && fail "ping with 
 # Expected: Packet is fragmented into 2 fragments (1276 + 32 bytes) and ping succeeds
 ip netns exec n0 ip route flush cache
 ip netns exec n0 ping -i0.01 -c3 -s 1260 -M dont -n 172.16.1.2
+
+# Test 4: run tracepath to do PMTU discovery
+ip netns exec n0 tracepath -n 172.16.1.2


### PR DESCRIPTION

When receiving a large packet that does not fit into the MTU and has a DF (don't fragment) bit set, we send an ICMP error (fragment needed) to the source IP.

According to RFC 729, the ICMP error payload must be the original IP header and 64 bits of the IP payload.

Currently, we do not trim the end of the packet, prepend the ICMP header and move on with our lives. This causes the ICMP error packet to enter the ip_fragment node (because it is too big, in fact it is bigger than before prepending the ICMP header).

But the new ip header has a total length which is short (original IP header + 64 bits). Which triggers this assert error:

    grout: modules/ip/datapath/ip_fragment.c:86: ip_fragment_process:
    Assertion `num_frags > 1' failed.

Make sure to trim the mbuf to the proper length before prepending the ICMP header.

Run tracepath in the IP fragmentation smoke test to ensure it works as expected.

Fixes: 350afcd9f515 ("ip: send an icmp message when TTL is expired")
