### PR TITLE
frr: sweep stale grout routes across zebra restart

### DIFF
--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -324,10 +324,11 @@ static void grout_route_change(
 	uint16_t family,
 	void *dest_addr,
 	uint8_t dest_prefixlen,
+	uint16_t gr_route_vrf_id,
 	struct gr_nexthop *gr_nh,
 	bool startup
 ) {
-	uint32_t vrf_id = vrf_grout_to_frr(gr_nh->vrf_id);
+	uint32_t vrf_id = vrf_grout_to_frr(gr_route_vrf_id);
 	bool selfroute = is_selfroute(origin);
 	int proto = ZEBRA_ROUTE_KERNEL;
 	uint32_t nh_id = gr_nh->nh_id;
@@ -440,12 +441,13 @@ static void grout_route_change(
 
 void grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup) {
 	gr_log_debug(
-		"%s %pI4/%u origin %s nh_id %u vrf %u",
+		"%s %pI4/%u origin %s nh_id %u route_vrf %u nh_vrf %u",
 		new ? "add" : "del",
 		&gr_r4->dest.ip,
 		gr_r4->dest.prefixlen,
 		gr_nh_origin_name(gr_r4->origin),
 		gr_r4->nh.nh_id,
+		gr_r4->vrf_id,
 		gr_r4->nh.vrf_id
 	);
 	grout_route_change(
@@ -454,6 +456,7 @@ void grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup) {
 		AF_INET,
 		(void *)&gr_r4->dest.ip,
 		gr_r4->dest.prefixlen,
+		gr_r4->vrf_id,
 		&gr_r4->nh,
 		startup
 	);
@@ -461,12 +464,13 @@ void grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup) {
 
 void grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup) {
 	gr_log_debug(
-		"%s %pI6/%u origin %s nh_id %u vrf %u",
+		"%s %pI6/%u origin %s nh_id %u route_vrf %u nh_vrf %u",
 		new ? "add" : "del",
 		&gr_r6->dest.ip,
 		gr_r6->dest.prefixlen,
 		gr_nh_origin_name(gr_r6->origin),
 		gr_r6->nh.nh_id,
+		gr_r6->vrf_id,
 		gr_r6->nh.vrf_id
 	);
 	grout_route_change(
@@ -475,6 +479,7 @@ void grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup) {
 		AF_INET6,
 		(void *)&gr_r6->dest.ip,
 		gr_r6->dest.prefixlen,
+		gr_r6->vrf_id,
 		&gr_r6->nh,
 		startup
 	);

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -279,6 +279,7 @@ static int grout_gr_nexthop_to_frr_nexthop(
 
 		ctx.table = vrf_grout_to_frr(sr6->out_vrf_id);
 		nexthop_add_srv6_seg6local(nh, action, &ctx);
+		nh->type = nh->ifindex ? NEXTHOP_TYPE_IPV6_IFINDEX : NEXTHOP_TYPE_IPV6;
 		*nh_family = AF_INET6;
 		break;
 	}
@@ -298,12 +299,14 @@ static int grout_gr_nexthop_to_frr_nexthop(
 		}
 
 		nexthop_add_srv6_seg6(nh, (void *)sr6->seglist, sr6->n_seglist, encap_behavior);
+		nh->type = nh->ifindex ? NEXTHOP_TYPE_IPV6_IFINDEX : NEXTHOP_TYPE_IPV6;
 		*nh_family = AF_INET6;
 		break;
 	}
 	case GR_NH_T_GROUP:
 		nh->ifindex = ifindex_grout_to_frr(gr_nh->iface_id);
 		nh->vrf_id = vrf_grout_to_frr(gr_nh->vrf_id);
+		nh->type = NEXTHOP_TYPE_IFINDEX;
 		*nh_family = AF_UNSPEC;
 		nh->weight = 1;
 		break;

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -321,9 +321,11 @@ static void grout_route_change(
 	uint16_t family,
 	void *dest_addr,
 	uint8_t dest_prefixlen,
-	struct gr_nexthop *gr_nh
+	struct gr_nexthop *gr_nh,
+	bool startup
 ) {
 	uint32_t vrf_id = vrf_grout_to_frr(gr_nh->vrf_id);
+	bool selfroute = is_selfroute(origin);
 	int proto = ZEBRA_ROUTE_KERNEL;
 	uint32_t nh_id = gr_nh->nh_id;
 	// Grout has no per‑VRF routing tables; table_id always equals vrf_id
@@ -334,8 +336,12 @@ static void grout_route_change(
 	size_t sz;
 	afi_t afi;
 
-	if (new && is_selfroute(origin)) {
-		gr_log_debug("self-originated %s route, skip", gr_nh_origin_name(origin));
+	// Echo of our own install: skip. Mirrors the !startup && selfroute
+	// guard in netlink_route_change (zebra/rt_netlink.c).
+	if (new && !startup && selfroute) {
+		gr_log_debug(
+			"self-originated %s route notification, skip", gr_nh_origin_name(origin)
+		);
 		return;
 	}
 
@@ -383,6 +389,11 @@ static void grout_route_change(
 
 	proto = origin2zebra(origin, family, false);
 
+	// Route inserted by Zebra: mark SELFROUTE so rib_compare_routes can
+	// swap with a client's re-push and rib_sweep_route can purge.
+	if (selfroute)
+		flags |= ZEBRA_FLAG_SELFROUTE;
+
 	if (new) {
 		struct route_entry *re;
 		struct nexthop_group *ng = NULL;
@@ -424,7 +435,7 @@ static void grout_route_change(
 	}
 }
 
-void grout_route4_change(bool new, struct gr_ip4_route *gr_r4) {
+void grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup) {
 	gr_log_debug(
 		"%s %pI4/%u origin %s nh_id %u vrf %u",
 		new ? "add" : "del",
@@ -440,11 +451,12 @@ void grout_route4_change(bool new, struct gr_ip4_route *gr_r4) {
 		AF_INET,
 		(void *)&gr_r4->dest.ip,
 		gr_r4->dest.prefixlen,
-		&gr_r4->nh
+		&gr_r4->nh,
+		startup
 	);
 }
 
-void grout_route6_change(bool new, struct gr_ip6_route *gr_r6) {
+void grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup) {
 	gr_log_debug(
 		"%s %pI6/%u origin %s nh_id %u vrf %u",
 		new ? "add" : "del",
@@ -460,7 +472,8 @@ void grout_route6_change(bool new, struct gr_ip6_route *gr_r6) {
 		AF_INET6,
 		(void *)&gr_r6->dest.ip,
 		gr_r6->dest.prefixlen,
-		&gr_r6->nh
+		&gr_r6->nh,
+		startup
 	);
 }
 
@@ -493,6 +506,15 @@ enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx) {
 
 	if (!is_selfroute(origin)) {
 		gr_log_debug("non-frr origin, skip");
+		return ZEBRA_DPLANE_REQUEST_SUCCESS;
+	}
+
+	// Route was read from grout at startup and injected into zebra's RIB
+	// with ZEBRA_FLAG_SELFROUTE. Grout already has it, do not round-trip
+	// the install/update back to grout. Deletes must still flow so that
+	// rib_sweep_route can purge unreclaimed orphans.
+	if (new && (dplane_ctx_get_flags(ctx) & ZEBRA_FLAG_SELFROUTE)) {
+		gr_log_debug("selfroute install/update, already in grout, skip");
 		return ZEBRA_DPLANE_REQUEST_SUCCESS;
 	}
 

--- a/frr/rt_grout.h
+++ b/frr/rt_grout.h
@@ -9,8 +9,8 @@
 
 #include <zebra/zebra_dplane.h>
 
-void grout_route4_change(bool new, struct gr_ip4_route *gr_r4);
-void grout_route6_change(bool new, struct gr_ip6_route *gr_r6);
+void grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup);
+void grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup);
 enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx);
 enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx);
 void grout_nexthop_change(bool new, struct gr_nexthop *gr_nh, bool startup);

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -508,15 +508,17 @@ route6:
 		goto route6;
 	}
 
-	// Chain to next VRF
+	// Pass 3: chain to routes of next VRF. NHEs from all VRFs are
+	// already registered (Pass 2 ran nhs for every VRF before any
+	// routes), so cross-VRF NH references resolve at inject time.
 	for (unsigned int i = EVENT_VAL(e) + 1; i < GR_MAX_IFACES; i++) {
 		if (bf_test_index(grout_ctx.sync_vrf, i)) {
 			event_add_event(
-				dplane_get_thread_master(),
-				grout_sync_addrs,
+				zrouter.master,
+				grout_sync_routes,
 				NULL,
 				i,
-				&grout_ctx.dg_t_dplane_sync
+				&grout_ctx.dg_t_zebra_sync
 			);
 			return;
 		}
@@ -554,9 +556,35 @@ static void grout_sync_nhs(struct event *e) {
 		);
 		return;
 	}
-	event_add_event(
-		zrouter.master, grout_sync_routes, NULL, EVENT_VAL(e), &grout_ctx.dg_t_zebra_sync
-	);
+
+	// Pass 2 (this VRF done): chain to nhs of next VRF.
+	// All NHs across all VRFs are registered before any route is
+	// injected so cross-VRF NH references (e.g. SR6_LOCAL with
+	// out_vrf in a different VRF than the prefix being matched)
+	// resolve at route inject time.
+	for (unsigned int i = EVENT_VAL(e) + 1; i < GR_MAX_IFACES; i++) {
+		if (bf_test_index(grout_ctx.sync_vrf, i)) {
+			event_add_event(
+				zrouter.master, grout_sync_nhs, NULL, i, &grout_ctx.dg_t_zebra_sync
+			);
+			return;
+		}
+	}
+
+	// Pass 2 done across all VRFs. Kick off Pass 3 (routes) starting
+	// from the first VRF.
+	for (unsigned int i = 0; i < GR_MAX_IFACES; i++) {
+		if (bf_test_index(grout_ctx.sync_vrf, i)) {
+			event_add_event(
+				zrouter.master,
+				grout_sync_routes,
+				NULL,
+				i,
+				&grout_ctx.dg_t_zebra_sync
+			);
+			return;
+		}
+	}
 }
 
 static void grout_sync_addrs(struct event *e) {
@@ -593,9 +621,32 @@ static void grout_sync_addrs(struct event *e) {
 		goto err;
 	}
 
-	event_add_event(
-		zrouter.master, grout_sync_nhs, NULL, EVENT_VAL(e), &grout_ctx.dg_t_zebra_sync
-	);
+	// Pass 1 (this VRF done): chain to addrs of next VRF.
+	// All addrs across all VRFs are processed before any nhs, mirroring
+	// the kernel dplane init order (links -> addrs -> nexthops -> routes).
+	for (unsigned int i = EVENT_VAL(e) + 1; i < GR_MAX_IFACES; i++) {
+		if (bf_test_index(grout_ctx.sync_vrf, i)) {
+			event_add_event(
+				dplane_get_thread_master(),
+				grout_sync_addrs,
+				NULL,
+				i,
+				&grout_ctx.dg_t_dplane_sync
+			);
+			return;
+		}
+	}
+
+	// Pass 1 done across all VRFs. Kick off Pass 2 (nhs) starting
+	// from the first VRF.
+	for (unsigned int i = 0; i < GR_MAX_IFACES; i++) {
+		if (bf_test_index(grout_ctx.sync_vrf, i)) {
+			event_add_event(
+				zrouter.master, grout_sync_nhs, NULL, i, &grout_ctx.dg_t_zebra_sync
+			);
+			return;
+		}
+	}
 	return;
 
 err:

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -13,10 +13,13 @@
 #include "log_grout.h"
 #include "rt_grout.h"
 
+#include <fcntl.h>
+#include <getopt.h>
 #include <lib/bitfield.h>
 #include <lib/frr_pthread.h>
 #include <lib/libfrr.h>
 #include <lib/version.h>
+#include <unistd.h>
 #include <zebra/interface.h>
 #include <zebra/rib.h>
 #include <zebra/zebra_dplane.h>
@@ -41,6 +44,12 @@ static struct prefix grout_sync_marker_prefix = {
 // actual observation, mirroring kernel-side "Finished Initial Startup".
 #define GROUT_SYNC_MARKER_WARN_EVERY 100
 
+// Pre-arm delay for zrouter.t_rib_sweep. Only purpose: keep *t_ptr
+// non-NULL so zebra_main_router_started's event_add_timer takes the
+// early-return path (lib/event.c:1430) and the native sweep is a no-op.
+// Value is arbitrary; the nominal path replaces this with the real arm.
+#define GROUT_SYNC_SWEEP_PLACEHOLDER_SEC 3600
+
 struct grout_ctx_t {
 	struct gr_api_client *client;
 	struct gr_api_client *sync_client;
@@ -64,6 +73,10 @@ struct grout_ctx_t {
 	struct event *dg_t_poll_marker;
 	unsigned int marker_poll_retries;
 	void (*marker_cb)(void);
+
+	// -K value cached from /proc/self/cmdline. Same semantics as FRR's
+	// zebra_di.gr_cleanup_time: 0 means absent, positive means K seconds.
+	int gr_cleanup_time;
 };
 
 static struct grout_ctx_t grout_ctx = {0};
@@ -78,6 +91,7 @@ static void grout_sync_ifaces(struct event *);
 static void grout_sync_addrs(struct event *);
 static void grout_reconnect(struct event *);
 static void grout_reconnect_finish(void);
+static void grout_sync_arm_sweep(void);
 static void grout_sync_cleanup_marker(void);
 static void grout_sync_inject_marker(void);
 
@@ -186,12 +200,117 @@ static void grout_sync_fdb(struct event *) {
 	}
 }
 
+// Recover -K by re-parsing /proc/self/cmdline. zebra_di.gr_cleanup_time
+// is static in main.c (not exported) and zrouter.t_rib_sweep loses the
+// value after firing. Returns the -K seconds, or 0 if absent (matches
+// FRR's libfrr.c default + atoi semantics). Called once from
+// zd_grout_plugin_init (single-threaded, before event loop).
+static int grout_read_k_from_cmdline(void) {
+	// 1 MiB cap; ARG_MAX is 2 MiB, MTYPE_TMP aborts on OOM.
+	const size_t buf_cap_max = 1024 * 1024;
+	char *buf = NULL, **argv = NULL;
+	size_t buf_cap = 4096, buf_len = 0;
+	int argc = 0, argv_cap = 0;
+	int fd, ret = 0;
+
+	fd = open("/proc/self/cmdline", O_RDONLY);
+	if (fd < 0) {
+		gr_log_warn("/proc/self/cmdline: %s", strerror(errno));
+		return 0;
+	}
+
+	buf = XMALLOC(MTYPE_TMP, buf_cap);
+
+	for (;;) {
+		ssize_t n = read(fd, buf + buf_len, buf_cap - buf_len - 1);
+		if (n < 0)
+			goto out;
+		if (n == 0)
+			break;
+		buf_len += n;
+		if (buf_len >= buf_cap - 1) {
+			if (buf_cap >= buf_cap_max) {
+				gr_log_warn(
+					"/proc/self/cmdline exceeds %zu bytes, truncating; "
+					"-K parsing may miss the flag",
+					buf_cap_max
+				);
+				goto out;
+			}
+			buf_cap *= 2;
+			if (buf_cap > buf_cap_max)
+				buf_cap = buf_cap_max;
+			buf = XREALLOC(MTYPE_TMP, buf, buf_cap);
+		}
+	}
+	if (buf_len == 0)
+		goto out;
+	buf[buf_len] = '\0';
+
+	for (size_t i = 0; i < buf_len; i++)
+		if (buf[i] == '\0')
+			argv_cap++;
+
+	argv = XCALLOC(MTYPE_TMP, (argv_cap + 1) * sizeof(*argv));
+	for (char *p = buf; p < buf + buf_len; p += strlen(p) + 1)
+		argv[argc++] = p;
+	argv[argc] = NULL;
+
+	static const struct option lo[] = {
+		{"graceful_restart", optional_argument, NULL, 'K'}, {0, 0, 0, 0}
+	};
+	int saved_optind = optind;
+	int saved_opterr = opterr;
+	optind = 1;
+	opterr = 0;
+	int c;
+	while ((c = getopt_long(argc, argv, ":K::", lo, NULL)) != -1) {
+		if (c == 'K' && optarg)
+			ret = atoi(optarg);
+	}
+	optind = saved_optind;
+	opterr = saved_opterr;
+
+out:
+	close(fd);
+	XFREE(MTYPE_TMP, argv);
+	XFREE(MTYPE_TMP, buf);
+	return ret;
+}
+
 // Run the post-observation action set up by the marker injector.
 static void grout_sync_dispatch_marker_cb(void) {
 	void (*cb)(void) = grout_ctx.marker_cb;
 	grout_ctx.marker_cb = NULL;
 	assert(cb);
 	cb();
+}
+
+// Arm rib_sweep_route after observing the end-of-replay marker.
+// Re-stamp zrouter.startup_time to "now" so -K is measured from the
+// end of the grout dump (mirrors Donald Sharp's "Delay some processing
+// until after startup is finished"). Replaces the pre-arm placeholder
+// installed by zd_grout_plugin_init.
+static void grout_sync_arm_sweep(void) {
+	grout_sync_cleanup_marker();
+
+	time_t old_startup_time = zrouter.startup_time;
+	zrouter.startup_time = monotime(NULL);
+	gr_log_debug(
+		"restamping zrouter.startup_time %lld -> %lld; -K window starts now",
+		(long long)old_startup_time,
+		(long long)zrouter.startup_time
+	);
+
+	long delay = 0;
+	if (zrouter.graceful_restart) {
+		// Truthy check matches zebra/main.c: 0 falls back to default.
+		delay = grout_ctx.gr_cleanup_time ?
+			grout_ctx.gr_cleanup_time :
+			ZEBRA_GR_DEFAULT_RIB_SWEEP_TIME;
+	}
+	event_cancel(&zrouter.t_rib_sweep);
+	event_add_timer(zrouter.master, rib_sweep_route, NULL, delay, &zrouter.t_rib_sweep);
 }
 
 // Poll the RIB for our marker. FIFO ordering of META_QUEUE_EARLY_ROUTE
@@ -355,7 +474,7 @@ route4:
 			continue;
 		if (link && r4->origin != GR_NH_ORIGIN_LINK)
 			continue;
-		grout_route4_change(true, r4);
+		grout_route4_change(true, r4, true);
 	}
 	if (ret < 0) {
 		gr_log_err("GR_IP4_ROUTE_LIST: %s", strerror(errno));
@@ -378,7 +497,7 @@ route6:
 			continue;
 		if (link && r6->origin != GR_NH_ORIGIN_LINK)
 			continue;
-		grout_route6_change(true, r6);
+		grout_route6_change(true, r6, true);
 	}
 	if (ret < 0) {
 		gr_log_err("GR_IP6_ROUTE_LIST: %s", strerror(errno));
@@ -402,6 +521,12 @@ route6:
 			return;
 		}
 	}
+
+	// All VRFs synced. Defer arming rib_sweep_route until the marker is
+	// observed: arming inline would race the metaQ drain and miss
+	// not-yet-attached SELFROUTE injections.
+	grout_ctx.marker_cb = grout_sync_arm_sweep;
+	grout_sync_inject_marker();
 	return;
 
 err:
@@ -724,13 +849,13 @@ static void zebra_read_notifications(struct event *event) {
 		new = true;
 		// fallthrough
 	case GR_EVENT_IP_ROUTE_DEL:
-		grout_route4_change(new, PAYLOAD(gr_e));
+		grout_route4_change(new, PAYLOAD(gr_e), false);
 		break;
 	case GR_EVENT_IP6_ROUTE_ADD:
 		new = true;
 		// fallthrough
 	case GR_EVENT_IP6_ROUTE_DEL:
-		grout_route6_change(new, PAYLOAD(gr_e));
+		grout_route6_change(new, PAYLOAD(gr_e), false);
 		break;
 	case GR_EVENT_NEXTHOP_NEW:
 	case GR_EVENT_NEXTHOP_UPDATE:
@@ -953,6 +1078,26 @@ static int zd_grout_plugin_init(struct event_loop *) {
 		gr_log_err("Unable to register grout dplane provider: %d", ret);
 
 	gr_log_debug("%s register status %d", plugin_name, ret);
+
+	// Cache -K once: single-threaded under frr_late_init.
+	grout_ctx.gr_cleanup_time = grout_read_k_from_cmdline();
+
+	// Pre-arm to neutralise the native sweep: zebra_main_router_started's
+	// event_add_timer(... &zrouter.t_rib_sweep) early-returns when the
+	// pointer is non-NULL (lib/event.c:1430).
+	event_add_timer(
+		zrouter.master,
+		rib_sweep_route,
+		NULL,
+		GROUT_SYNC_SWEEP_PLACEHOLDER_SEC,
+		&zrouter.t_rib_sweep
+	);
+
+	// Detect FRR drift: if pre-arm did not set the pointer, the native
+	// sweep will fire uncontrolled. Plugin still works (predicate skips
+	// dump entries by uptime), just noisy.
+	if (!zrouter.t_rib_sweep)
+		gr_log_err("pre-arm failed: FRR event API may have changed");
 
 	return 0;
 }

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -18,13 +18,28 @@
 #include <lib/libfrr.h>
 #include <lib/version.h>
 #include <zebra/interface.h>
+#include <zebra/rib.h>
 #include <zebra/zebra_dplane.h>
 #include <zebra/zebra_router.h>
+#include <zebra/zebra_vrf.h>
 #include <zebra_dplane_grout.h>
 
 #define TOSTRING(x) #x
 
 static const char *gr_sock_path = GR_DEFAULT_SOCK_PATH;
+
+// Marker prefix and polling cadence. The marker is a dummy ::/128 SHARP
+// entry the plugin uses as a metaQ drain barrier: once observable in
+// the RIB, FIFO ordering of META_QUEUE_EARLY_ROUTE guarantees every
+// earlier ere has drained.
+static struct prefix grout_sync_marker_prefix = {
+	.family = AF_INET6,
+	.prefixlen = 128,
+};
+#define GROUT_SYNC_MARKER_POLL_MS 50
+// One warning every ~5s while polling. No timeout: dispatch only on
+// actual observation, mirroring kernel-side "Finished Initial Startup".
+#define GROUT_SYNC_MARKER_WARN_EVERY 100
 
 struct grout_ctx_t {
 	struct gr_api_client *client;
@@ -42,6 +57,13 @@ struct grout_ctx_t {
 	struct event *dg_t_dplane_sync;
 	struct event *dg_t_zebra_sync;
 	bitfield_t sync_vrf;
+
+	// Marker polling state. marker_cb selects the post-observation
+	// action (e.g. grout_reconnect_finish). Marker is always injected
+	// in VRF_DEFAULT on prefix ::/128.
+	struct event *dg_t_poll_marker;
+	unsigned int marker_poll_retries;
+	void (*marker_cb)(void);
 };
 
 static struct grout_ctx_t grout_ctx = {0};
@@ -55,6 +77,9 @@ static void grout_sync(struct event *);
 static void grout_sync_ifaces(struct event *);
 static void grout_sync_addrs(struct event *);
 static void grout_reconnect(struct event *);
+static void grout_reconnect_finish(void);
+static void grout_sync_cleanup_marker(void);
+static void grout_sync_inject_marker(void);
 
 void ipaddr_to_l3_addr(struct l3_addr *dst, const struct ipaddr *src) {
 	switch (src->ipa_type) {
@@ -159,6 +184,158 @@ static void grout_sync_fdb(struct event *) {
 			return;
 		}
 	}
+}
+
+// Run the post-observation action set up by the marker injector.
+static void grout_sync_dispatch_marker_cb(void) {
+	void (*cb)(void) = grout_ctx.marker_cb;
+	grout_ctx.marker_cb = NULL;
+	assert(cb);
+	cb();
+}
+
+// Poll the RIB for our marker. FIFO ordering of META_QUEUE_EARLY_ROUTE
+// guarantees that when the marker is observable, every earlier ere has
+// been attached. The marker itself is skipped by rib_process (distance
+// INFINITY + type != KERNEL): never selected, never installed.
+static void grout_sync_poll_marker(struct event *e) {
+	struct route_table *table;
+	struct route_node *rn;
+	struct route_entry *re;
+	bool found = false;
+
+	// !table: keep polling, do not dispatch. The marker is a strict
+	// FIFO barrier; a best-effort dispatch would defeat its purpose.
+	table = zebra_vrf_table(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT);
+	if (table) {
+		rn = route_node_lookup(table, &grout_sync_marker_prefix);
+		if (rn) {
+			RNODE_FOREACH_RE(rn, re) {
+				if (CHECK_FLAG(re->status, ROUTE_ENTRY_REMOVED))
+					continue;
+				if (re->tag == GROUT_SYNC_MARKER_TAG
+				    && re->type == ZEBRA_ROUTE_SHARP) {
+					found = true;
+					break;
+				}
+			}
+			route_unlock_node(rn);
+		}
+	}
+
+	if (found) {
+		gr_log_info(
+			"sync marker observed after %u poll(s) (%u ms)",
+			grout_ctx.marker_poll_retries + 1,
+			(grout_ctx.marker_poll_retries + 1) * GROUT_SYNC_MARKER_POLL_MS
+		);
+		goto dispatch;
+	}
+
+	grout_ctx.marker_poll_retries++;
+	if (grout_ctx.marker_poll_retries % GROUT_SYNC_MARKER_WARN_EVERY == 0) {
+		gr_log_warn(
+			"sync marker still not visible after %u ms; metaQ drain may be slow",
+			grout_ctx.marker_poll_retries * GROUT_SYNC_MARKER_POLL_MS
+		);
+	}
+
+	event_add_timer_msec(
+		zrouter.master,
+		grout_sync_poll_marker,
+		NULL,
+		GROUT_SYNC_MARKER_POLL_MS,
+		&grout_ctx.dg_t_poll_marker
+	);
+	return;
+
+dispatch:
+	grout_sync_dispatch_marker_cb();
+}
+
+// Drop the marker route (in metaQ or already attached). Idempotent:
+// the FRR APIs are no-op if no matching entry exists, so this is safe
+// to call before injecting a new marker (covers an interrupted
+// previous reconnect) or after observation (cosmetic cleanup).
+static void grout_sync_cleanup_marker(void) {
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+	rib_meta_queue_early_route_cleanup(
+		&grout_sync_marker_prefix, AFI_IP6, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_SHARP
+	);
+#else
+	rib_meta_queue_early_route_cleanup(&grout_sync_marker_prefix, ZEBRA_ROUTE_SHARP);
+#endif
+	rib_delete(
+		AFI_IP6,
+		SAFI_UNICAST,
+		VRF_DEFAULT,
+		ZEBRA_ROUTE_SHARP,
+		0,
+		0,
+		&grout_sync_marker_prefix,
+		NULL,
+		NULL,
+		0,
+		0,
+		0,
+		0,
+		false
+	);
+}
+
+// Inject the marker into VRF_DEFAULT and kick off polling.
+//   prefix     ::/128         never a real destination
+//   type       SHARP          test/demo, no collision
+//   distance   INFINITY (255) rib_process skips it
+//   flags      0              keeps it out of rib_sweep_table predicate
+//   tag        unique id      distinguishes from user routes on ::/128
+//   nexthop    blackhole      inert (entry never installed)
+static void grout_sync_inject_marker(void) {
+	// Local non-const copy: rib_add_multipath takes a non-const prefix
+	// pointer and may apply_mask in-place.
+	struct prefix p = grout_sync_marker_prefix;
+	struct nexthop *nh;
+	struct nexthop_group *ng;
+	struct route_entry *re;
+
+	nh = nexthop_new();
+	nh->type = NEXTHOP_TYPE_BLACKHOLE;
+	nh->bh_type = BLACKHOLE_NULL;
+	nh->vrf_id = VRF_DEFAULT;
+
+	ng = nexthop_group_new();
+	nexthop_group_add_sorted(ng, nh);
+
+	re = zebra_rib_route_entry_new(
+		VRF_DEFAULT,
+		ZEBRA_ROUTE_SHARP,
+		0,
+		0,
+		0,
+		0,
+		0,
+		0,
+		DISTANCE_INFINITY,
+		GROUT_SYNC_MARKER_TAG
+	);
+
+	grout_ctx.marker_poll_retries = 0;
+
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+	rib_add_multipath(AFI_IP6, SAFI_UNICAST, &p, NULL, re, ng, true, false);
+#else
+	rib_add_multipath(AFI_IP6, SAFI_UNICAST, &p, NULL, re, ng, true);
+#endif
+
+	nexthop_group_delete(&ng);
+
+	event_add_timer_msec(
+		zrouter.master,
+		grout_sync_poll_marker,
+		NULL,
+		GROUT_SYNC_MARKER_POLL_MS,
+		&grout_ctx.dg_t_poll_marker
+	);
 }
 
 static void grout_sync_routes(struct event *e) {
@@ -663,6 +840,13 @@ static void grout_ns_reset(void) {
 	}
 }
 
+// Phase 2 of grout_reconnect: barrier observed, metaQ drained, safe to
+// wipe and re-sync. vrf_terminate clears OLD ere's attached to OLD VRF.
+static void grout_reconnect_finish(void) {
+	grout_ns_reset();
+	event_add_event(zrouter.master, grout_sync, NULL, 0, &grout_ctx.dg_t_sync);
+}
+
 static void grout_reconnect(struct event *) {
 	gr_log_notice("grout disconnected, performing full re-sync");
 
@@ -670,15 +854,23 @@ static void grout_reconnect(struct event *) {
 	event_cancel(&grout_ctx.dg_t_zebra_sync);
 	event_cancel(&grout_ctx.dg_t_reconnect);
 	event_cancel(&grout_ctx.dg_t_sync);
+	event_cancel(&grout_ctx.dg_t_poll_marker);
 	event_cancel_async(dplane_get_thread_master(), &grout_ctx.dg_t_dplane_update, NULL);
 	event_cancel_async(dplane_get_thread_master(), &grout_ctx.dg_t_dplane_sync, NULL);
+
+	// Drop any marker left over from an interrupted prior reconnect
+	// before injecting the new barrier.
+	grout_sync_cleanup_marker();
 
 	gr_api_client_disconnect(grout_ctx.sync_client);
 	grout_ctx.sync_client = NULL;
 	clear_ifindex_mappings();
 
-	grout_ns_reset();
-	event_add_event(zrouter.master, grout_sync, NULL, 0, &grout_ctx.dg_t_sync);
+	// Inject a barrier marker before destroying VRF_DEFAULT. FIFO drain
+	// guarantees all earlier ere's are attached when observed; vrf_terminate
+	// (in grout_reconnect_finish) then wipes them along with the VRF.
+	grout_ctx.marker_cb = grout_reconnect_finish;
+	grout_sync_inject_marker();
 }
 
 static void zd_grout_ns(struct event *) {
@@ -724,6 +916,7 @@ static int zd_grout_finish(struct zebra_dplane_provider *, bool early) {
 		event_cancel(&grout_ctx.dg_t_zebra_sync);
 		event_cancel(&grout_ctx.dg_t_reconnect);
 		event_cancel(&grout_ctx.dg_t_sync);
+		event_cancel(&grout_ctx.dg_t_poll_marker);
 		event_cancel_async(dplane_get_thread_master(), &grout_ctx.dg_t_dplane_update, NULL);
 		event_cancel_async(dplane_get_thread_master(), &grout_ctx.dg_t_dplane_sync, NULL);
 		return 0;

--- a/frr/zebra_dplane_grout.h
+++ b/frr/zebra_dplane_grout.h
@@ -12,6 +12,12 @@
 
 #define GROUT_NS NS_DEFAULT
 
+// Tag identifying the marker route the plugin injects to detect
+// META_QUEUE_EARLY_ROUTE drain completion. Used by the polling logic
+// in zebra_dplane_grout.c and to filter the DELETE round-trip back
+// to grout in rt_grout.c.
+#define GROUT_SYNC_MARKER_TAG 0x03011986U
+
 int grout_client_send_recv(uint32_t req_type, size_t tx_len, const void *tx_data, void **rx_data);
 
 void ipaddr_to_l3_addr(struct l3_addr *dst, const struct ipaddr *src);

--- a/modules/srv6/control/route.c
+++ b/modules/srv6/control/route.c
@@ -95,6 +95,12 @@ static struct api_out srv6_tunsrc_set(const void *request, struct api_ctx *ctx) 
 	if (rte_ipv6_addr_is_unspec(&req->addr))
 		return srv6_tunsrc_clear(NULL, ctx);
 
+	if (tunsrc_nh != NULL) {
+		struct nexthop_info_l3 *old = nexthop_info_l3(tunsrc_nh);
+		if (rte_ipv6_addr_eq(&old->ipv6, &req->addr))
+			return api_out(0, 0, NULL);
+	}
+
 	struct gr_nexthop_base base = {
 		.type = GR_NH_T_L3,
 		.iface_id = GR_IFACE_ID_UNDEF,

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -358,22 +358,57 @@ if [ "${trace_enable:-true}" = true ]; then
 	grcli trace enable all
 fi
 
-case "${follow_events:-true}" in
-	hide)
-		grcli events > $tmp/events.log &
-		;;
-	false)
-		touch $tmp/events.log
-		;;
-	*)
-		if [ -t 1 ]; then
-			# print events in yellow
-			grcli events | tee $tmp/events.log | awk '{print "\033[33m" $0 "\033[0m"}' &
-		else
-			grcli events | tee $tmp/events.log &
-		fi
-		;;
-esac
+# Truncates events.log and resets __event_mark so wait_event reads
+# from the new line 1 onwards.
+_start_events_stream() {
+	case "${follow_events:-true}" in
+		hide)
+			grcli events > $tmp/events.log &
+			;;
+		false)
+			touch $tmp/events.log
+			;;
+		*)
+			if [ -t 1 ]; then
+				# print events in yellow
+				grcli events | tee $tmp/events.log | awk '{print "\033[33m" $0 "\033[0m"}' &
+			else
+				grcli events | tee $tmp/events.log &
+			fi
+			;;
+	esac
+	__event_mark=0
+}
+
+_start_events_stream
+
+# SIGKILL the running grout, respawn it with the same command, wait for
+# its socket, and respawn the grcli events stream (the previous one died
+# with grout). The events log is truncated and the mark is reset by
+# _start_events_stream, so the caller can directly use wait_event after.
+restart_grout() {
+	kill -9 "$grout_pid" || true
+	SECONDS=0
+	while kill -0 "$grout_pid" 2>/dev/null; do
+		[ "$SECONDS" -gt 5 ] && fail "grout still alive after SIGKILL"
+		sleep 0.1
+	done
+
+	kill %?grcli 2>/dev/null || true
+	wait %?grcli 2>/dev/null || true
+
+	$local_grout_cmd &
+	grout_pid=$!
+
+	SECONDS=0
+	while ! socat FILE:/dev/null UNIX-CONNECT:$GROUT_SOCK_PATH 2>/dev/null; do
+		[ "$SECONDS" -gt 30 ] && fail "respawned grout did not open its socket"
+		kill -0 "$grout_pid" || fail "respawned grout died"
+		sleep 0.2
+	done
+
+	_start_events_stream
+}
 
 __event_mark=0
 mark_events() {

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -69,8 +69,6 @@ set_ip_route() {
 	local next_hop="$2"
 	local vrf_name="${3:-default}"
 	local nexthop_vrf_name="${4:-}"
-	local max_tries=5
-	local count=0
 
 	local nexthop_vrf_clause=""
 	if [[ -n "$nexthop_vrf_name" ]]; then
@@ -113,8 +111,6 @@ set_srv6_localsid() {
 	local sid_prefix="$2"
 	local sid_local="$3"
 	local grout_behavior="${4:-end.dt4}"   # default behaviour
-	local max_tries=5
-	local count=0
 
 	# ---- translate behaviour aliases --------------------------------------
 	local frr_behavior
@@ -163,9 +159,7 @@ EOF
 set_srv6_route() {
     local prefix="$1"
     local nhop="$2"
-    local max_tries=5
-    local count=0
-    shift 2                       # all remaining words are SIDs (and maybe max_tries)
+    shift 2                       # all remaining words are SIDs
 
     # ----- collect SIDs ----------------------------------------------------
     local sids=()

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -120,10 +120,14 @@ set_ip_route() {
 		"${frr_ip} route ${prefix} ${next_hop} vrf ${vrf_name}${nexthop_vrf_clause}"
 }
 
-# set_srv6_localsid <locator> <sid-prefix> <sid-local> [behavior]
+# set_srv6_localsid [--persist] <locator> <sid-prefix> <sid-local> [behavior] [vrf]
 #
-# Example:
+# Examples:
 #   set_srv6_localsid myloc fd00:202 fc00:100:64:10::666 end.dt4
+#   set_srv6_localsid myloc fd00:202 fc00:100:64:10::667 end.dt4 vrf2
+#
+# zebra's SRv6 manager keeps one SID per (behavior, vrf) ctx; coexisting
+# localsids must therefore use distinct VRFs (or behaviors).
 #
 set_srv6_localsid() {
 	local persist=0
@@ -132,6 +136,7 @@ set_srv6_localsid() {
 	local sid_prefix="$2"
 	local sid_local="$3"
 	local grout_behavior="${4:-end.dt4}"   # default behaviour
+	local vrf_name="${5:-default}"
 
 	# ---- translate behaviour aliases --------------------------------------
 	local frr_behavior
@@ -144,7 +149,7 @@ set_srv6_localsid() {
 	esac
 
 	# --- push the config into FRR ------------------------------------------
-	local vrf_clause="vrf default"
+	local vrf_clause="vrf ${vrf_name}"
 	case "${frr_behavior}" in
 		uN) vrf_clause="" ;;
 	esac

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -179,9 +179,9 @@ set_srv6_route() {
 	    route="route4"
     fi
 
-    # ----- build CLI & Grout forms ----------------------------------------
-    local seg_frr   ; IFS=/ ; seg_frr="${sids[*]}"       # SID/SID/…
-    local seg_space ; IFS=' ' ; seg_space="${sids[*]}"   # SID SID …
+    # ----- build CLI form -------------------------------------------------
+    local seg_frr="${sids[*]}"
+    seg_frr=${seg_frr// //}
 
     mark_events
 

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -214,7 +214,7 @@ start_frr() {
 
 	local frr_etc="$builddir/frr_install/etc/frr"
 	local frr_logdir="$builddir/frr_install/var/log/frr"
-	local conf_dir flog daemons_file frrconf_file frr_global_opts
+	local conf_dir frr_log daemons_file frrconf_file frr_global_opts
 	local zebra_options="-s 90000000"
 
 	mkdir -p "$frr_etc"
@@ -222,14 +222,14 @@ start_frr() {
 
 	# Common config dir + files + log file + opts
 	conf_dir="$frr_etc${namespace:+/$namespace}"
-	flog="$frr_logdir/frr-${namespace:-grout}.log"
+	frr_log="$frr_logdir/frr-${namespace:-grout}.log"
 
 	mkdir -p "$conf_dir"
 	touch "$conf_dir/vtysh.conf"
 
 	daemons_file="$conf_dir/daemons"
 	frrconf_file="$conf_dir/frr.conf"
-	frr_global_opts="-A 127.0.0.1 --log file:$flog"
+	frr_global_opts="-A 127.0.0.1 --log file:$frr_log"
 
 	if [ "$use_grout" = "1" ]; then
 		zebra_options="$zebra_options -M dplane_grout"
@@ -261,8 +261,8 @@ debug zebra dplane dpdk
 EOF
 
 	# reset log
-	rm -f "$flog"
-	touch "$flog"
+	rm -f "$frr_log"
+	touch "$frr_log"
 
 	# logging: root strips ts, ns gets [ns] prefix
 	local sed_expr color
@@ -277,10 +277,10 @@ EOF
 	# Run the log tail pipeline in a subshell so we can kill all
 	# pipeline processes by killing the subshell's children.
 	if [ -t 1 ]; then
-		(tail -F "$flog" | sed -u -E "$sed_expr" | \
+		(tail -F "$frr_log" | sed -u -E "$sed_expr" | \
 			stdbuf -oL awk -v color="$color" '{print color $0 "\033[0m"}') &
 	else
-		(tail -F "$flog" | sed -u -E "$sed_expr") &
+		(tail -F "$frr_log" | sed -u -E "$sed_expr") &
 	fi
 	local tailpid=$!
 
@@ -334,7 +334,7 @@ EOF
 	# extra check when using Grout: wait for iface/ip events
 	if [ "$use_grout" = "1" ]; then
 		local attempts=25
-		while ! grep -q "GROUT:.*iface/ip events" "$flog" 2>/dev/null; do
+		while ! grep -q "GROUT:.*iface/ip events" "$frr_log" 2>/dev/null; do
 			if [ "$attempts" -le 0 ]; then
 				fail "Zebra is not listening grout events."
 			fi

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -206,6 +206,50 @@ set_srv6_route() {
 		"${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}"
 }
 
+# kill_frr_daemons <daemon> [<daemon>...]
+#
+# Simulate a crash of the named FRR daemons (e.g. zebra, staticd) and
+# block until watchfrr has respawned each one. PIDs are read from the
+# per-test pidfiles under $builddir/frr_install/var/run/frr/ so this is
+# safe to call from tests running in parallel; a host-wide pkill would
+# clobber daemons spawned by sibling smoke tests.
+#
+# Caller MUST export WATCHFRR_EXTRA_OPTS="--min-restart-interval=1"
+# before start_frr (the value is cached by watchfrr at startup).
+# Default is 60s, which silently postpones the respawn well past the
+# 10s budget enforced below and would make this helper always fail.
+#
+# Fails after 10s if any daemon is not respawned with a different pid.
+kill_frr_daemons() {
+	local frr_run="$builddir/frr_install/var/run/frr"
+	local daemon new
+	declare -A old_pids
+
+	for daemon in "$@"; do
+		old_pids[$daemon]=$(cat "$frr_run/$daemon.pid")
+	done
+
+	for daemon in "$@"; do
+		kill -9 "${old_pids[$daemon]}"
+	done
+
+	SECONDS=0
+	while :; do
+		local all_respawned=1
+		for daemon in "$@"; do
+			new=$(cat "$frr_run/$daemon.pid" 2>/dev/null || true)
+			if [ -z "$new" ] || [ "$new" = "${old_pids[$daemon]}" ]; then
+				all_respawned=0
+				break
+			fi
+		done
+		[ "$all_respawned" -eq 1 ] && break
+		[ "$SECONDS" -ge 10 ] && \
+			fail "watchfrr did not respawn $* within 10s"
+		sleep 0.1
+	done
+}
+
 #   <namespace> : optional netns name ("" = root namespace)
 #   <use_grout> : "1" -> enable dplane_grout, anything else -> no grout
 start_frr() {
@@ -214,8 +258,10 @@ start_frr() {
 
 	local frr_etc="$builddir/frr_install/etc/frr"
 	local frr_logdir="$builddir/frr_install/var/log/frr"
-	local conf_dir frr_log daemons_file frrconf_file frr_global_opts
-	local zebra_options="-s 90000000"
+	# $frr_log is intentionally global (not local) so tests sourcing
+	# _init_frr.sh can grep it after start_frr completes.
+	local conf_dir daemons_file frrconf_file frr_global_opts
+	local zebra_options="-s 90000000${ZEBRA_EXTRA_OPTS:+ $ZEBRA_EXTRA_OPTS}"
 
 	mkdir -p "$frr_etc"
 	mkdir -p "$frr_logdir"
@@ -247,10 +293,13 @@ frr_global_options="$frr_global_opts"
 zebra_options="$zebra_options"
 EOF
 
-	# only namespaces use watchfrr in a netns
-	if [ -n "$namespace" ]; then
+	if [ -n "$namespace" ] || [ -n "${WATCHFRR_EXTRA_OPTS:-}" ]; then
+		local wopts=""
+		[ -n "$namespace" ] && wopts="--netns=$namespace"
+		[ -n "${WATCHFRR_EXTRA_OPTS:-}" ] && \
+			wopts="${wopts:+$wopts }$WATCHFRR_EXTRA_OPTS"
 		cat >>"$daemons_file" <<EOF
-watchfrr_options="--netns=$namespace"
+watchfrr_options="$wopts"
 EOF
 	fi
 

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -38,7 +38,36 @@ create_interface() {
 	done
 }
 
+# _apply_frr_config <persist> <wait_pattern> <config>
+#
+# Push <config> via vtysh (default) or append it to frr.conf
+# (persist=1). In vtysh mode "configure terminal" is prepended
+# automatically and wait_event waits for <wait_pattern> when non-empty.
+# In persist mode the block is written verbatim and no event is awaited
+# (config takes effect at the next FRR start).
+#
+_apply_frr_config() {
+	local persist="$1"
+	local wait_pattern="$2"
+	local config="$3"
+
+	mark_events
+	vtysh <<EOF
+configure terminal
+$config
+EOF
+	[ -n "$wait_pattern" ] && wait_event -t 10 "$wait_pattern"
+
+	if [ "$persist" = 1 ]; then
+		cat >>"$builddir/frr_install/etc/frr/frr.conf" <<EOF
+$config
+EOF
+	fi
+}
+
 set_ip_address() {
+	local persist=0
+	[ "$1" = "--persist" ] && { persist=1; shift; }
 	local p="$1"
 	local ip_cidr="$2"
 
@@ -52,19 +81,15 @@ set_ip_address() {
 		local addr="addr4"
 	fi
 
-	mark_events
-
-	vtysh <<-EOF
-	configure terminal
-	interface ${p}
-	${frr_ip} address ${ip_cidr}
-	exit
-EOF
-
-	wait_event "$addr add: iface=$p $ip_cidr"
+	_apply_frr_config "$persist" "$addr add: iface=$p $ip_cidr" \
+"interface ${p}
+ ${frr_ip} address ${ip_cidr}
+exit"
 }
 
 set_ip_route() {
+	local persist=0
+	[ "$1" = "--persist" ] && { persist=1; shift; }
 	local prefix="$1"
 	local next_hop="$2"
 	local vrf_name="${3:-default}"
@@ -85,20 +110,14 @@ set_ip_route() {
 		local route="route4"
 	fi
 
-	mark_events
-
-	vtysh <<-EOF
-	configure terminal
-	${frr_ip} route ${prefix} ${next_hop} vrf ${vrf_name}${nexthop_vrf_clause}
-	exit
-EOF
-
 	# strip optional nexthop interface
 	local nh=${next_hop% *}
 	local gr_vrf_name="${vrf_name}"
 	[ "$gr_vrf_name" = "default" ] && gr_vrf_name="main"
 
-	wait_event "$route add: vrf=$gr_vrf_name $prefix origin=zebra_static via type=L3 .*$nh"
+	_apply_frr_config "$persist" \
+		"$route add: vrf=$gr_vrf_name $prefix origin=zebra_static via type=L3 .*$nh" \
+		"${frr_ip} route ${prefix} ${next_hop} vrf ${vrf_name}${nexthop_vrf_clause}"
 }
 
 # set_srv6_localsid <locator> <sid-prefix> <sid-local> [behavior]
@@ -107,6 +126,8 @@ EOF
 #   set_srv6_localsid myloc fd00:202 fc00:100:64:10::666 end.dt4
 #
 set_srv6_localsid() {
+	local persist=0
+	[ "$1" = "--persist" ] && { persist=1; shift; }
 	local locator="$1"
 	local sid_prefix="$2"
 	local sid_local="$3"
@@ -128,25 +149,20 @@ set_srv6_localsid() {
 		uN) vrf_clause="" ;;
 	esac
 
-	mark_events
-
-	vtysh <<-EOF
-	configure terminal
-	 segment-routing
-	  srv6
-	   locators
-	    locator ${locator}
-	     prefix ${sid_prefix}::/32 block-len 16 node-len 16 func-bits 16
-	    exit
-	   exit
-	   static-sids
-	    sid ${sid_local}/48 locator ${locator} behavior ${frr_behavior} ${vrf_clause}
-	   exit
-	 exit
-EOF
-
-	# --- wait until grout has the localsid ---------------------------------
-	wait_event "route6 add: vrf=.+ $sid_local/48 origin=zebra_static via type=SRv6-local .*behavior=$grout_behavior"
+	_apply_frr_config "$persist" \
+		"route6 add: vrf=.+ $sid_local/48 origin=zebra_static via type=SRv6-local .*behavior=$grout_behavior" \
+"segment-routing
+ srv6
+  locators
+   locator ${locator}
+    prefix ${sid_prefix}::/32 block-len 16 node-len 16 func-bits 16
+   exit
+  exit
+  static-sids
+    sid ${sid_local}/48 locator ${locator} behavior ${frr_behavior} ${vrf_clause}
+  exit
+ exit
+exit"
 }
 
 # set_srv6_route <prefix> <next-hop|iface> <sid1> [sid2 sid3 …]
@@ -157,6 +173,8 @@ EOF
 #       fd00:202::2 fd00:202::3 fd00:202::4
 #
 set_srv6_route() {
+	local persist=0
+	[ "$1" = "--persist" ] && { persist=1; shift; }
 	local prefix="$1"
 	local nhop="$2"
 	shift 2                       # all remaining words are SIDs
@@ -183,17 +201,9 @@ set_srv6_route() {
 	local seg_frr="${sids[*]}"
 	seg_frr=${seg_frr// //}
 
-	mark_events
-
-	# ----- push route into FRR --------------------------------------------
-	vtysh <<-EOF
-	configure terminal
-	  ${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}
-	  exit
-EOF
-
-	# ----- wait until Grout shows it --------------------------------------
-	wait_event "$route add: vrf=.+ $prefix origin=zebra_static via type=SRv6 .*${sids[0]}"
+	_apply_frr_config "$persist" \
+		"$route add: vrf=.+ $prefix origin=zebra_static via type=SRv6 .*${sids[0]}" \
+		"${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}"
 }
 
 #   <namespace> : optional netns name ("" = root namespace)

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -157,43 +157,43 @@ EOF
 #       fd00:202::2 fd00:202::3 fd00:202::4
 #
 set_srv6_route() {
-    local prefix="$1"
-    local nhop="$2"
-    shift 2                       # all remaining words are SIDs
+	local prefix="$1"
+	local nhop="$2"
+	shift 2                       # all remaining words are SIDs
 
-    # ----- collect SIDs ----------------------------------------------------
-    local sids=()
-    while [[ "$1" =~ : ]]; do     # anything with a ":" is assumed to be a SID
-	    sids+=("$1")
-	    shift
-    done
-    [[ ${#sids[@]} -eq 0 ]] && { echo "set_srv6_route: need at least one SID" >&2; return 1; }
+	# ----- collect SIDs ----------------------------------------------------
+	local sids=()
+	while [[ "$1" =~ : ]]; do     # anything with a ":" is assumed to be a SID
+		sids+=("$1")
+		shift
+	done
+	[[ ${#sids[@]} -eq 0 ]] && { echo "set_srv6_route: need at least one SID" >&2; return 1; }
 
-    # ----- choose FRR keyword ---------------------------------------------
-    local frr_ip route
-    if [[ "$prefix" == *:* ]]; then
-	    frr_ip="ipv6"
-	    route="route6"
-    else
-	    frr_ip="ip"
-	    route="route4"
-    fi
+	# ----- choose FRR keyword ---------------------------------------------
+	local frr_ip route
+	if [[ "$prefix" == *:* ]]; then
+		frr_ip="ipv6"
+		route="route6"
+	else
+		frr_ip="ip"
+		route="route4"
+	fi
 
-    # ----- build CLI form -------------------------------------------------
-    local seg_frr="${sids[*]}"
-    seg_frr=${seg_frr// //}
+	# ----- build CLI form -------------------------------------------------
+	local seg_frr="${sids[*]}"
+	seg_frr=${seg_frr// //}
 
-    mark_events
+	mark_events
 
-    # ----- push route into FRR --------------------------------------------
-    vtysh <<-EOF
-    configure terminal
-      ${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}
-      exit
+	# ----- push route into FRR --------------------------------------------
+	vtysh <<-EOF
+	configure terminal
+	  ${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}
+	  exit
 EOF
 
-    # ----- wait until Grout shows it --------------------------------------
-    wait_event "$route add: vrf=.+ $prefix origin=zebra_static via type=SRv6 .*${sids[0]}"
+	# ----- wait until Grout shows it --------------------------------------
+	wait_event "$route add: vrf=.+ $prefix origin=zebra_static via type=SRv6 .*${sids[0]}"
 }
 
 #   <namespace> : optional netns name ("" = root namespace)

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -170,19 +170,38 @@ set_srv6_localsid() {
 exit"
 }
 
-# set_srv6_route <prefix> <next-hop|iface> <sid1> [sid2 sid3 …]
+# set_srv6_route [--persist] <prefix> <next-hop|iface>
+#                [<vrf> [<nexthop-vrf>]] <sid1> [sid2 sid3 ...]
 #
-# EXAMPLE
-#   # Three SIDs provided as separate arguments
+# EXAMPLES
+#   # default VRF (no vrf args), three SIDs:
 #   set_srv6_route 192.168.0.0/16 gmydsn1 \
 #       fd00:202::2 fd00:202::3 fd00:202::4
+#
+#   # L3VPN encap: route in vrf2, encap iface in default. nexthop-vrf
+#   # is passed explicitly as the 4th positional.
+#   set_srv6_route 192.168.0.0/24 p0 vrf2 default fd00:202:100::
 #
 set_srv6_route() {
 	local persist=0
 	[ "$1" = "--persist" ] && { persist=1; shift; }
 	local prefix="$1"
 	local nhop="$2"
-	shift 2                       # all remaining words are SIDs
+	shift 2
+
+	# 3rd & 4th positional are vrf and nexthop-vrf (mirrors set_ip_route).
+	# Both optional; SIDs come last and always contain ':'. Peek $1: if
+	# it is colon-free we treat it as the vrf, then likewise for nh_vrf.
+	local vrf_name="default"
+	local nexthop_vrf_name=""
+	if [ -n "$1" ] && [[ "$1" != *:* ]]; then
+		vrf_name="$1"
+		shift
+		if [ -n "$1" ] && [[ "$1" != *:* ]]; then
+			nexthop_vrf_name="$1"
+			shift
+		fi
+	fi
 
 	# ----- collect SIDs ----------------------------------------------------
 	local sids=()
@@ -206,9 +225,16 @@ set_srv6_route() {
 	local seg_frr="${sids[*]}"
 	seg_frr=${seg_frr// //}
 
+	# grout names the default VRF "main"; rest match by name.
+	local gr_vrf_name="${vrf_name}"
+	[ "$gr_vrf_name" = "default" ] && gr_vrf_name="main"
+
+	local nh_vrf_clause=""
+	[ -n "$nexthop_vrf_name" ] && nh_vrf_clause=" nexthop-vrf ${nexthop_vrf_name}"
+
 	_apply_frr_config "$persist" \
-		"$route add: vrf=.+ $prefix origin=zebra_static via type=SRv6 .*${sids[0]}" \
-		"${frr_ip} route ${prefix} ${nhop} segments ${seg_frr}"
+		"$route add: vrf=$gr_vrf_name $prefix origin=zebra_static via type=SRv6 .*${sids[0]}" \
+		"${frr_ip} route ${prefix} ${nhop} segments ${seg_frr} vrf ${vrf_name}${nh_vrf_clause}"
 }
 
 # kill_frr_daemons <daemon> [<daemon>...]

--- a/smoke/frr_restart_graceful_frr_test.sh
+++ b/smoke/frr_restart_graceful_frr_test.sh
@@ -41,14 +41,29 @@ export WATCHFRR_EXTRA_OPTS="--min-restart-interval=1"
 
 prefix_orphan=10.99.99.0/24
 prefix_kept=10.88.88.0/24
+sr6_orphan=192.168.99.0/24
+sr6_kept=192.168.88.0/24
+sr6_orphan_sid=fd00:202:100::
+sr6_kept_sid=fd00:202:200::
+sr6_localsid_orphan=fd00:202:300::
+sr6_localsid_kept=fd00:202:400::
 nh_ip=172.16.0.2
+nh6_ip=fd00:102::2
+
+# A second VRF is required so the two SR6_LOCAL SIDs land in distinct
+# (behavior, vrf) contexts in zebra's SRv6 manager. With a single VRF
+# the second sid request would release the first one rather than
+# coexist.
+create_vrf vrf2
 
 create_interface p0
 set_ip_address p0 172.16.0.1/24
+set_ip_address p0 fd00:102::1/64
 
 netns_add n0
 move_to_netns x-p0 n0
 ip -n n0 addr add ${nh_ip}/24 dev x-p0
+ip -n n0 addr add ${nh6_ip}/64 dev x-p0
 
 # The *_orphan entries stay vty-only: their install vanishes from
 # staticd memory after SIGKILL, the plugin's SELFROUTE placeholders
@@ -59,6 +74,21 @@ ip -n n0 addr add ${nh_ip}/24 dev x-p0
 set_ip_route $prefix_orphan $nh_ip
 set_ip_route --persist $prefix_kept $nh_ip
 
+# Reachability for the SID block + SR6_OUTPUT prefixes.
+set_ip_route --persist fd00:202::/32 $nh6_ip
+# L3VPN shape: customer prefix in vrf2, encap nexthop on p0 in default.
+# This is the cross-vrf encap case (route.vrf != nh.vrf) that the dump
+# path must preserve through restart; without the gr_r4->vrf_id fix in
+# rt_grout.c, the prefix gets re-injected into zebra's main vrf at
+# startup and sweep then misses the real entry in grout's vrf2.
+set_srv6_route $sr6_orphan p0 vrf2 default $sr6_orphan_sid
+set_srv6_route --persist $sr6_kept p0 vrf2 default $sr6_kept_sid
+
+# SR6_LOCAL static-SIDs. Two SIDs need two distinct (behavior, vrf)
+# contexts: the orphan decaps into the default VRF, the kept one
+# into vrf2. Only the kept SID is persisted to frr.conf.
+set_srv6_localsid loc1 fd00:202 $sr6_localsid_orphan
+set_srv6_localsid --persist loc1 fd00:202 $sr6_localsid_kept end.dt4 vrf2
 
 grcli -j route show | jq -e \
 	".[] | select(.destination == \"$prefix_orphan\")" >/dev/null \
@@ -66,6 +96,18 @@ grcli -j route show | jq -e \
 grcli -j route show | jq -e \
 	".[] | select(.destination == \"$prefix_kept\")" >/dev/null \
 	|| fail "prefix $prefix_kept not installed in grout FIB"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_orphan\")" >/dev/null \
+	|| fail "prefix $sr6_orphan not installed in grout FIB"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_kept\")" >/dev/null \
+	|| fail "prefix $sr6_kept not installed in grout FIB"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_localsid_orphan/48\")" >/dev/null \
+	|| fail "static-SID $sr6_localsid_orphan/48 not installed in grout FIB"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_localsid_kept/48\")" >/dev/null \
+	|| fail "static-SID $sr6_localsid_kept/48 not installed in grout FIB"
 
 mark_events
 # Mark frr_log so the marker wait skips start_frr's earlier emission.
@@ -89,14 +131,28 @@ kill_frr_daemons zebra staticd
 
 # Del events propagate to grout in <1s. Reclaimed routes must NOT emit a del.
 wait_event -t 3 "route4 del: vrf=main $prefix_orphan"
+wait_event -t 3 "route4 del: vrf=vrf2 $sr6_orphan"
+wait_event -t 3 "route6 del: vrf=main $sr6_localsid_orphan/48"
 
 grcli -j route show | jq -e \
 	".[] | select(.destination == \"$prefix_orphan\")" >/dev/null \
 	&& fail "$prefix_orphan still in grout FIB after sweep"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_orphan\")" >/dev/null \
+	&& fail "$sr6_orphan still in grout FIB after sweep"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_localsid_orphan/48\")" >/dev/null \
+	&& fail "$sr6_localsid_orphan/48 still in grout FIB after sweep"
 
 grcli -j route show | jq -e \
 	".[] | select(.destination == \"$prefix_kept\")" >/dev/null \
 	|| fail "$prefix_kept unexpectedly gone from grout FIB after sweep (reclaim broken)"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_kept\")" >/dev/null \
+	|| fail "$sr6_kept unexpectedly gone from grout FIB after sweep (SR6 reclaim broken)"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$sr6_localsid_kept/48\")" >/dev/null \
+	|| fail "$sr6_localsid_kept/48 unexpectedly gone from grout FIB after sweep (SR6_LOCAL reclaim broken)"
 
 # In zebra's RIB the reclaimed prefix must be ZEBRA_ROUTE_STATIC, not
 # kernel/self: rib_compare_routes transferred ownership from the
@@ -104,6 +160,13 @@ grcli -j route show | jq -e \
 vtysh -c "show ip route $prefix_kept" 2>/dev/null \
 	| grep -qE 'Known via "static"' \
 	|| fail "$prefix_kept is not a static route in zebra RIB after reclaim"
+vtysh -c "show ip route vrf vrf2 $sr6_kept" 2>/dev/null \
+	| grep -qE 'Known via "static"' \
+	|| fail "$sr6_kept is not a static route in zebra vrf2 RIB after reclaim"
+vtysh -c "show ip route vrf vrf2 $sr6_kept json" 2>/dev/null \
+	| jq -e ".\"$sr6_kept\"[].nexthops[] | select(.seg6.segs == \"$sr6_kept_sid\")" \
+	>/dev/null \
+	|| fail "$sr6_kept lost its seg6 SID after reclaim"
 
 # Marker must not leak into the dataplane.
 grcli -j route show | jq -e \
@@ -116,10 +179,13 @@ out=$(vtysh -c "show ipv6 route ::/128 json" 2>/dev/null)
 
 # zebra's RIB must contain exactly the static routes declared in frr.conf
 # ($prefix_kept was appended; $prefix_orphan was vty-only and must be swept).
+# Count across all VRFs since the SR6 L3VPN entry lives in vrf2.
 expected=$(grep -cE '^[[:space:]]*ip route ' "$builddir/frr_install/etc/frr/frr.conf" || true)
-actual=$(vtysh -c "show ip route static json" 2>/dev/null | jq 'length // 0')
+actual_default=$(vtysh -c "show ip route static json" 2>/dev/null | jq 'length // 0')
+actual_vrf2=$(vtysh -c "show ip route vrf vrf2 static json" 2>/dev/null | jq 'length // 0')
+actual=$((actual_default + actual_vrf2))
 [ "$expected" = "$actual" ] \
-	|| fail "static route count mismatch: expected $expected from frr.conf, got $actual"
+	|| fail "static route count mismatch: expected $expected from frr.conf, got $actual (default=$actual_default vrf2=$actual_vrf2)"
 
 # Sweep ran exactly once: the placeholder pre-arm in zd_grout_plugin_init
 # neutralised zebra_main_router_started's native arm (event_add_timer

--- a/smoke/frr_restart_graceful_frr_test.sh
+++ b/smoke/frr_restart_graceful_frr_test.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+# Graceful restart test: zebra is killed along with its clients while
+# grout keeps running. On restart with -K 5 the plugin re-injects the
+# orphan routes as SELFROUTE; staticd (re-reading the persisted config)
+# re-pushes the static route via zapi. rib_compare_routes transfers
+# ownership of the reclaimed route. At T0+5 rib_sweep_route fires:
+# the orphan route is purged, the reclaimed one survives.
+#
+# zd_grout_plugin_init pre-arms zrouter.t_rib_sweep with a long delay so
+# zebra_main_router_started()'s own event_add_timer(rib_sweep_route, K,
+# &zrouter.t_rib_sweep) is a no-op (*t_ptr != NULL early-return,
+# lib/event.c:1430). grout_sync_arm_sweep replaces the placeholder with
+# the real clamped delay once the replay marker is observed.
+#
+# Follows the pattern of FRR upstream tests/topotests/zebra_graceful_restart
+# (PR 21550) but uses staticd with two prefixes instead of sharpd+staticd:
+#   - $prefix_orphan: installed via vtysh runtime only, never persisted;
+#                     staticd loses it on restart, plugin's SELFROUTE
+#                     placeholder is never reclaimed, sweep wipes it.
+#   - $prefix_kept:   installed via vtysh AND appended to frr.conf so
+#                     staticd rehydrates it at restart and re-pushes via
+#                     zapi within the -K window. rib_compare_routes
+#                     promotes the SELFROUTE entry to ZEBRA_ROUTE_STATIC;
+#                     the sweep predicate no longer matches and the
+#                     route survives.
+
+# -K5: graceful restart window so staticd can re-push $prefix_kept
+# before the sweep fires. Set BEFORE start_frr so watchfrr caches the
+# args and respawns zebra with -K5 after the simulated crash.
+export ZEBRA_EXTRA_OPTS="-K5"
+
+# Watchfrr's default min-restart-interval is 60s, which silently postpones
+# zebra's respawn after SIGKILL well beyond any sane test timeout. Drop
+# it to 1s so the respawn is observable within the 10s pid-change poll.
+export WATCHFRR_EXTRA_OPTS="--min-restart-interval=1"
+
+. $(dirname $0)/_init_frr.sh
+
+prefix_orphan=10.99.99.0/24
+prefix_kept=10.88.88.0/24
+nh_ip=172.16.0.2
+
+create_interface p0
+set_ip_address p0 172.16.0.1/24
+
+netns_add n0
+move_to_netns x-p0 n0
+ip -n n0 addr add ${nh_ip}/24 dev x-p0
+
+# The *_orphan entries stay vty-only: their install vanishes from
+# staticd memory after SIGKILL, the plugin's SELFROUTE placeholders
+# end up unreclaimed and swept. The *_kept entries are also written
+# to frr.conf via --persist so staticd rehydrates them via mgmtd at
+# restart and rib_compare_routes transfers ownership of the
+# SELFROUTE entries to ZEBRA_ROUTE_STATIC.
+set_ip_route $prefix_orphan $nh_ip
+set_ip_route --persist $prefix_kept $nh_ip
+
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix_orphan\")" >/dev/null \
+	|| fail "prefix $prefix_orphan not installed in grout FIB"
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix_kept\")" >/dev/null \
+	|| fail "prefix $prefix_kept not installed in grout FIB"
+
+mark_events
+# Mark frr_log so the marker wait skips start_frr's earlier emission.
+frr_log_mark=$(wc -l < "$frr_log")
+
+# Simulate crash: SIGKILL zebra + staticd. Watchfrr respawns them with
+# the cached argv (zebra_options="... -K5" from ZEBRA_EXTRA_OPTS at the
+# top of this test), so the new zebra honours the graceful restart
+# window.
+kill_frr_daemons zebra staticd
+
+# Gate 1: end-of-sync (marker observed = arm_sweep ran, timer armed).
+{ tail -f -n +$((frr_log_mark + 1)) "$frr_log" || : ; } | \
+	timeout 20 grep -m 1 -E "sync marker observed" >/dev/null \
+	|| fail "timeout 20s waiting for FRR sync marker after restart"
+
+# Gate 2: sweep actually fired (covers 5s -K + event loop config replay).
+{ tail -f -n +$((frr_log_mark + 1)) "$frr_log" || : ; } | \
+	timeout 15 grep -m 1 -E "Sweeping the RIB for stale routes" >/dev/null \
+	|| fail "timeout 15s waiting for rib_sweep_route to fire"
+
+# Del events propagate to grout in <1s. Reclaimed routes must NOT emit a del.
+wait_event -t 3 "route4 del: vrf=main $prefix_orphan"
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix_orphan\")" >/dev/null \
+	&& fail "$prefix_orphan still in grout FIB after sweep"
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix_kept\")" >/dev/null \
+	|| fail "$prefix_kept unexpectedly gone from grout FIB after sweep (reclaim broken)"
+
+# In zebra's RIB the reclaimed prefix must be ZEBRA_ROUTE_STATIC, not
+# kernel/self: rib_compare_routes transferred ownership from the
+# plugin's SELFROUTE injection to staticd's re-push.
+vtysh -c "show ip route $prefix_kept" 2>/dev/null \
+	| grep -qE 'Known via "static"' \
+	|| fail "$prefix_kept is not a static route in zebra RIB after reclaim"
+
+# Marker must not leak into the dataplane.
+grcli -j route show | jq -e \
+	'.[] | select(.destination == "::/128")' >/dev/null \
+	&& fail "sync marker ::/128 leaked into grout FIB"
+
+out=$(vtysh -c "show ipv6 route ::/128 json" 2>/dev/null)
+[ -z "$out" ] || [ "$out" = "{}" ] \
+	|| fail "sync marker ::/128 still in zebra RIB after sweep"
+
+# zebra's RIB must contain exactly the static routes declared in frr.conf
+# ($prefix_kept was appended; $prefix_orphan was vty-only and must be swept).
+expected=$(grep -cE '^[[:space:]]*ip route ' "$builddir/frr_install/etc/frr/frr.conf" || true)
+actual=$(vtysh -c "show ip route static json" 2>/dev/null | jq 'length // 0')
+[ "$expected" = "$actual" ] \
+	|| fail "static route count mismatch: expected $expected from frr.conf, got $actual"
+
+# Sweep ran exactly once: the placeholder pre-arm in zd_grout_plugin_init
+# neutralised zebra_main_router_started's native arm (event_add_timer
+# *t_ptr != NULL early-return), and grout_sync_arm_sweep's cancel + arm
+# is the only fire. Any count > 1 means the pre-arm trick regressed.
+sweep_count=$(tail -n +$((frr_log_mark + 1)) "$frr_log" \
+	| grep -cE 'Sweeping the RIB for stale routes\.\.\.$' || true)
+[ "$sweep_count" -eq 1 ] \
+	|| fail "expected exactly 1 sweep invocation, found $sweep_count (pre-arm placeholder regressed)"
+
+true

--- a/smoke/frr_restart_sweep_no_k_frr_test.sh
+++ b/smoke/frr_restart_sweep_no_k_frr_test.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+# Variant of frr_restart_graceful_frr_test.sh that proves the plugin's
+# t_rib_sweep control path works with the default zebra invocation
+# (no -K option). Without the pre-arm of zrouter.t_rib_sweep in
+# zd_grout_plugin_init, the native sweep armed by zebra_main_router_started()
+# with delay=0 would race our SELFROUTE injections and produce inconsistent
+# timing. The pre-arm exploits event_add_timer's *t_ptr != NULL early-return
+# (lib/event.c:1430) so the native arm becomes a no-op; the plugin then
+# cancels and re-arms with the proper delay after the replay marker is
+# observed. This test asserts that:
+#   - the route is still swept (no leak),
+#   - the plugin's sync marker is observed (arm_sweep ran),
+#   - marker lifecycle is clean (not in FIB, not in RIB after sweep).
+
+# Watchfrr's default min-restart-interval is 60s, which silently postpones
+# zebra's respawn after SIGKILL well beyond any sane test timeout. Drop
+# it to 1s so the respawn is observable within the 10s pid-change poll.
+export WATCHFRR_EXTRA_OPTS="--min-restart-interval=1"
+
+. $(dirname $0)/_init_frr.sh
+
+prefix=10.99.99.0/24
+nh_ip=172.16.0.2
+
+create_interface p0
+set_ip_address p0 172.16.0.1/24
+
+netns_add n0
+move_to_netns x-p0 n0
+ip -n n0 addr add ${nh_ip}/24 dev x-p0
+
+set_ip_route $prefix $nh_ip
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix\")" >/dev/null \
+	|| fail "prefix $prefix not installed in grout FIB"
+
+grcli -j nexthop show | jq -e \
+	".[] | select(.origin == \"zebra\" and (.info | contains(\"$nh_ip\")))" >/dev/null \
+	|| fail "zebra nexthop for $nh_ip not installed in grout FIB"
+
+mark_events
+# Mark frr_log so the marker wait skips start_frr's earlier emission.
+frr_log_mark=$(wc -l < "$frr_log")
+
+# Simulate crash: SIGKILL zebra + staticd. Watchfrr respawns them.
+# Key difference vs frr_restart_graceful_frr_test.sh: ZEBRA_EXTRA_OPTS
+# is unset, so zebra comes back without -K.
+# zebra_main_router_started() will try to arm t_rib_sweep with delay=0
+# (graceful_restart=false) - but zd_grout_plugin_init already pre-armed
+# that slot with a long delay, so event_add_timer returns early and the
+# native arm is a no-op. grout_sync_arm_sweep later cancels the
+# placeholder and re-arms with delay=0 once the replay marker is seen.
+kill_frr_daemons zebra staticd
+
+# Gate 1: end-of-sync (marker observed = arm_sweep ran, timer armed at 0).
+{ tail -f -n +$((frr_log_mark + 1)) "$frr_log" || : ; } | \
+	timeout 20 grep -m 1 -E "sync marker observed" >/dev/null \
+	|| fail "timeout 20s waiting for FRR sync marker after restart"
+
+# Gate 2: sweep actually fired (delay=0, only event loop dispatch slack).
+{ tail -f -n +$((frr_log_mark + 1)) "$frr_log" || : ; } | \
+	timeout 5 grep -m 1 -E "Sweeping the RIB for stale routes" >/dev/null \
+	|| fail "timeout 5s waiting for rib_sweep_route to fire"
+
+# Del event propagates to grout in <1s.
+# We skip the nh del assertion: without -K, the sweep races mgmtd's zapi
+# apply of "nexthop-group keep 1" so the NHE keep-around defaults to 180s
+# (an FRR pre-existing limitation, unrelated to this plugin fix).
+wait_event -t 3 "route4 del: vrf=main $prefix"
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix\")" >/dev/null \
+	&& fail "prefix $prefix still in grout FIB after sweep"
+
+# The sweep ran exactly once. With the pre-arm placeholder in
+# zd_grout_plugin_init, zebra_main_router_started's native
+# event_add_timer(..., 0, &zrouter.t_rib_sweep) is a no-op (*t_ptr
+# already set); only grout_sync_arm_sweep's cancel+arm produces a real
+# rib_sweep_route fire. Any count > 1 would mean the pre-arm regressed.
+sweep_count=$(tail -n +$((frr_log_mark + 1)) "$frr_log" \
+	| grep -cE 'Sweeping the RIB for stale routes\.\.\.$' || true)
+[ "$sweep_count" -eq 1 ] \
+	|| fail "expected exactly 1 sweep invocation, found $sweep_count (pre-arm placeholder regressed)"
+
+# Marker never reached grout's FIB.
+grcli -j route show | jq -e \
+	'.[] | select(.destination == "::/128")' >/dev/null \
+	&& fail "sync marker ::/128 leaked into grout FIB"
+
+# Marker prefix must be absent from zebra's RIB after sweep.
+out=$(vtysh -c "show ipv6 route ::/128 json" 2>/dev/null)
+[ -z "$out" ] || [ "$out" = "{}" ] \
+	|| fail "sync marker ::/128 still in zebra RIB after sweep"
+
+# zebra's RIB must contain exactly the static routes declared in frr.conf
+# (none here - $prefix was added via vty only and must be swept).
+expected=$(grep -cE '^[[:space:]]*ip route ' "$builddir/frr_install/etc/frr/frr.conf" || true)
+actual=$(vtysh -c "show ip route static json" 2>/dev/null | jq 'length // 0')
+[ "$expected" = "$actual" ] \
+	|| fail "static route count mismatch: expected $expected from frr.conf, got $actual"
+
+true

--- a/smoke/grout_restart_resync_frr_test.sh
+++ b/smoke/grout_restart_resync_frr_test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+# Grout restart test: grout is SIGKILL'd while FRR keeps running, then
+# respawned with a fresh empty FIB (simulating initd auto-restart in a
+# real deployment). The plugin detects the broken socket, calls
+# grout_ns_reset which wipes zebra's RIB via vrf_terminate(), then
+# resyncs from the repopulated grout. staticd (still alive across the
+# crash) re-pushes its route via zapi once the interface comes back up.
+#
+# Complements frr_restart_graceful_frr_test.sh which covers the
+# opposite direction (zebra crash while grout survives). Here we
+# validate that zebra's RIB and grout's FIB reconverge without manual
+# intervention after a grout crash.
+
+. $(dirname $0)/_init_frr.sh
+
+prefix=10.99.99.0/24
+nh_ip=172.16.0.2
+
+create_interface p0
+set_ip_address p0 172.16.0.1/24
+
+netns_add n0
+move_to_netns x-p0 n0
+ip -n n0 addr add ${nh_ip}/24 dev x-p0
+
+set_ip_route $prefix $nh_ip
+
+grcli -j route show | jq -e \
+	".[] | select(.destination == \"$prefix\")" >/dev/null \
+	|| fail "prefix $prefix not in grout FIB pre-crash"
+
+vtysh -c "show ip route $prefix" 2>/dev/null \
+	| grep -qE 'Known via "static"' \
+	|| fail "$prefix not a static route in zebra RIB pre-crash"
+
+# Simulate grout crash. initd would respawn grout in a real
+# deployment; restart_grout does the equivalent here.
+restart_grout
+
+# Replay what initd's post-restart script does in prod: recreate the
+# port and re-assign the address. The plugin is expected to detect
+# the reconnect, wipe zebra's RIB via vrf_terminate, then resync from
+# this repopulated grout. staticd (still alive across the grout
+# crash) re-pushes its route via zapi once the nexthop becomes
+# resolvable again.
+grcli route config set default rib4-routes 128 rib6-routes 128
+grcli interface add port p0 devargs net_tap0,iface=x-p0
+grcli address add 172.16.0.1/24 iface p0
+
+# Wait for the plugin's resync to finish: the static route pushed by
+# staticd (which survived the crash) should reappear in grout's FIB
+# once the plugin has replayed ifaces/addrs and staticd has re-pushed
+# via zapi.
+wait_event -t 30 "route4 add: vrf=main $prefix"
+
+vtysh -c "show ip route $prefix" 2>/dev/null \
+	| grep -qE 'Known via "static"' \
+	|| fail "$prefix not reclaimed as static in zebra RIB after resync"
+
+true


### PR DESCRIPTION
When zebra is killed and restarted while grout keeps running, grout's FIB retains every route the previous FRR instance had installed. With the current plugin those routes become orphans: the startup sync explicitly drops every self-originated route returned by the grout dump (rt_grout.c:337) so zebra's RIB never sees them, and no mechanism ever garbage-collects them from grout. Unreclaimed prefixes linger indefinitely and can blackhole traffic to stale nexthops.

Upstream FRR solves the same problem for the kernel dplane through the ZEBRA_FLAG_SELFROUTE flag, rib_sweep_route and the GR_RUN metaQ sub-queue: kernel-read routes are re-inserted as selfroute placeholders with a pre-startup uptime; protocol clients take them over via rib_compare_routes when they re-announce; anything unreclaimed is purged when rib_sweep_route fires after -K seconds. The grout plugin could not reuse that directly because grout_sync runs from frr_config_post, which is after zebra_main_router_started() has already stamped zrouter.startup_time and armed t_rib_sweep. Entries created in grout_sync therefore have uptime > startup_time and would never match the sweep predicate, and the sweep itself is already scheduled.

Transplant the mechanism into the plugin:

* Thread a bool startup flag through grout_route4_change / grout_route6_change / grout_route_change (mirroring the existing grout_nexthop_change signature), true on the initial dump path, false on asynchronous notifications. The blanket self-origin skip stays for the notification case (an echo of an install we sent) but becomes injection for the dump case: build the route_entry with ZEBRA_FLAG_SELFROUTE and force re->uptime = zrouter.startup_time so the sweep predicate SELFROUTE && uptime <= startup_time matches, and rib_compare_routes will replace the placeholder cleanly when a client reclaims the prefix.

* In grout_add_del_route, short-circuit DPLANE_OP_ROUTE_INSTALL and DPLANE_OP_ROUTE_UPDATE when the ctx carries ZEBRA_FLAG_SELFROUTE. Those are the routes we just learned from grout; pushing them back down would be a redundant round-trip. DPLANE_OP_ROUTE_DELETE is left alone so the sweep's uninstall reaches grout via the normal flow.

* At the very end of the sync chain (last VRF of grout_sync_routes), cancel zrouter.t_rib_sweep and re-arm it with delay equal to the operator's -K value. This aligns the sweep on sync_complete + -K instead of startup_time + -K, giving our backdated SELFROUTE entries the full reclaim window the operator asked for. The -K value is recovered by re-parsing /proc/self/cmdline with getopt_long on a minimal option table: zebra_di.gr_cleanup_time is static in main.c and not exported, re-invoking frr_getopt would re-run frr_opt() with its side effects (exit on -h/-v, double-allocation of modules, errors++ path), and zrouter.t_rib_sweep loses the -K value once it has fired, so none of those routes are reliable. /proc/self/cmdline always holds the original argv. When -K was passed without a value the plugin falls back to ZEBRA_GR_DEFAULT_RIB_SWEEP_TIME exactly as zebra itself does; non-GR startups keep delay = 0 (fire immediately) to match kernel-dplane wipe semantics.

With these pieces in place, zebra's existing SELFROUTE machinery works uniformly over grout-injected entries:

  * Reclaim: clients reconnecting over zapi take over matching SELFROUTE entries via rib_compare_routes; the fresh entry loses SELFROUTE and has a current uptime.
  * GR_RUN (metaQ sub-q 10): per-client early cleanup triggered by ZEBRA_CLIENT_ROUTE_UPDATE_COMPLETE works automatically because our entries carry the real protocol type (via origin2zebra) and a backdated uptime (older than client->restart_time).
  * rib_sweep_route catch-all: reprogrammed to fire after the full grout sync chain completes, purges any SELFROUTE entry nobody reclaimed, and the subsequent DPLANE_OP_ROUTE_DELETE ctxs flow through grout_add_del_route to remove the routes from grout's FIB (the install guard above is install/update only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Problem
When zebra is killed and restarted while grout remains running, grout's FIB retains routes installed by the previous FRR instance. The plugin’s startup sync currently drops self-originated routes returned by the grout dump so zebra’s RIB never sees them; without a reclamation path these prefixes persist in grout and can blackhole traffic.

## Technical changes

Route handling during startup sync
- Thread a startup boolean through grout_route4_change(), grout_route6_change(), and grout_route_change() (true for initial dump, false for async notifications).
- For dump-path entries, set ZEBRA_FLAG_SELFROUTE on the created route_entry and backdate re->uptime to zrouter.startup_time so they match the sweep predicate (SELFROUTE && uptime <= startup_time) and are reclaimable when protocol clients reannounce.
- Preserve existing self-origin skip behavior for notification-path entries.

Dplane operations
- In grout_add_del_route(), short-circuit DPLANE_OP_ROUTE_INSTALL and DPLANE_OP_ROUTE_UPDATE when the dplane context carries ZEBRA_FLAG_SELFROUTE (return success without redundant install/update round-trips).
- Leave DPLANE_OP_ROUTE_DELETE unchanged so rib_sweep_route can uninstall unreclaimed SELFROUTE entries.
- Add a targeted delete short-circuit for the SRTE end-of-replay sync marker to avoid needless uninstall round-trips.

Nexthop handling
- When startup is true, lookup corresponding nexthop-hash entries and backdate their uptime to zrouter.startup_time; log a warning if the nexthop entry cannot be found.

Sweep rescheduling and sync marker
- Append an IPv6 self-route sync marker (::/128) tagged with GROUT_SYNC_MARKER_TAG during replay to detect end-of-replay visibility.
- After the last VRF in grout_sync_routes completes, cancel any prior zrouter.t_rib_sweep and re-arm it with a delay equal to the operator’s -K value (re-parsed from /proc/self/cmdline once via getopt_long and cached; fallback to ZEBRA_GR_DEFAULT_RIB_SWEEP_TIME if -K provided without a value; non-GR startups keep delay = 0).
- Defer arming rib_sweep_route until the marker is observed (or max retry reached), so backdated SELFROUTE entries receive the intended reclaim window; delete the marker once observed.

API/signature changes
- grout_route4_change(bool new, struct gr_ip4_route *gr_r4) → grout_route4_change(bool new, struct gr_ip4_route *gr_r4, bool startup)
- grout_route6_change(bool new, struct gr_ip6_route *gr_r6) → grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup)
- grout_route_change(...) now accepts a bool startup parameter.
- Add public constant GROUT_SYNC_MARKER_TAG.

Tests and infra
- New smoke tests:
  - smoke/frr_restart_graceful_frr_test.sh: validates graceful restart with -K5, ensuring orphan routes are swept while configured routes persist and are reclassified in zebra.
  - smoke/frr_restart_sweep_no_k_frr_test.sh: validates sweep behavior when zebra is started without -K.
  - smoke/grout_restart_resync_frr_test.sh: validates grout self-resynchronization after grout restart while FRR remains running.
- smoke/_init_frr.sh: keep flog variable non-local so tests can inspect log file after start.

Behavioral outcomes
- Reconnecting protocol clients reclaim matching SELFROUTE entries via rib_compare_routes() (SELFROUTE removed, uptime updated to current).
- Per-client early cleanup functions operate correctly because entries carry protocol type and backdated uptime.
- rib_sweep_route, after the rescheduled delay, purges unreclaimed SELFROUTE entries and causes DPLANE_OP_ROUTE_DELETE flows that remove routes from grout’s FIB.

Status
- Work in progress: unit tests still in development; author notes upstream FRR PR FRRouting/frr#21550 addresses similar kernel-dplane startup cases and recommends auditing NHG cleanup across zebra restarts as follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->