### PR TITLE
Fix link local bind

### DIFF
--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -171,14 +171,10 @@ static void iface_cp_poll(evutil_socket_t, short reason, void *ev_iface) {
 		}
 
 		e = eth_input_mbuf_data(mbuf);
-		e->iface = get_vrf_iface(iface->vrf_id);
-		if (e->iface == NULL) {
-			LOG(ERR,
-			    "cp_poll: no VRF iface for vrf_id %u on %s",
-			    iface->vrf_id,
-			    iface->name);
-			goto err;
-		}
+		// Keep the original iface so the link-local scope (iface->id) is
+		// preserved for fib6_lookup. The VRF context comes from
+		// iface->vrf_id either way.
+		e->iface = iface;
 		e->domain = ETH_DOMAIN_LOOPBACK;
 
 		if (post_to_stack(loopback_get_control_id(), mbuf) < 0) {

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -25,10 +25,12 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <linux/ethtool.h>
 #include <linux/if_tun.h>
 #include <linux/sockios.h>
 #include <net/if.h>
+#include <stdio.h>
 #include <sys/ioctl.h>
 
 LOG_TYPE("ctlplane");
@@ -307,6 +309,21 @@ static void cp_create(struct iface *iface) {
 	snprintf(ifalias, IFALIASZ, "Grout control plane interface");
 	netlink_set_ifalias(iface->cp_id, ifalias);
 	netlink_link_set_admin_state(iface->cp_id, false, true);
+
+	// Keep IPv6 addresses assigned to the tap across admin-down events.
+	// When the datapath port flaps (e.g. a peer tap being moved to another
+	// netns), grout brings this tap down; with the default sysctl value of
+	// 0, the kernel would flush all IPv6 addresses, and userspace (FRR)
+	// would then fail to bind() sockets on those addresses.
+	char path[PATH_MAX];
+	snprintf(path, sizeof(path), "/proc/sys/net/ipv6/conf/%s/keep_addr_on_down", iface->name);
+	FILE *f = fopen(path, "w");
+	if (f != NULL) {
+		fputs("1", f);
+		fclose(f);
+	} else {
+		LOG(WARNING, "fopen(%s): %s", path, strerror(errno));
+	}
 
 	iface->cp_ev = event_new(
 		ev_base,

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -198,6 +198,23 @@ move_to_netns() {
 		fi
 		sleep 0.2
 	done
+
+	# The datapath tap follows the "x-<grout_port>" naming convention;
+	# strip the prefix to derive the control-plane netdev name. Grout
+	# brings the CP tap UP asynchronously on GR_EVENT_IFACE_STATUS_UP
+	# (ctlplane.c), so we must wait before tests inject traffic that
+	# would need CP delivery, otherwise writes to the tap fail with EIO.
+	local grout_iface="${iface#x-}"
+	if [ "$grout_iface" != "$iface" ]; then
+		SECONDS=0
+		while ! ip -o link show "$grout_iface" 2>/dev/null \
+				| grep -qw 'state UP'; do
+			if [ "$SECONDS" -gt 5 ]; then
+				fail "grout CP tap $grout_iface was not UP after 5 seconds"
+			fi
+			sleep 0.2
+		done
+	fi
 }
 
 tap_counter=0

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -172,6 +172,13 @@ tmux_new_window() {
 netns_add() {
 	local ns="$1"
 	ip netns add "$ns"
+	# Skip IPv6 DAD and ignore kernel RA processing in test netns: grout
+	# does not perform DAD on its own addresses, and RA-learned default
+	# routes would race with the explicit routes set up by each test.
+	ip netns exec "$ns" sysctl -wq net.ipv6.conf.all.accept_dad=0
+	ip netns exec "$ns" sysctl -wq net.ipv6.conf.default.accept_dad=0
+	ip netns exec "$ns" sysctl -wq net.ipv6.conf.all.accept_ra=0
+	ip netns exec "$ns" sysctl -wq net.ipv6.conf.default.accept_ra=0
 	cat >> $tmp/cleanup <<EOF
 ip netns pids "$ns" | xargs -r kill -TERM 2>/dev/null || true
 sleep 0.5

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -302,6 +302,13 @@ EOF
 
 	if [ -n "$namespace" ]; then
 		ip netns add "$namespace"
+		# Match netns_add's defaults: skip IPv6 DAD and ignore kernel RA
+		# processing so FRR peer netns behave consistently with the rest
+		# of the smoke suite.
+		ip netns exec "$namespace" sysctl -wq net.ipv6.conf.all.accept_dad=0
+		ip netns exec "$namespace" sysctl -wq net.ipv6.conf.default.accept_dad=0
+		ip netns exec "$namespace" sysctl -wq net.ipv6.conf.all.accept_ra=0
+		ip netns exec "$namespace" sysctl -wq net.ipv6.conf.default.accept_ra=0
 	fi
 
 	# cleanup -- kill the subshell children (tail, sed, awk)

--- a/smoke/bfd6_frr_test.sh
+++ b/smoke/bfd6_frr_test.sh
@@ -77,8 +77,6 @@ router bgp 64512
 exit
 EOF
 
-sleep 3  # wait for DAD
-
 # Wait for BFD session to come up on the grout side
 attempts=0
 while ! vtysh -c "show bfd peers json" | jq -e '.[] | select(.status == "up")'; do

--- a/smoke/bfd6_frr_test.sh
+++ b/smoke/bfd6_frr_test.sh
@@ -102,8 +102,8 @@ while ! vtysh -N bfd-peer -c "show bfd peers json" | jq -e '.[] | select(.status
 done
 
 # Verify BFD counters are non-zero (packets flowing)
-input=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-input"')
-output=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-output"')
+input=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-input" // 0')
+output=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-output" // 0')
 
 if [ "$input" -eq 0 ] || [ "$output" -eq 0 ]; then
 	vtysh -c "show bfd peers counters"

--- a/smoke/bfd_frr_test.sh
+++ b/smoke/bfd_frr_test.sh
@@ -98,8 +98,8 @@ while ! vtysh -N bfd-peer -c "show bfd peers json" | jq -e '.[] | select(.status
 done
 
 # Verify BFD counters are non-zero (packets flowing)
-input=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-input"')
-output=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-output"')
+input=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-input" // 0')
+output=$(vtysh -c "show bfd peers counters json" | jq '.[0]."control-packet-output" // 0')
 
 if [ "$input" -eq 0 ] || [ "$output" -eq 0 ]; then
 	vtysh -c "show bfd peers counters"

--- a/smoke/bond_active_backup_test.sh
+++ b/smoke/bond_active_backup_test.sh
@@ -6,6 +6,10 @@ wait_member_active() {
 	local iface=$1
 	local attempts=0
 	while [ "$attempts" -lt 20 ]; do
+		# Generate traffic so the Linux bridge learns grout's MAC on the
+		# newly active bond member: the reply comes back via that member,
+		# which is exactly what the FDB should reflect.
+		ip netns exec n0 ping -c1 -W 0.2 -n 172.16.0.1 >/dev/null 2>&1 || true
 		if bridge -n n0 fdb show br br0 brport "$iface" state reachable | grep -F "$mac"; then
 			return 0
 		fi

--- a/smoke/ip6_builtin_icmp_test.sh
+++ b/smoke/ip6_builtin_icmp_test.sh
@@ -18,8 +18,6 @@ for n in 0 1; do
 	ip -n $ns route add fd00:ba4::/62 via fd00:ba4:$n::1 dev $p
 done
 
-sleep 3  # wait for DAD
-
 grcli ping fd00:ba4:0::2 count 10 delay 100
 grcli ping fd00:ba4:1::2 count 3 delay 10
 

--- a/smoke/ip6_forward_frr_test.sh
+++ b/smoke/ip6_forward_frr_test.sh
@@ -26,8 +26,6 @@ set_ip_address p2 fd00:ba4:2::1/64
 set_ip_route fd00:f00:1::/64 fd00:ba4:1::2
 set_ip_route fd00:f00:2::/64 p2
 
-sleep 3  # wait for DAD
-
 ip netns exec n1 ping6 -i0.01 -c3 -n $(llocal_addr p1)
 ip netns exec n2 ping6 -i0.01 -c3 -n $(llocal_addr p2)
 ip netns exec n1 ping6 -i0.01 -c3 -n fd00:f00:2::2

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -26,8 +26,6 @@ for n in 1 2; do
 	ip -n $ns route add default via fd00:ba4:$n::1
 done
 
-sleep 3  # wait for DAD
-
 ip netns exec n1 ping6 -i0.01 -c3 -n $(llocal_addr p1)
 ip netns exec n2 ping6 -i0.01 -c3 -n $(llocal_addr p2)
 ip netns exec n1 ping6 -i0.01 -c3 -n fd00:f00:2::2

--- a/smoke/ip6_rs_ra_test.sh
+++ b/smoke/ip6_rs_ra_test.sh
@@ -13,6 +13,4 @@ netns_add n1
 move_to_netns x-p1 n1
 ip -n n1 addr add fd00:ba4:1::2/64 dev x-p1
 
-sleep 3  # wait for DAD
-
 ip netns exec n1 rdisc6 -n x-p1

--- a/smoke/ip6_same_peer_test.sh
+++ b/smoke/ip6_same_peer_test.sh
@@ -19,8 +19,6 @@ for n in 1 2; do
 	ip -n $ns route add default via fd00:ba4:$n::1
 done
 
-sleep 3  # wait for DAD
-
 ip netns exec n1 ping6 -i0.01 -c3 -n $(llocal_addr p1)
 ip netns exec n2 ping6 -i0.01 -c3 -n $(llocal_addr p2)
 ip netns exec n1 ping6 -i0.01 -c3 -n $(llocal_addr p2) && fail "Unexpected answer from foreign link local address"

--- a/smoke/ip_forward_ip6nh_frr_test.sh
+++ b/smoke/ip_forward_ip6nh_frr_test.sh
@@ -22,8 +22,6 @@ for n in 0 1; do
 	set_ip_route 16.$n.0.0/16 "$ll p$n"
 done
 
-sleep 3  # wait for DAD
-
 for n in 0 1; do
 	ns=n$n
 	ip netns exec $ns ping -i0.01 -c3 -n 16.$((n^1)).0.1

--- a/smoke/ip_forward_ip6nh_test.sh
+++ b/smoke/ip_forward_ip6nh_test.sh
@@ -20,8 +20,6 @@ for n in 0 1; do
 	grcli route add 16.$n.0.0/16 via id $((n+42))
 done
 
-sleep 3  # wait for DAD
-
 for n in 0 1; do
 	ns=n$n
 	ip netns exec $ns ping -i0.01 -c3 -n 16.$((n^1)).0.1

--- a/smoke/so_bindtodevice_test.sh
+++ b/smoke/so_bindtodevice_test.sh
@@ -57,8 +57,6 @@ ip -n peer1 link set x-p1.43 up
 ip -n peer1 addr add 172.19.0.2/24 dev x-p1.43
 ip -n peer1 addr add fd03::2/64    dev x-p1.43
 
-sleep 3  # DAD + neighbor discovery
-
 for ns in peer0 peer1; do
 	ip netns exec $ns socat UDP4-LISTEN:9001,fork EXEC:'/bin/cat' &
 	ip netns exec $ns socat UDP6-LISTEN:9000,fork EXEC:'/bin/cat' &

--- a/smoke/so_bindtodevice_test.sh
+++ b/smoke/so_bindtodevice_test.sh
@@ -25,8 +25,8 @@ grcli interface add vrf gr-vrf1
 
 port_add p0
 port_add p1 vrf gr-vrf1
-grcli interface add vlan p0.42 parent p0  vlan_id 42
-grcli interface add vlan p1.43 parent p1  vlan_id 43 vrf gr-vrf1
+grcli interface add vlan p0.42 parent p0 vlan_id 42
+grcli interface add vlan p1.43 parent p1 vlan_id 43 vrf gr-vrf1
 
 grcli address add 172.16.0.1/24 iface p0
 grcli address add fd00::1/64    iface p0

--- a/smoke/so_bindtodevice_test.sh
+++ b/smoke/so_bindtodevice_test.sh
@@ -125,3 +125,23 @@ run_scenario "bind=gr-vrf1/vlan" 172.19.0.2 fd03::2 ",so-bindtodevice=gr-vrf1" 1
 
 # 7. no bind (baseline)
 run_scenario "nobind" 172.16.0.2 fd00::2 ""
+
+# 8. IPv6 link-local on port TAP. grout pushes fe80::xxx/128 (host route)
+# rather than /64; this scenario verifies the daemon can still reach a
+# link-local peer when the egress interface is provided via socat's
+# scope_id syntax (peer_ll%p0). FRR daemons (ospf6d, etc.) do the same
+# via IPV6_PKTINFO ipi6_ifindex.
+peer0_ll=$(ip -n peer0 -6 addr show dev x-p0 | sed -nE 's#.*inet6 (fe80:[^/]+).*#\1#p' | head -1)
+grout0_ll=$(llocal_addr p0)
+[ -z "$peer0_ll" ] && fail "peer0 link-local not found on x-p0"
+[ -z "$grout0_ll" ] && fail "grout link-local not found on p0"
+for proto_port in "UDP6:9000" "TCP6:9002"; do
+	proto=${proto_port%:*}
+	port=${proto_port#*:}
+	reply=$(echo "ping" | timeout 3 socat - \
+		"${proto}:[${peer0_ll}%p0]:${port},so-bindtodevice=p0,bind=[${grout0_ll}]" \
+		2>/dev/null) || true
+	if [ "$reply" != "ping" ]; then
+		fail "ll-bind=p0/${proto}: reply not received"
+	fi
+done

--- a/smoke/so_listen_test.sh
+++ b/smoke/so_listen_test.sh
@@ -56,8 +56,6 @@ ip -n peer1 link set x-p1.43 up
 ip -n peer1 addr add 172.19.0.2/24 dev x-p1.43
 ip -n peer1 addr add fd03::2/64    dev x-p1.43
 
-sleep 3  # DAD + neighbor discovery
-
 saved_tcp=$(sysctl -n net.ipv4.tcp_l3mdev_accept)
 saved_udp=$(sysctl -n net.ipv4.udp_l3mdev_accept)
 cat >> $tmp/cleanup <<EOF

--- a/smoke/so_listen_test.sh
+++ b/smoke/so_listen_test.sh
@@ -174,3 +174,26 @@ sysctl -qw net.ipv4.tcp_l3mdev_accept=1
 sysctl -qw net.ipv4.udp_l3mdev_accept=1
 run_listen "nobind/l3mdev=1/vrf" "" \
 	peer1 172.17.0.1 fd01::1 accept tcp-only
+
+# 9. IPv6 link-local: server side. grout pushes fe80::xxx/128 (host
+# route) rather than /64; this scenario verifies a peer can still
+# connect to a link-local listener on the TAP, scoping the destination
+# via x-p0 in its own netns. Mirrors so_bindtodevice_test scenario 8.
+grout0_ll=$(llocal_addr p0)
+[ -z "$grout0_ll" ] && fail "grout link-local not found on p0"
+socat "UDP6-LISTEN:9501,so-bindtodevice=p0,bind=[${grout0_ll}],fork"           EXEC:'/bin/cat' &
+ll_u6=$!
+socat "TCP6-LISTEN:9503,so-bindtodevice=p0,bind=[${grout0_ll}],fork,reuseaddr" EXEC:'/bin/cat' &
+ll_t6=$!
+sleep 0.5
+for proto_port in "UDP6:9501" "TCP6:9503"; do
+	proto=${proto_port%:*}
+	port=${proto_port#*:}
+	reply=$(echo "ping" | ip netns exec peer0 timeout 3 \
+		socat - "${proto}:[${grout0_ll}%x-p0]:${port}" 2>/dev/null) || true
+	if [ "$reply" != "ping" ]; then
+		fail "listen=p0/ll/${proto}: peer did not get reply"
+	fi
+done
+kill "$ll_u6" "$ll_t6" 2>/dev/null || true
+wait "$ll_u6" "$ll_t6" 2>/dev/null || true

--- a/smoke/srv6_frr_test.sh
+++ b/smoke/srv6_frr_test.sh
@@ -19,8 +19,6 @@ ip -n n1 addr add fd00:102::2/32 dev x-p1
 set_ip_address p0 192.168.61.1/24
 set_ip_address p1 fd00:102::1/32
 
-sleep 3
-
 #
 # network layout:
 #  (client) p0(netns) <--> p0 <grout> p1 <--->  p1(netns) (public: 192.168.60.1/24 on p0)


### PR DESCRIPTION
Some missing fixes of PR569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## modules/infra/control/ctlplane.c
- iface_cp_poll(): in the NOARP control-plane TAP unicast loopback reinjection path, removed the VRF-specific lookup/get_vrf_iface() and its NULL/error abort. The mbuf event now uses e->iface = iface directly, sets e->domain = ETH_DOMAIN_LOOPBACK, and calls post_to_stack(...) as before.
- cp_create(): attempts to write "1" to /proc/sys/net/ipv6/conf/<iface->name>/keep_addr_on_down via fopen/fprintf to retain IPv6 addresses across admin-down; on fopen failure a WARNING is logged and setup continues.

## smoke scripts — jq fallback for BFD counters and removed fixed sleeps
- smoke/bfd_frr_test.sh, smoke/bfd6_frr_test.sh: jq extraction for BFD counters now supplies numeric defaults using `... // 0` for control-packet-input and control-packet-output so subsequent `-eq 0` comparisons operate on defined numbers; bfd6_frr_test.sh retains its BFD polling logic.
- Multiple IPv6-related smoke tests removed unconditional `sleep 3` waits that were used to "wait for DAD": smoke/so_bindtodevice_test.sh, smoke/so_listen_test.sh, smoke/ip6_builtin_icmp_test.sh, smoke/ip6_forward_frr_test.sh, smoke/ip6_forward_test.sh, smoke/ip6_rs_ra_test.sh, smoke/ip6_same_peer_test.sh, smoke/ip_forward_ip6nh_frr_test.sh, smoke/ip_forward_ip6nh_test.sh, smoke/srv6_frr_test.sh.

## smoke/so_bindtodevice_test.sh
- Fixed extraneous double-space in two `grcli interface add vlan` commands.
- Added scenario 8:
  - Extract peer0 link-local into peer0_ll and daemon link-local for p0 via `llocal_addr p0`; fail if either is absent.
  - Perform UDP6:9000 and TCP6:9002 echo attempts to `${peer0_ll}%p0` using `so-bindtodevice=p0` and explicit local bind `bind=[${grout0_ll}]`, fail if expected "ping" reply not received.

## smoke/so_listen_test.sh
- Added scenario 9:
  - Discover p0 link-local via `llocal_addr p0`.
  - Start UDP6 listener on 9501 and TCP6 listener on 9503 bound with `so-bindtodevice=p0` and `bind=[<link-local>]`.
  - Probe from peer0 to `[<link-local>%x-p0]` for both ports, verify responses contain "ping", then kill/wait for listener processes.

## smoke/_init.sh and smoke/_init_frr.sh
- smoke/_init.sh:
  - netns_add(): after creating a netns, set `net.ipv6.conf.{all,default}.accept_dad=0` and `net.ipv6.conf.{all,default}.accept_ra=0` inside the namespace via `ip netns exec ... sysctl -wq ...`.
  - move_to_netns(): when moved interface name matches `x-<...>`, derive grout_iface by stripping `x-` and poll `ip -o link show "$grout_iface"` until `state UP`, timeout 5s and fail if not UP.
- smoke/_init_frr.sh:
  - start_frr(namespace): when namespace is supplied, run sysctl writes inside that namespace to set `net.ipv6.conf.*.accept_dad=0` and `net.ipv6.conf.*.accept_ra=0` for both `all` and `default`.

## smoke/bond_active_backup_test.sh
- wait_member_active(): send a single ICMP probe from netns n0 to 172.16.0.1 (`ip netns exec n0 ping ... || true`) on each polling iteration before checking "bridge ... fdb show ... state reachable", suppressing ping errors so polling continues.

## Miscellaneous
- Removed a small number of fixed 3-second sleeps used across multiple IPv6 test scripts (see list above).
- No exported/public C or shell function signatures were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->