### PR TITLE
icmp: check nexthop validity

### DIFF
--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -53,6 +53,10 @@ int icmp_local_send(
 			return errno_set(EHOSTUNREACH);
 	}
 
+	// FIXME
+	if (gw->type != GR_NH_T_L3)
+		return errno_set(ENONET);
+
 	if ((msg = calloc(1, sizeof(struct ctl_to_stack))) == NULL)
 		return errno_set(ENOMEM);
 

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -53,6 +53,10 @@ int icmp6_local_send(
 			return errno_set(EHOSTUNREACH);
 	}
 
+	// FIXME
+	if (gw->type != GR_NH_T_L3)
+		return errno_set(ENONET);
+
 	if ((local = addr6_get_preferred(gw->iface_id, &nexthop_info_l3(gw)->ipv6)) == NULL)
 		return -errno;
 


### PR DESCRIPTION
Trying to ping a host with a non-L3 gateway (SRv6) crashes grout. Until the proper fix is implemented, forbid generating icmp packets from grout to these non-L3 nexthops.

This doesn't change the behavior for routed packets.