### PR TITLE
port: handle RTE_ETH_EVENT_INTR_RESET events

### DIFF
--- a/modules/infra/control/gr_port.h
+++ b/modules/infra/control/gr_port.h
@@ -28,6 +28,7 @@ GR_IFACE_INFO(GR_IFACE_TYPE_PORT, iface_info_port, {
 
 	uint16_t port_id;
 	bool started;
+	bool needs_reset;
 	struct rte_mempool *pool;
 	char *devargs;
 	uint32_t pool_size;


### PR DESCRIPTION
Register a callback for RTE_ETH_EVENT_INTR_RESET which is raised by some DPDK drivers when the hardware requires a reset. This typically happens when the PF driver modifies VF settings from the host side, for example when changing a VF MAC address via ip link:

    ip link set $pf vf $vf_num mac $mac

When the reset event is received, the port is fully reset and reconfigured via rte_eth_dev_reset() followed by rte_eth_dev_configure() and rte_eth_dev_start(). The MAC address is re-read from hardware to pick up any changes made by the PF.

The callback is invoked from DPDK internal threads, so we use event_active() to defer the actual reset handling to the main control plane event loop.

Note that RTE_ETH_EVENT_INTR_RESET support varies by driver. The Intel iavf driver reports this event when the VF MAC is changed from the PF. The mlx5 driver does not report this event in the same scenario.