### PR TITLE
frr: add FRR 10.6.0 compatibility

### DIFF
--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -10,6 +10,7 @@
 #include <gr_l2.h>
 #include <gr_srv6.h>
 
+#include <lib/libfrr.h>
 #include <linux/if.h>
 #include <net/if.h>
 #include <zebra/interface.h>
@@ -173,7 +174,12 @@ void grout_link_change(struct gr_iface *gr_if, bool new, bool startup) {
 			vi.vni_info.iftype = ZEBRA_VXLAN_IF_VNI;
 			vi.vni_info.vni.vni = gr_vxlan->vni;
 			vi.ifindex_link = ifindex_grout_to_frr(gr_vxlan->encap_vrf_id);
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+			vi.vtep_ip.ipa_type = IPADDR_V4;
+			vi.vtep_ip.ipaddr_v4.s_addr = gr_vxlan->local;
+#else
 			vi.vtep_ip.s_addr = gr_vxlan->local;
+#endif
 			dplane_ctx_set_ifp_vxlan_info(ctx, &vi);
 		}
 	} else {

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -18,6 +18,15 @@ endif
 
 install_build_flag = frr_dep.get_variable('install_on_build', default_value: 'false') == 'true'
 frr_moduledir = frr_dep.get_variable('moduledir')
+
+frr_version = frr_dep.version()
+frr_ver = frr_version.split('.')
+# Match MAKE_FRRVERSION() layout from libfrr.h: MAJOR(8) | MINOR(16) | SUB(8)
+frr_ver_num = frr_ver[0].to_int() * 16777216 + frr_ver[1].to_int() * 256 + frr_ver[2].to_int()
+frr_c_args = [
+  '-DCURRENT_FRR_VERSION=' + frr_ver_num.to_string(),
+]
+
 frr_plugin = shared_module(
   'dplane_grout',
   files(
@@ -27,6 +36,7 @@ frr_plugin = shared_module(
     'zebra_dplane_grout.c',
   ) + grout_header,
   name_prefix: '',
+  c_args: frr_c_args,
   dependencies: [frr_dep],
   include_directories: api_inc + include_directories('.'),
   install: not install_build_flag,

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -8,6 +8,7 @@
 #include <gr_l2.h>
 #include <gr_srv6.h>
 
+#include <lib/libfrr.h>
 #include <lib/srv6.h>
 #include <linux/neighbour.h>
 #include <zebra/rib.h>
@@ -392,7 +393,11 @@ static void grout_route_change(
 			assert(nh_id == 0);
 		}
 
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+		rib_add_multipath(afi, SAFI_UNICAST, &p, NULL, re, ng, false, false);
+#else
 		rib_add_multipath(afi, SAFI_UNICAST, &p, NULL, re, ng, false);
+#endif
 
 		if (ng)
 			nexthop_group_delete(&ng);
@@ -890,7 +895,16 @@ void grout_macfdb_change(const struct gr_fdb_entry *fdb, bool new) {
 	dplane_ctx_mac_set_ndm_state(ctx, NUD_REACHABLE);
 	dplane_ctx_mac_set_ndm_flags(ctx, NTF_MASTER);
 	dplane_ctx_mac_set_dst_present(ctx, fdb->vtep != 0);
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+	// clang-format off
+	dplane_ctx_mac_set_vtep_ip(ctx, &(struct ipaddr) {
+		.ipa_type = IPADDR_V4,
+		.ipaddr_v4.s_addr = fdb->vtep,
+	});
+	// clang-format on
+#else
 	dplane_ctx_mac_set_vtep_ip(ctx, &(struct in_addr) {fdb->vtep});
+#endif
 	dplane_ctx_mac_set_vid(ctx, fdb->vlan_id);
 	dplane_ctx_mac_set_dp_static(ctx, fdb->flags & GR_FDB_F_STATIC);
 	dplane_ctx_mac_set_local_inactive(ctx, false);
@@ -934,7 +948,11 @@ enum zebra_dplane_result grout_macfdb_update_ctx(struct zebra_dplane_ctx *ctx) {
 		if (dplane_ctx_mac_get_dp_static(ctx))
 			add->fdb.flags |= GR_FDB_F_STATIC;
 		memcpy(&add->fdb.mac, dplane_ctx_mac_get_addr(ctx), sizeof(add->fdb.mac));
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+		add->fdb.vtep = dplane_ctx_mac_get_vtep_ip(ctx)->ipaddr_v4.s_addr;
+#else
 		add->fdb.vtep = dplane_ctx_mac_get_vtep_ip(ctx)->s_addr;
+#endif
 		req_type = GR_FDB_ADD;
 	} else {
 		struct gr_fdb_del_req *del = req;

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -656,7 +656,11 @@ static void zd_grout_ns(struct event *) {
 	// loop which asserts that the caller is not its owner. At startup, the
 	// dplane event loop owner is still the main thread until the dplane
 	// pthread has actually started and claimed it. Retry until it has.
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+	if (frr_event_loop_get_pthread_owner(dg_master) == pthread_self()) {
+#else
 	if (dg_master->owner == pthread_self()) {
+#endif
 		event_add_timer_msec(zrouter.master, zd_grout_ns, NULL, 10, NULL);
 		return;
 	}

--- a/subprojects/packagefiles/frr/meson.build
+++ b/subprojects/packagefiles/frr/meson.build
@@ -77,6 +77,7 @@ frr_dep = declare_dependency(
     '-Wno-unused-parameter',
   ],
   sources: [build],
+  version: meson.project_version(),
   variables: {
     'moduledir': moduledir,
     'prefix': prefix,


### PR DESCRIPTION
FRR 10.6.0 introduced several API changes that break compilation:

- rib_add_multipath() gained a bool replace parameter
- dplane_ctx_mac_set_vtep_ip() and dplane_ctx_mac_get_vtep_ip() now use struct ipaddr instead of struct in_addr
- zebra_l2info_vxlan.vtep_ip changed from struct in_addr to struct ipaddr
- struct event_loop is now opaque, requiring the new accessor frr_event_loop_get_pthread_owner() instead of direct field access

Detect the FRR version at build time in meson and define CURRENT_FRR_VERSION macro. Guard
all changed call sites with #ifdef to support both 10.5 and 10.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Compatibility with FRR 10.6.0

Build-time FRR version detection and conditional compilation enable building against both FRR 10.5.x and FRR 10.6.x API variants by exposing a packed numeric FRR version to the compiler and guarding affected call sites with #if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10,6,0).

### Build system changes
- frr/meson.build: Read the resolved FRR dependency version, split into major/minor/sub, compute a packed integer using MAKE_FRRVERSION layout (major*2^24 + minor*256 + sub), and pass it to the compiler as -DCURRENT_FRR_VERSION=<value> via c_args for the dplane_grout shared module.
- subprojects/packagefiles/frr/meson.build: Export the FRR dependency version by adding version: meson.project_version() to the frr_dep declare_dependency().

### API adaptations (version-guarded)
- frr/if_grout.c:
  - Include <lib/libfrr.h>.
  - VXLAN L2 info: when CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10,6,0) populate vi.vtep_ip as struct ipaddr (set ipa_type = IPADDR_V4 and write ipaddr_v4.s_addr); otherwise assign legacy vi.vtep_ip.s_addr. vi is passed unchanged to dplane_ctx_set_ifp_vxlan_info().

- frr/rt_grout.c:
  - Include <lib/libfrr.h>.
  - Route installation: call rib_add_multipath(...) with the additional bool replace parameter (two trailing false arguments) when building against FRR >= 10.6.0; retain the prior call signature for older FRR.
  - MAC-FDB handling: when FRR >= 10.6.0, pass and read VTEP addresses using struct ipaddr (ipa_type = IPADDR_V4 and ipaddr_v4.s_addr) to/from dplane_ctx_mac_set_vtep_ip()/dplane_ctx_mac_get_vtep_ip(); for older FRR keep using struct in_addr and ->s_addr.

- frr/zebra_dplane_grout.c:
  - Include <lib/libfrr.h>.
  - Event-loop ownership check: use frr_event_loop_get_pthread_owner(dg_master) == pthread_self() when CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10,6,0); otherwise continue using direct dg_master->owner comparison.

### Notes
- All API changes are covered with #if CURRENT_FRR_VERSION conditionals so the codebase remains buildable against both older and newer FRR headers without changing public/exported interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->