### PR TITLE
snap: allow snap over vlan

### DIFF
--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -60,11 +60,6 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 		eth_type = eth->ether_type;
 		vlan_id = 0;
 
-		if (unlikely(rte_be_to_cpu_16(eth_type) < SNAP_MAX_LEN)) {
-			edge = SNAP;
-			goto snap;
-		}
-
 		if (m->ol_flags & RTE_MBUF_F_RX_VLAN_STRIPPED) {
 			vlan_id = m->vlan_tci & 0xfff;
 			m->ol_flags &= ~RTE_MBUF_F_RX_VLAN_STRIPPED;
@@ -90,6 +85,12 @@ eth_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			}
 			eth_in->iface = vlan_iface;
 		}
+
+		if (unlikely(rte_be_to_cpu_16(eth_type) < SNAP_MAX_LEN)) {
+			edge = SNAP;
+			goto snap;
+		}
+
 		edge = l2l3_edges[eth_type];
 
 		if (iface == NULL || iface->id != eth_in->iface->id) {


### PR DESCRIPTION
SNAP frames may be transmitted over vlan.
For control planes, this means we must send the frame over the proper interface.

In the following case:

NOTICE: GROUT: [rx eno49v1] ea:e7:65:49:e1:d6 > 01:80:c2:00:00:14 / VLAN id=210 / SNAP / IS-IS all Level 1 IS's, (pkt_len=1514)
NOTICE: GROUT: [cp tx eno49v1] ea:e7:65:49:e1:d6 > 01:80:c2:00:00:14 / VLAN id=210 / SNAP / IS-IS all Level 1 IS's, (pkt_len=1514)

The frame is sent to the CP interface on the parent interface with a vlan instead of the sub-interface.

In eth_input node, pop the vlan and update the interface before checking if the frame has to be redirected to the SNAP node.

Fixes: 236e7440516d ("infra: add snap input node")