### PR TITLE
infra: fallback for non-multicast capable drivers

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -349,9 +349,15 @@ static int iface_port_reconfig(
 			return ret;
 
 		// always enable allmulti
-		if ((ret = rte_eth_allmulticast_enable(p->port_id)) < 0)
-			return errno_log(-ret, "rte_eth_allmulticast_enable");
-		iface->state |= GR_IFACE_S_ALLMULTI;
+		if ((ret = rte_eth_allmulticast_enable(p->port_id)) < 0) {
+			LOG(ERR, "rte_eth_allmulticast_enable failed %s", rte_strerror(-ret));
+			if ((ret = rte_eth_promiscuous_enable(p->port_id)) < 0)
+				return errno_log(-ret, "rte_eth_promiscuous_enable failed");
+			else
+				iface->state |= GR_IFACE_S_PROMISC_FIXED;
+		} else {
+			iface->state |= GR_IFACE_S_ALLMULTI;
+		}
 
 		if ((ret = port_plug(p)) < 0)
 			return ret;


### PR DESCRIPTION
af_packet and af_xdp drivers do not support enabling "all_multi". When we add a port, if the call to enable all_multi fails, try to enable "promisc" mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network interface configuration with enhanced error handling for multicast mode activation. If enabling multicast fails, the system now logs the error, automatically attempts an alternative (promiscuous) mode, and updates interface status accordingly. This fallback preserves connectivity and keeps interface state accurate, resulting in more reliable and stable network behavior across varied deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->