### PR TITLE
frr: tests multiple FRR versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,18 @@ jobs:
             os: ubuntu-24.04
             extra_opts: -Dfrr=enabled
             rebase: false
+          - compiler: gcc-14
+            sanitize: none
+            buildtype: debugoptimized
+            os: ubuntu-24.04
+            extra_opts: -Dfrr=enabled -Dfrr_version=10.6.0
+            rebase: false
+          - compiler: gcc-14
+            sanitize: none
+            buildtype: debugoptimized
+            os: ubuntu-24.04
+            extra_opts: -Dfrr=enabled -Dfrr_version=master
+            rebase: false
           - compiler: clang-15
             sanitize: none
             buildtype: debugoptimized

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (c) 2025 Maxime Leroy, Free Mobile
 frr_opt = get_option('frr')
+frr_version = get_option('frr_version')
 
 if frr_opt.disabled()
   subdir_done()
@@ -9,7 +10,11 @@ endif
 frr_dep = dependency('frr', version: '>= 10.5', required: false)
 if not frr_dep.found()
   if get_option('frr').enabled()
-    sp = subproject('frr')
+    if frr_version == 'default'
+      sp = subproject('frr')
+    else
+      sp = subproject('frr-' + frr_version)
+    endif
     frr_dep = sp.get_variable('frr_dep')
   else
     subdir_done()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,6 +12,11 @@ option(
 )
 
 option(
+  'frr_version', type: 'combo', choices: ['default', '10.6.0', 'master'], value: 'default',
+  description: 'FRR version, defaults to 10.5.3.',
+)
+
+option(
   'tests', type: 'feature', value: 'auto',
   description: 'Build unit-tests. If set to "auto", only build if cmocka is found.',
 )

--- a/subprojects/frr-10.6.0.wrap
+++ b/subprojects/frr-10.6.0.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.6.0.tar.gz
+source_filename = frr-10.6.0.tar.gz
+source_hash = f575c821f0b6a2c9034eda0b464e6053eadce892d29ccaf54d60e601cc9f59ef
+directory = frr-frr-10.6.0
+patch_directory = frr
+
+[provide]
+dependency_names = frr-10.6.0

--- a/subprojects/frr-master.wrap
+++ b/subprojects/frr-master.wrap
@@ -1,0 +1,9 @@
+[wrap-git]
+url = https://github.com/FRRouting/frr
+revision = master
+depth = 1
+directory = frr-frr-master
+patch_directory = frr
+
+[provide]
+dependency_names = frr-master

--- a/subprojects/packagefiles/frr/meson.build
+++ b/subprojects/packagefiles/frr/meson.build
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025 Maxime Leroy, Free Mobile
-
-project('frr', 'c', version: '10.5.3', license: 'GPL-2.0-or-later', meson_version: '>= 0.63.0')
+project('frr', 'c',
+  version: run_command('sed', '-nE',
+    's/.*AC_INIT.*\[([0-9]+\.[0-9]+\.[0-9]+)(-dev)?\].*/\\1/p',
+    meson.current_source_dir() / 'configure.ac',
+    capture: true,
+    check:true).stdout().strip(),
+  license: 'GPL-2.0-or-later',
+  meson_version: '>= 0.63.0')
 
 srcdir = meson.current_source_dir()
 builddir = meson.current_build_dir()


### PR DESCRIPTION
Add a new meson option to select the FRR version to build and test. Current supported values are '10.5.3', '10.6.0' and 'master'.

As meson wrap files don't support variables, add a wrap file for each version, use the proper one from frr/meson.build.

Run smoke tests with FRR 10.6.0 as well as the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds configurable selection and CI coverage for multiple FRRouting (FRR) versions via Meson.

### Build configuration
- Introduced Meson combo option `frr_version` with choices `default`, `10.6.0`, and `master` (value `default` corresponds to the existing 10.5.3 behavior).

### Subproject / wrap handling
- Added separate wrap files:
  - `subprojects/frr-10.6.0.wrap` — fetches FRR 10.6.0 release archive.
  - `subprojects/frr-master.wrap` — fetches FRR master via shallow git checkout.
- Updated `frr/meson.build` to select the subproject based on `frr_version`:
  - `subproject('frr')` when `frr_version == 'default'`
  - `subproject('frr-' + frr_version)` otherwise
- Rationale (reflected in code): separate wrap files required because Meson wrap files do not support variable substitution.

### Package metadata
- `subprojects/packagefiles/frr/meson.build` now computes the project `version` by extracting the version string from `configure.ac` (using sed) instead of a hardcoded `'10.5.3'`.

### CI
- Extended `.github/workflows/check.yml` matrix with two new jobs that pass `-Dfrr=enabled` and `-Dfrr_version=10.6.0` or `-Dfrr_version=master` to exercise FRR 10.6.0 and master in CI (ubuntu-24.04, gcc-14, buildtype=debugoptimized, sanitize=none).

### Tests
- Smoke tests configured to run for FRR 10.6.0 in addition to the existing default branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->