### PR TITLE
icmp: return ENOENT when no echo reply is available

### DIFF
--- a/modules/ip/cli/icmp.c
+++ b/modules/ip/cli/icmp.c
@@ -67,9 +67,9 @@ static cmd_status_t icmp_send(
 			);
 			if (resp_ptr != NULL)
 				break;
-		} while (ret == 0 && --timeout > 0);
+		} while (ret == -ENOENT && --timeout > 0);
 
-		if (ret < 0)
+		if (ret < 0 && ret != -ENOENT)
 			return CMD_ERROR;
 
 		reply_resp = resp_ptr;

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -80,11 +80,11 @@ static struct rte_mbuf *get_icmp_response(uint16_t ident, uint16_t seq_num, cloc
 			mbuf = i->mbuf;
 			*timestamp = i->timestamp;
 			icmp_queue_pop(i, false);
-			break;
+			return mbuf;
 		}
 	}
 
-	return mbuf;
+	return errno_set_null(ENOENT);
 }
 
 static struct api_out icmp_send(const void *request, struct api_ctx *) {
@@ -114,7 +114,7 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 
 	m = get_icmp_response(icmp_req->ident, icmp_req->seq_num, &rcv_timestamp);
 	if (m == NULL)
-		return api_out(0, 0, NULL);
+		return api_out(errno, 0, NULL);
 
 	if ((resp = calloc(1, sizeof(*resp))) == NULL) {
 		ret = ENOMEM;

--- a/modules/ip6/cli/icmp6.c
+++ b/modules/ip6/cli/icmp6.c
@@ -59,9 +59,9 @@ static cmd_status_t icmp_send(
 			);
 			if (resp_ptr != NULL)
 				break;
-		} while (ret == 0 && --timeout > 0);
+		} while (ret == -ENOENT && --timeout > 0);
 
-		if (ret < 0)
+		if (ret < 0 && ret != -ENOENT)
 			return CMD_ERROR;
 
 		reply_resp = resp_ptr;

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -91,7 +91,7 @@ free_and_skip:
 		icmp6_queue_pop(i, true);
 	}
 
-	return NULL;
+	return errno_set_null(ENOENT);
 }
 
 static struct api_out icmp6_send(const void *request, struct api_ctx *) {
@@ -118,7 +118,7 @@ static struct api_out icmp6_recv(const void *request, struct api_ctx *) {
 
 	m = get_icmp6_echo_reply(recvreq->ident, recvreq->seq_num, &icmp6, &rcv_timestamp);
 	if (m == NULL)
-		return api_out(0, 0, NULL);
+		return api_out(errno, 0, NULL);
 
 	d_ip6 = ip6_local_mbuf_data(m);
 	icmp6_echo = PAYLOAD(icmp6);


### PR DESCRIPTION
Since commit ab83fb6fd670 ("api: validate response payload size in clients"), the client library rejects responses whose payload size does not match the declared response type. The ICMP and ICMPv6 recv handlers were returning success with an empty payload when no reply had arrived yet, which now triggers EMSGSIZE on the client side.

Here is an example trace (truncated):

```
+ grcli ping fd00:ba4:1::2 count 3 delay 10
API: accept_conn_cb: new connection fd=20 pid=17607
API: read_cb: ... (GR_HELLO) req_len=132 status=0 (Success) resp_len=0
API: read_cb: ... (GR_IP6_ICMP6_SEND) req_len=26 status=0 (Success) resp_len=0
TRACE: [tx p1] ... / ICMPv6 neigh solicit who has fd00:ba4:1::2? ...
API: read_cb: ... (GR_IP6_ICMP6_RECV) req_len=4 status=0 (Success) resp_len=0
                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: command failed: Message too long (EMSGSIZE)
API: disconnect_client: client pid=17607 disconnected
TRACE: [rx p1] ... / ICMPv6 neigh advert fd00:ba4:1::2 is at ...
TRACE: [tx p1] ... / ICMPv6 echo request id=53710 seq=0, (pkt_len=70)
TRACE: [rx p1] ... / ICMPv6 echo reply id=53710 seq=0, (pkt_len=70)
```

Return ENOENT from the recv handlers when no matching echo reply is found. Adjust the CLI polling loops to retry on ENOENT and treat it as a normal "not yet" condition rather than a fatal error.

I have checked that no other API handlers return an empty success response when they are expected to return a payload with the following obscure shell pipeline:

```
sed -En 's/^GR_REQ\((.+), .+, (.+)\)\;$/\1 \2/p' $(git grep -wl GR_REQ) |
grep -v gr_empty | sed -En 's/(.*) struct .*/\1/p' |
while read -r req; do sed -En "s/^.*api_handler\($req, (.+)\);$/\\1/p" $(git grep -wl $req); done | \
while read -r func; do sed -En "/$func\\(/,/^}\$/p" $(git grep -wl $func); done |
grep -c 'api_out(0, 0'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Technical changes

Control layer (ICMP / ICMPv6 recv handlers)
- get_icmp_response() and get_icmp6_echo_reply() return errno_set_null(ENOENT) when no matching echo reply/error packet is found (instead of returning NULL).
- icmp_recv() and icmp6_recv() propagate errno via api_out(errno, 0, NULL) on the "no message found" path rather than returning api_out(0, 0, NULL).

CLI layer (polling loops)
- icmp_send() in modules/ip/cli/icmp.c and modules/ip6/cli/icmp6.c: the reply-wait loop now continues only while gr_api_client_send_recv() returns -ENOENT and timeout remains; previously the loop continued while ret == 0. After the loop, negative return values are treated as fatal only when ret != -ENOENT (ret == -ENOENT is now treated as the expected "no reply yet" condition).

Control-flow simplification
- get_icmp_response() returns the matched rte_mbuf immediately when an identifier/sequence match is found (replacing an earlier break-based exit).

Workflows and test helpers
- .github/workflows/check.sh prints the active compiler version and, on unit-test failure, runs each test binary under gdb -batch to capture backtraces before exiting non-zero.

## Rationale tied to code history
- Commit ab83fb6f ("api: validate response payload size in clients") made clients reject responses whose payload size does not match the declared response type. Previously, recv handlers returned a successful zero-length response when no reply existed, which caused clients to see an empty-success response (status=0, resp_len=0) and fail with EMSGSIZE. Returning ENOENT from recv handlers distinguishes "no reply yet" from a successful empty response so CLI polling loops retry instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->