### PR TITLE
Api check stuff

### DIFF
--- a/api/gr_api.h
+++ b/api/gr_api.h
@@ -156,6 +156,9 @@ const char *gr_api_message_name(uint32_t type);
 		code##_OBJ_SIZE = sizeof(obj)                                                      \
 	}
 #endif
+#ifndef GR_API_INLINE
+#define GR_API_INLINE static inline
+#endif
 
 struct gr_empty { };
 

--- a/devtools/check_api.sh
+++ b/devtools/check_api.sh
@@ -43,6 +43,7 @@ tar -C "$dir/check_api/a" -x --transform='s|.*/||'
 # Exclude gr_api_client_impl.h which isn't a real API header.
 rm -f $dir/check_api/*/gr_api_client_impl.h
 
+cc_cmd="$cc_cmd -Wno-missing-declarations -Wno-missing-prototypes"
 cc_cmd="$cc_cmd -fno-eliminate-unused-debug-types -Werror -O0 -g"
 
 # Compile a dummy binary
@@ -63,6 +64,9 @@ for d in $dir/check_api/*; do
 	obj *e##_(void) {                                                     \\
 		return (void *)0;                                             \\
 	}
+
+#define GR_API_INLINE __attribute__((section(".api_inline")))
+
 EOF
 		basename -a $d/*.h | sed 's/.*/#include <&>/'
 	} |
@@ -76,14 +80,43 @@ printf "Checking for API changes between %s and %s\n" \
 	$(git describe --long --abbrev=8 $prev_revision) \
 	$(git describe --long --abbrev=8 --dirty)
 
+# Check for inline function body changes.
+# GR_API_INLINE functions are placed in a dedicated ELF section so we can
+# compare their disassembly to detect code changes.
+{
+	objdump -t -j .api_inline $dir/check_api/a.bin 2>/dev/null || true
+	objdump -t -j .api_inline $dir/check_api/b.bin 2>/dev/null || true
+} | awk '/F .api_inline/{print $NF}' | sort -u > $dir/check_api/inline_funcs
+
+inline_change=false
+while read -r func; do
+	a=$(objdump -d --disassemble="$func" $dir/check_api/a.bin 2>/dev/null \
+		| sed -n '/^[0-9a-f].*:/{s/^[^:]*://;s/\t[0-9a-f ]*\t/\t/;p}')
+	b=$(objdump -d --disassemble="$func" $dir/check_api/b.bin 2>/dev/null \
+		| sed -n '/^[0-9a-f].*:/{s/^[^:]*://;s/\t[0-9a-f ]*\t/\t/;p}')
+	if [ -z "$a" ] && [ -z "$b" ]; then
+		continue
+	elif [ -z "$a" ]; then
+		echo "inline API function $func: added"
+	elif [ -z "$b" ]; then
+		inline_change=true
+		echo "inline API function $func: removed"
+	elif [ "$a" != "$b" ]; then
+		inline_change=true
+		echo "inline API function $func: code changed"
+	fi
+done < $dir/check_api/inline_funcs
+
+api_version_a=$(sed -nE 's/^#define GR_API_VERSION ([0-9]+).*/\1/p' $dir/check_api/a/*.h)
+api_version_b=$(sed -nE 's/^#define GR_API_VERSION ([0-9]+).*/\1/p' $dir/check_api/b/*.h)
+
 if ! $abidiff --non-reachable-types --drop-private-types --show-bytes \
 	--headers-dir1 $dir/check_api/a --headers-dir2 $dir/check_api/b \
-	$dir/check_api/a.bin $dir/check_api/b.bin >"$dir/abidiff.log" 2>&1
+	$dir/check_api/a.bin $dir/check_api/b.bin >"$dir/abidiff.log" 2>&1 \
+	|| [ "$inline_change" = true ]
 then
 	grep -vE '((Functions|Variables) changes|Unreachable types) summary:' "$dir/abidiff.log"
-	api_version_a=$(sed -nE 's/^#define GR_API_VERSION ([0-9]+).*/\1/p' $dir/check_api/a/*.h)
-	api_version_b=$(sed -nE 's/^#define GR_API_VERSION ([0-9]+).*/\1/p' $dir/check_api/b/*.h)
-	if grep -q '^  \[[DC]\]' "$dir/abidiff.log"; then
+	if grep -q '^  \[[DC]\]' "$dir/abidiff.log" || [ "$inline_change" = true ]; then
 		echo "breaking API changes"
 		if [ "${api_version_a:-0}" -ge "${api_version_b:-0}" ]; then
 			grep -n '#define GR_API_VERSION' "$@"
@@ -93,11 +126,12 @@ then
 	else
 		echo "backward compatible API changes"
 	fi
-	if [ "$api_version_a" = "$api_version_b" ]; then
-		echo "GR_API_VERSION unchanged"
-	else
-		echo "GR_API_VERSION changed from ${api_version_a:-0} to ${api_version_b:-0}"
-	fi
+fi
+
+if [ "$api_version_a" = "$api_version_b" ]; then
+	echo "GR_API_VERSION unchanged"
+else
+	echo "GR_API_VERSION changed from ${api_version_a:-0} to ${api_version_b:-0}"
 fi
 
 touch "$output"

--- a/devtools/gen_api_header.sh
+++ b/devtools/gen_api_header.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Robin Jarry
 
 echo "// SPDX-License-Identifier: BSD-3-Clause"
-echo "// Copyright (c) $(date +Y) Red Hat"
+echo "// Copyright (c) $(date +%Y) Red Hat"
 echo
 echo "#pragma once"
 echo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## API inline function compatibility checking

Extends the API compatibility tooling to detect changes in generated inline wrapper functions by placing them into a dedicated ELF section and comparing their disassembly between revisions.

### Changes

api/gr_api.h
- Adds a conditional macro definition:
  - If GR_API_INLINE is not defined, define it as `#define GR_API_INLINE static inline`.

devtools/check_api.sh
- Compiler command: appends `-Wno-missing-declarations` and `-Wno-missing-prototypes`.
- Injects a GR_API_INLINE definition used during the check: `#define GR_API_INLINE __attribute__((section(".api_inline")))` so generated inline wrapper functions are emitted into the `.api_inline` ELF section.
- After building previous (`a.bin`) and current (`b.bin`) test binaries, extracts symbol names from the `.api_inline` section (using `objdump -t -j .api_inline`) and writes them to `inline_funcs`.
- Introduces `inline_change` variable (initialized false) and logic to set it to true when inline functions are added, removed, or when per-function disassembled instruction streams differ between the two builds.
- Integrates inline changes into the ABI check:
  - The `abidiff` invocation is treated as failed when `inline_change` is true (`if ! abidiff ... || [ "$inline_change" = true ]`).
  - The script treats inline changes as breaking-change triggers when determining whether to emit the `[DC]` diagnostic.
- Moves GR_API_VERSION extraction and the unchanged/changed reporting outside the `abidiff` failure conditional so the version comparison is always printed.

devtools/gen_api_header.sh
- Fixes the date command in the generated header comment from `date +Y` to `date +%Y` to emit the four-digit year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->