### PR TITLE
Simplify FRR build and rework CI matrix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,46 +28,34 @@ jobs:
           - compiler: gcc-13
             sanitize: none
             buildtype: debugoptimized
-            os: ubuntu-24.04
             extra_opts: -Dfrr=enabled
             rebase: true
           - compiler: gcc-14
             sanitize: address
             buildtype: debug
-            os: ubuntu-24.04
             extra_opts: -Dfrr=enabled
             rebase: false
           - compiler: gcc-14
             sanitize: none
             buildtype: debugoptimized
-            os: ubuntu-24.04
             extra_opts: -Dfrr=enabled -Dfrr_version=10.6
             rebase: false
           - compiler: gcc-14
             sanitize: none
             buildtype: debugoptimized
-            os: ubuntu-24.04
             extra_opts: -Dfrr=enabled -Dfrr_version=master
-            rebase: false
-          - compiler: clang-15
-            sanitize: none
-            buildtype: debugoptimized
-            os: ubuntu-22.04
-            extra_opts:
             rebase: false
           - compiler: clang-16
             sanitize: none
             buildtype: debugoptimized
-            os: ubuntu-24.04
             extra_opts:
             rebase: false
           - compiler: clang-18
             sanitize: none
             buildtype: debugoptimized
-            os: ubuntu-24.04
             extra_opts:
             rebase: false
-    runs-on: ${{ matrix.conf.os }}
+    runs-on: ubuntu-24.04
     env:
       SANITIZE: ${{ matrix.conf.sanitize }}
       BUILDTYPE: ${{ matrix.conf.buildtype }}
@@ -97,10 +85,6 @@ jobs:
               $(lsb_release -s -c) frr-stable" | sudo tee /etc/apt/sources.list.d/frr.list > /dev/null
             sudo apt-get update -qy
             sudo apt-get install -qy librtr-dev libyang2-dev libyang2-tools
-          fi
-          if printf '%s\n0.63.0\n' "$(meson --version)" | sort -V -C ; then
-            sudo apt install -y python3-pip
-            pip3 install --user -U meson~=0.63.0
           fi
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
             sanitize: none
             buildtype: debugoptimized
             os: ubuntu-24.04
-            extra_opts: -Dfrr=enabled -Dfrr_version=10.6.0
+            extra_opts: -Dfrr=enabled -Dfrr_version=10.6
             rebase: false
           - compiler: gcc-14
             sanitize: none

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,39 +26,24 @@ jobs:
       matrix:
         conf:
           - compiler: gcc-13
-            sanitize: none
-            buildtype: debugoptimized
             extra_opts: -Dfrr=enabled
             rebase: true
           - compiler: gcc-14
-            sanitize: address
-            buildtype: debug
             extra_opts: -Dfrr=enabled
-            rebase: false
+            asan: true
+            debug: true
           - compiler: gcc-14
-            sanitize: none
-            buildtype: debugoptimized
             extra_opts: -Dfrr=enabled -Dfrr_version=10.6
-            rebase: false
           - compiler: gcc-14
-            sanitize: none
-            buildtype: debugoptimized
             extra_opts: -Dfrr=enabled -Dfrr_version=master
-            rebase: false
           - compiler: clang-16
-            sanitize: none
-            buildtype: debugoptimized
             extra_opts:
-            rebase: false
           - compiler: clang-18
-            sanitize: none
-            buildtype: debugoptimized
             extra_opts:
-            rebase: false
     runs-on: ubuntu-24.04
     env:
-      SANITIZE: ${{ matrix.conf.sanitize }}
-      BUILDTYPE: ${{ matrix.conf.buildtype }}
+      SANITIZE: ${{ case(matrix.conf.asan || false, 'address', 'none') }}
+      BUILDTYPE: ${{ case(matrix.conf.debug || false, 'debug', 'debugoptimized') }}
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: l
       CC: ccache ${{ matrix.conf.compiler }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,20 +26,20 @@ jobs:
       matrix:
         conf:
           - compiler: gcc-13
-            extra_opts: -Dfrr=enabled
+            frr: '10.5'
             rebase: true
           - compiler: gcc-14
-            extra_opts: -Dfrr=enabled
+            frr: '10.5'
             asan: true
             debug: true
           - compiler: gcc-14
-            extra_opts: -Dfrr=enabled -Dfrr_version=10.6
+            frr: '10.6'
           - compiler: gcc-14
-            extra_opts: -Dfrr=enabled -Dfrr_version=master
+            frr: 'master'
           - compiler: clang-16
-            extra_opts:
+            frr: '10.5'
           - compiler: clang-18
-            extra_opts:
+            frr: '10.5'
     runs-on: ubuntu-24.04
     env:
       SANITIZE: ${{ case(matrix.conf.asan || false, 'address', 'none') }}
@@ -47,11 +47,13 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
       NEEDRESTART_MODE: l
       CC: ccache ${{ matrix.conf.compiler }}
-      MESON_EXTRA_OPTS: -Ddpdk:cpu_instruction_set=generic ${{ matrix.conf.extra_opts }}
+      FRR: ${{ matrix.conf.frr }}
+      MESON_EXTRA_OPTS: -Ddpdk:cpu_instruction_set=generic
     steps:
       - name: install system dependencies
         run: |
           set -xe
+          # grout dependencies
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
             make gcc gdb ccache ninja-build meson git scdoc \
@@ -60,17 +62,15 @@ jobs:
             socat tcpdump traceroute graphviz iproute2 iputils-ping ndisc6 jq \
             dnsmasq systemd-coredump abigail-tools \
             "linux-modules-extra-$(uname -r)"
-          if echo $MESON_EXTRA_OPTS | grep -q frr=enabled ; then
-            sudo apt-get install -qy --no-install-recommends \
-              libjson-c-dev libelf-dev libprotobuf-c-dev protobuf-c-compiler \
-              libreadline-dev libcap-dev
-            sudo mkdir -p /etc/apt/keyrings
-            sudo curl -s -o /etc/apt/keyrings/frrouting.gpg https://deb.frrouting.org/frr/keys.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/frrouting.gpg] https://deb.frrouting.org/frr \
-              $(lsb_release -s -c) frr-stable" | sudo tee /etc/apt/sources.list.d/frr.list > /dev/null
-            sudo apt-get update -qy
-            sudo apt-get install -qy librtr-dev libyang2-dev libyang2-tools
-          fi
+          # FRR dependencies
+          sudo mkdir -p /etc/apt/keyrings
+          sudo curl -s -o /etc/apt/keyrings/frrouting.gpg https://deb.frrouting.org/frr/keys.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/frrouting.gpg] https://deb.frrouting.org/frr \
+            $(lsb_release -s -c) frr-stable" | sudo tee /etc/apt/sources.list.d/frr.list > /dev/null
+          sudo apt-get update -qy
+          sudo apt-get install -qy --no-install-recommends \
+            libjson-c-dev libelf-dev libprotobuf-c-dev protobuf-c-compiler \
+            libreadline-dev libcap-dev librtr-dev libyang2-dev libyang2-tools
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -127,9 +127,13 @@ jobs:
           dpkg --add-architecture arm64
           apt update -qy
           apt install -qy --no-install-recommends \
-            make gcc ccache git meson scdoc python3-pyelftools ca-certificates pkg-config \
-            crossbuild-essential-arm64 libcmocka-dev:arm64 libedit-dev:arm64 \
-            libevent-dev:arm64 libmnl-dev:arm64 libnuma-dev:arm64
+            make gcc ccache git meson scdoc python3-pyelftools python3-dev \
+            ca-certificates pkg-config autoconf automake bison flex patch \
+            libyang3-tools libtool libelf-dev crossbuild-essential-arm64 \
+            libcmocka-dev:arm64 libedit-dev:arm64 libevent-dev:arm64 \
+            libmnl-dev:arm64 libnuma-dev:arm64 libjson-c-dev:arm64 \
+            libprotobuf-c-dev:arm64 protobuf-c-compiler libreadline-dev:arm64 \
+            libcap-dev:arm64 librtr-dev:arm64 libyang-dev:arm64
       - uses: actions/checkout@v4
         with:
           persist-credentials: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,11 @@ jobs:
           tags: ${{ steps.meta-grout.outputs.tags }}
           labels: ${{ steps.meta-grout.outputs.labels }}
           push: true
-      - run: sed -n 's/^revision = /version=/p' subprojects/frr.wrap >> $GITHUB_OUTPUT
+      - run: |
+          set -xe
+          apt-get update -qy
+          apt-get install -qy --no-install-recommends rpm
+          rpm -qp --queryformat '%{VERSION}\n' frr.*.rpm | tee $GITHUB_OUTPUT
         id: frr-version
       - uses: docker/metadata-action@v5
         name: Extract metadata for the Docker image

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -102,6 +102,7 @@ install: $(BUILDDIR)/build.ninja
 
 meson_opts = --buildtype=$(BUILDTYPE) --werror --warnlevel=2
 meson_opts += -Db_sanitize=$(SANITIZE) -Db_coverage=$(COVERAGE)
+meson_opts += -Dfrr_version=$(FRR)
 meson_opts += $(MESON_EXTRA_OPTS)
 
 $(BUILDDIR)/build.ninja:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,7 @@ BUILDDIR ?= build
 BUILDTYPE ?= debugoptimized
 SANITIZE ?= none
 COVERAGE ?= false
+FRR ?= $(shell sed -En "s/.*'frr_version'.*value: '([^']+)'.*/\\1/p" meson_options.txt)
 V ?= 0
 ifeq ($V,1)
 ninja_opts = --verbose
@@ -142,13 +143,13 @@ rpm:
 		mv -vf ~/rpmbuild/RPMS/$$arch/grout-frr-debuginfo-$$version.$$arch.rpm grout-frr-debuginfo.$$arch.rpm; \
 	fi
 
-frr_version = $(shell sed -nE 's/^source_filename = frr-(.+)\.tar\.gz$$/\1/p' subprojects/frr.wrap)
-frr_hash = $(shell sed -nE 's/^source_hash = //p' subprojects/frr.wrap)
+frr_version = $(shell sed -nE 's/^source_filename = frr-(.+)\.tar\.gz$$/\1/p' subprojects/frr-$(FRR).wrap)
+frr_hash = $(shell sed -nE 's/^source_hash = //p' subprojects/frr-$(FRR).wrap)
 frr_archive = subprojects/packagecache/frr-$(frr_version).tar.gz
 
 .PHONY: frr-rpm
 frr-rpm:
-	meson subprojects download frr
+	meson subprojects download frr-$(FRR)
 	echo '$(frr_hash)  $(frr_archive)' | sha256sum -c
 	install -Dt ~/rpmbuild/SOURCES $(frr_archive)
 	rpmbuild -bb -D'version $(frr_version)' -D 'release 1$(rpmdist).grout' rpm/frr.spec

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -26,6 +26,7 @@ frr_ver = frr_version.split('.')
 frr_ver_num = frr_ver[0].to_int() * 16777216 + frr_ver[1].to_int() * 256 + frr_ver[2].to_int()
 frr_c_args = [
   '-DCURRENT_FRR_VERSION=' + frr_ver_num.to_string(),
+  '-Wno-constant-logical-operand',
 ]
 
 frr_plugin = shared_module(

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Copyright (c) 2025 Maxime Leroy, Free Mobile
+
 frr_opt = get_option('frr')
 frr_version = get_option('frr_version')
 
@@ -7,15 +8,12 @@ if frr_opt.disabled()
   subdir_done()
 endif
 
-frr_dep = dependency('frr', version: '>= 10.5', required: false)
-if not frr_dep.found()
-  if get_option('frr').enabled()
-    sp = subproject('frr-' + frr_version)
-    frr_dep = sp.get_variable('frr_dep')
-  else
-    subdir_done()
-  endif
-endif
+frr_dep = dependency(
+  'frr',
+  version: '>= 10.5',
+  required: frr_opt,
+  fallback: ['frr-' + frr_version, 'frr_dep'],
+)
 
 install_build_flag = frr_dep.get_variable('install_on_build', default_value: 'false') == 'true'
 frr_moduledir = frr_dep.get_variable('moduledir')

--- a/frr/meson.build
+++ b/frr/meson.build
@@ -10,11 +10,7 @@ endif
 frr_dep = dependency('frr', version: '>= 10.5', required: false)
 if not frr_dep.found()
   if get_option('frr').enabled()
-    if frr_version == 'default'
-      sp = subproject('frr')
-    else
-      sp = subproject('frr-' + frr_version)
-    endif
+    sp = subproject('frr-' + frr_version)
     frr_dep = sp.get_variable('frr_dep')
   else
     subdir_done()

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -12,8 +12,8 @@ option(
 )
 
 option(
-  'frr_version', type: 'combo', choices: ['default', '10.6.0', 'master'], value: 'default',
-  description: 'FRR version, defaults to 10.5.3.',
+  'frr_version', type: 'combo', choices: ['10.5', '10.6', 'master'], value: '10.5',
+  description: 'FRR version, defaults to 10.5.',
 )
 
 option(

--- a/subprojects/frr-10.5.wrap
+++ b/subprojects/frr-10.5.wrap
@@ -6,4 +6,4 @@ directory = frr-frr-10.5.3
 patch_directory = frr
 
 [provide]
-dependency_names = frr
+dependency_names = frr-10.5

--- a/subprojects/frr-10.6.wrap
+++ b/subprojects/frr-10.6.wrap
@@ -6,4 +6,4 @@ directory = frr-frr-10.6.0
 patch_directory = frr
 
 [provide]
-dependency_names = frr-10.6.0
+dependency_names = frr-10.6

--- a/subprojects/packagefiles/frr/meson.build
+++ b/subprojects/packagefiles/frr/meson.build
@@ -9,6 +9,8 @@ project('frr', 'c',
   license: 'GPL-2.0-or-later',
   meson_version: '>= 0.63.0')
 
+cc = meson.get_compiler('c')
+
 srcdir = meson.current_source_dir()
 builddir = meson.current_build_dir()
 libdir = builddir / 'lib' / '.libs'
@@ -33,11 +35,22 @@ moduledir = prefix / get_option('libdir') / 'frr/modules'
 user_name  = run_command('id', '-un', check: true).stdout().strip()
 group_name = run_command('id', '-gn', check: true).stdout().strip()
 extra_configure_option = '--enable-user=' + user_name + ' ' + '--enable-group=' + group_name
+extra_configure_env = ''
 
 buildtype = get_option('buildtype')
 debug = buildtype.startswith('debug')
 if debug
   extra_configure_option += ' --enable-dev-build'
+endif
+
+if meson.is_cross_build()
+  host_triplet = host_machine.cpu_family() + '-' + host_machine.system() + '-gnu'
+  extra_configure_option += ' --host=' + host_triplet
+  extra_configure_env += 'CC="' + ' '.join(cc.cmd_array()) + '" '
+  pkg_config_libdir = meson.get_external_property('pkg_config_libdir', '')
+  if pkg_config_libdir != ''
+    extra_configure_env += 'PKG_CONFIG_LIBDIR="' + pkg_config_libdir + '" '
+  endif
 endif
 
 configure = custom_target(
@@ -46,6 +59,7 @@ configure = custom_target(
   command: [
     'sh', '-c',
     'cd "' + builddir + '" && ' +
+    extra_configure_env +
     '"' + srcdir + '/configure" ' +
     '--prefix="' + prefix + '" ' +
     '--with-moduledir="' + moduledir + '" ' +


### PR DESCRIPTION
Simplify the FRR meson dependency resolution by using the builtin fallback parameter instead of manually calling subproject(). Rename the wrap files to match the version they provide so the fallback name resolves naturally.

Rework the CI compiler matrix to use compact cc/cv fields with setup-gcc and setup-clang actions. Add gcc-15, gcc-16, clang-20 and clang-22 to the build matrix. Always install FRR build dependencies in all CI jobs including aarch64 cross-compilation. Mark the FRR master build as non-voting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Meson build changes

frr/meson.build
- Use a single Meson dependency() with fallback instead of manual subproject()/found() checks:
  - frr_dep = dependency('frr', version: '>= 10.5', required: frr_opt, fallback: ['frr-' + frr_version, 'frr_dep'])
- Early exit when the frr option is disabled remains (if frr_opt.disabled() subdir_done()).
- Read variables from frr_dep (install_on_build, moduledir) and compute CURRENT_FRR_VERSION from frr_dep.version(); pass frr_dep as the shared_module dependency.
- Add compiler flag -Wno-constant-logical-operand to frr_c_args.

subprojects/packagefiles/frr/meson.build
- Capture the detected C compiler: cc = meson.get_compiler('c').
- Introduce extra_configure_env and append a host triplet to configure options during cross builds: --host=<cpu-family>-<system>-gnu.
- Prefix the configure invocation with extra_configure_env (sets CC from cc.cmd_array(), and PKG_CONFIG_LIBDIR when provided) so the configure script runs with the Meson-detected toolchain environment.

meson_options.txt
- Change frr_version option choices and default:
  - choices: ['10.5', '10.6', 'master']
  - value: '10.5'
  - description: 'FRR version, defaults to 10.5.'

subprojects/*.wrap
- Rename/provide dependency names to versioned identifiers:
  - subprojects/frr-10.5.wrap: dependency_names = frr-10.5
  - subprojects/frr-10.6.wrap: dependency_names = frr-10.6

## CI workflow changes

.github/workflows/check.yml
- Replace previous per-entry matrix fields with a compact matrix.conf list containing compiler, frr, and optional asan/rebase flags; jobs run on ubuntu-24.04.
- Set SANITIZE via case(matrix.conf.asan || false, 'address', 'none'); set CC to "ccache ${matrix.conf.compiler}" and always include -Dfrr_version=${{ matrix.conf.frr }} in MESON_EXTRA_OPTS.
- Install FRR APT key/repo and FRR development packages unconditionally in the main build job (libjson-c-dev, libelf-dev, libprotobuf-c-dev, protobuf-c-compiler, libreadline-dev, libcap-dev, librtr-dev, libyang2-dev, libyang2-tools).
- Cross aarch64 job runs in debian:stable container, sets MESON_EXTRA_OPTS=--cross-file=devtools/cross/aarch64.ini, and installs an expanded list of cross/arm64 toolchain and FRR-related development packages (autoconf, automake, bison, flex, patch, python3-dev, crossbuild-essential-arm64, plus many :arm64 packages).

.github/workflows/publish.yml
- Extract FRR revision/version from subprojects/frr-10.5.wrap (sed ...) and expose it via steps.frr-version.outputs.version for Docker image metadata.

## Packaging / Makefile changes

GNUmakefile
- frr-rpm target now reads frr_version and frr_hash from subprojects/frr-10.5.wrap, runs meson subprojects download frr-10.5, verifies the downloaded archive checksum, and uses the derived frr_version for rpmbuild inputs and archive paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->