### PR TITLE
ecoli: update to version 0.11.0

### DIFF
--- a/cli/cli.h
+++ b/cli/cli.h
@@ -11,6 +11,11 @@
 
 #include <sys/queue.h>
 
+#ifndef EC_INTERACT_HELP_ATTR
+// Compatibility with libecoli < 0.11
+#define EC_INTERACT_HELP_ATTR EC_EDITLINE_HELP_ATTR
+#endif
+
 struct cli_context {
 	const char *name;
 

--- a/cli/complete.c
+++ b/cli/complete.c
@@ -60,7 +60,7 @@ static const char *find_help(const struct ec_comp_item *item) {
 		type = ec_node_get_type_name(node);
 		if (strcmp(type, "devargs") == 0 || strcmp(type, "file") == 0)
 			break;
-		help = ec_dict_get(ec_node_attrs(node), EC_EDITLINE_HELP_ATTR);
+		help = ec_dict_get(ec_node_attrs(node), EC_INTERACT_HELP_ATTR);
 		pstate = ec_pnode_get_parent(pstate);
 	}
 

--- a/cli/dump.c
+++ b/cli/dump.c
@@ -61,7 +61,7 @@ static void print_tree(const struct ec_node *tree, unsigned depth) {
 	printf(",\n");
 
 	printf("%*s\"help\": ", indent, " ");
-	print_string(ec_dict_get(ec_node_attrs(tree), EC_EDITLINE_HELP_ATTR));
+	print_string(ec_dict_get(ec_node_attrs(tree), EC_INTERACT_HELP_ATTR));
 	printf(",\n");
 
 	printf("%*s\"children\": [", indent, " ");

--- a/cli/ecoli.c
+++ b/cli/ecoli.c
@@ -13,7 +13,7 @@ struct ec_node *with_help(const char *help, struct ec_node *node) {
 	if (node == NULL)
 		return NULL;
 	struct ec_dict *attrs = ec_node_attrs(node);
-	if (attrs == NULL || ec_dict_set(attrs, EC_EDITLINE_HELP_ATTR, (void *)help, NULL) < 0) {
+	if (attrs == NULL || ec_dict_set(attrs, EC_INTERACT_HELP_ATTR, (void *)help, NULL) < 0) {
 		ec_node_free(node);
 		node = NULL;
 	}

--- a/subprojects/ecoli.wrap
+++ b/subprojects/ecoli.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-source_url = https://github.com/rjarry/libecoli/archive/refs/tags/v0.10.1.tar.gz
-source_filename = libecoli-0.10.1.tar.gz
-source_hash = ec359850f4f338b607d05200d508736b14eaa30fca8aefdfde980a283afd789d
-directory = libecoli-0.10.1
+source_url = https://github.com/rjarry/libecoli/archive/refs/tags/v0.11.3.tar.gz
+source_filename = libecoli-0.11.3.tar.gz
+source_hash = 25ed9638452fa050749746c863574dfd47df95bde98347d210c9deedea188151
+directory = libecoli-0.11.3
 
 [provide]
 dependency_names = libecoli


### PR DESCRIPTION
Update to the latest release of libecoli which contains various bug fixes.

The EC_EDITLINE namespace has been split in two. Rename references to EC_EDITLINE_HELP_ATTR -> EC_INTERACT_HELP_ATTR.

Link: https://github.com/rjarry/libecoli/releases/tag/v0.11.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Bump libecoli dependency and subproject
  - meson.build: dependency('libecoli', ...) version constraint changed from ">= 0.10.0" to ">= 0.11.0".
  - subprojects/ecoli.wrap: wrap updated to libecoli v0.11.2 (source_url, source_filename, source_hash, directory).

- Switch help attribute key used by CLI code
  - Replaced EC_EDITLINE_HELP_ATTR with EC_INTERACT_HELP_ATTR where help text is stored or read:
    - cli/complete.c: find_help() reads EC_INTERACT_HELP_ATTR while walking ancestor nodes.
    - cli/dump.c: print_tree() prints the JSON "help" field using EC_INTERACT_HELP_ATTR.
    - cli/ecoli.c: with_help() stores help under EC_INTERACT_HELP_ATTR.
  - No other control-flow or return-value changes introduced by these edits.

- Public API / exported symbols
  - No exported/public entity signatures added, removed, or modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->