### PR TITLE
ci: add ppc64le cross-compilation test

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -200,6 +200,65 @@ jobs:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
 
+  build-cross-ppc64le:
+    if: ${{ github.actor != 'grout-bot' }}
+    permissions:
+      actions: write
+    runs-on: ubuntu-24.04
+    container: debian:stable
+    env:
+      MESON_EXTRA_OPTS: --cross-file=devtools/cross/ppc64le.ini
+      DEBIAN_FRONTEND: noninteractive
+      NEEDRESTART_MODE: l
+    steps:
+      - name: install system dependencies
+        run: |
+          set -xe
+          dpkg --add-architecture ppc64el
+          apt update -qy
+          apt install -qy --no-install-recommends \
+            make gcc ccache git meson scdoc python3-pyelftools ca-certificates pkg-config \
+            crossbuild-essential-ppc64el libcmocka-dev:ppc64el libedit-dev:ppc64el \
+            libevent-dev:ppc64el libmnl-dev:ppc64el libnuma-dev:ppc64el
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # force fetch all history
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - run: git config --global --add safe.directory $PWD
+      - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
+      - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
+      - uses: actions/cache/restore@v4
+        id: cache
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-ppc64le
+      - run: ccache -z
+      - run: git rebase -x .github/workflows/check.sh "HEAD~${{ github.event.pull_request.commits }}"
+        if: ${{ github.event.pull_request.commits }}
+      - run: .github/workflows/check.sh
+        if: ${{ ! github.event.pull_request.commits }}
+      - run: ccache -sv
+      - name: delete old cache
+        if: ${{ ! github.event.pull_request.commits }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.actions.deleteActionsCacheByKey({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                key: "${{ steps.cache.outputs.cache-primary-key }}"
+              });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+      - uses: actions/cache/save@v4
+        if: ${{ ! github.event.pull_request.commits }}
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
   lint:
     if: ${{ github.actor != 'grout-bot' }}
     runs-on: ubuntu-24.04

--- a/devtools/cross/ppc64le.ini
+++ b/devtools/cross/ppc64le.ini
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+
+[binaries]
+c = ['ccache', 'powerpc64le-linux-gnu-gcc']
+cpp = ['ccache', 'powerpc64le-linux-gnu-g++']
+ar = 'powerpc64le-linux-gnu-ar'
+strip = 'powerpc64le-linux-gnu-strip'
+pkg-config = '/usr/bin/pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'ppc64'
+cpu = 'power8'
+endian = 'little'
+
+[properties]
+platform = 'generic'
+pkg_config_libdir = '/usr/lib/powerpc64le-linux-gnu/pkgconfig'
+
+[dpdk:project options]
+platform = 'generic'
+enable_drivers = 'net/null'


### PR DESCRIPTION
Add a meson cross-file for ppc64le and a GitHub Actions job to cross-compile on Debian stable, mirroring the existing aarch64 job. This ensures the codebase builds cleanly with powerpc64le-linux-gnu-gcc which pulls in AltiVec headers.

The build will fail for now until #600 is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Added a new GitHub Actions job `build-cross-ppc64le` that cross-compiles the project for powerpc64le target architecture using Debian stable container on ubuntu-24.04. The job installs ppc64le cross-compilation dependencies via `dpkg --add-architecture ppc64el` and `crossbuild-essential-ppc64el`, along with target-specific development libraries (`libcmocka-dev:ppc64el`, `libedit-dev:ppc64el`, `libevent-dev:ppc64el`, `libmnl-dev:ppc64el`, `libnuma-dev:ppc64el`). The job structure mirrors the existing aarch64 cross-compilation job, including ccache integration and conditional rebasing logic.

Added `devtools/cross/ppc64le.ini` Meson cross-file that configures:
- Cross-compiler toolchain using `powerpc64le-linux-gnu-gcc/g++` wrapped with ccache
- Target machine as linux with ppc64 CPU family, power8 CPU, and little-endian byte order
- Appropriate `pkg-config` path for the target architecture (`/usr/lib/powerpc64le-linux-gnu/pkgconfig`)
- DPDK project options forced to generic platform with only the `net/null` driver enabled

The addition enables validation that the codebase builds with powerpc64le-linux-gnu-gcc, which brings in AltiVec headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->