### PR TITLE
contributing: clarify multiple licenses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,11 @@ There is a great reference for commit messages in the
 
 IMPORTANT: you must sign-off your work using `git commit --signoff`. Follow the
 [Linux kernel developer's certificate of origin][linux-signoff] for more
-details. All contributions are made under the
-[BSD-3-Clause][https://spdx.org/licenses/BSD-3-Clause.html] license. Please use
-your real name and not a pseudonym. Here is an example:
+details. All contributions are made under the [BSD-3-Clause][BSD-3-Clause]
+license, except for contributions made to the [FRR plugin](/frr) which is
+[GPL-2.0-or-later][GPL-2.0-or-later] licensed.
+
+Please use your real name and not a pseudonym. Here is an example:
 
     Signed-off-by: Robin Jarry <rjarry@redhat.com>
 
@@ -383,3 +385,5 @@ is available in the repository.
 [linux-coding-style]: https://www.kernel.org/doc/html/v5.19-rc8/process/coding-style.html
 [linux-review]: https://www.kernel.org/doc/html/latest/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes
 [linux-signoff]: https://www.kernel.org/doc/html/latest/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin
+[BSD-3-Clause]: https://spdx.org/licenses/BSD-3-Clause
+[GPL-2.0-or-later]: https://spdx.org/licenses/GPL-2.0-or-later

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ that hardens to fill gaps between tiles.
 `grout` is a DPDK based network processing application. It uses the [rte_graph]
 library for data path processing.
 
-Its main purpose is to simulate a network function or a physical router for
-testing/replicating real (usually closed source) VNF/CNF behavior with an
+Its main purpose is to provide an example of a network function or a physical
+router, replicating real (usually closed source) VNF/CNF behavior with an
 opensource tool.
 
 It comes with a client library to configure it over a standard UNIX socket and
@@ -22,19 +22,25 @@ also in scripts one command at a time, or by batches.
 
 * [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)
 * [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html) — only
-  for the `frr` plugin.
+  for the [FRR dplane plugin](/frr) which is linked with zebra.
 
 ## Features
 
 * IPv4 forwarding
 * IPv6 forwarding
+* IPv6 router advertisements
 * Multiple VRF domains
 * VLAN sub interfaces
+* L2 bridging
+* VXLAN tunnels
+* Bond/LACP interfaces
 * IP in IP tunnels
 * SRv6
+* DHCP client
 * Static IPv4 DNAT
 * Dynamic IPv4 SNAT (with connection tracking)
-* FRR synchronization via a [dplane plugin](/frr)
+* FRR synchronization via a [zebra dplane plugin](/frr) which configures grout
+  via the UNIX socket API.
 
 ## Quickstart
 


### PR DESCRIPTION
The project is BSD-3-Clause licensed but the FRR zebra dplane plugin must be GPL-2.0-or-later. This is not a choice: since the plugin is dlopen()ed by zebra at runtime, it executes in the same memory space as GPL licensed code, which requires it to be GPL licensed as well. Note that merely including headers from a GPL project does not propagate the license.

The rest of grout is not affected. The dplane plugin does not link against any grout library; it only includes public API headers and communicates with the daemon over a UNIX socket, neither of which propagate the GPL.

Update the sign-off section to mention both licenses and fix a broken markdown link reference.

Reported-by: Morten Brørup <mb@smartsharesystems.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

CONTRIBUTING.md adds explicit dual-license guidance: the main codebase uses the BSD-3-Clause license, while contributions to the FRR plugin are governed by GPL-2.0-or-later. License references use SPDX links to the canonical license pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->