### PR TITLE
Build multiarch image

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,9 @@ jobs:
             asan: true
             debug: true
           - compiler: gcc-14
+            frr: '10.5'
+            arch: arm
+          - compiler: gcc-14
             frr: '10.6'
           - compiler: gcc-14
             frr: 'master'
@@ -40,7 +43,7 @@ jobs:
             frr: '10.5'
           - compiler: clang-18
             frr: '10.5'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04${{ matrix.conf.arch == 'arm' && '-arm' || '' }}
     env:
       SANITIZE: ${{ case(matrix.conf.asan || false, 'address', 'none') }}
       BUILDTYPE: ${{ case(matrix.conf.debug || false, 'debug', 'debugoptimized') }}
@@ -83,7 +86,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-${{ matrix.conf.compiler }}
+          key: ccache-${{ matrix.conf.arch }}-${{ matrix.conf.compiler }}
       - run: ccache -z
       - run: git rebase -x .github/workflows/check.sh "HEAD~${{ github.event.pull_request.commits }}"
         if: ${{ matrix.conf.rebase && github.event.pull_request.commits }}
@@ -109,70 +112,6 @@ jobs:
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ steps.cache.outputs.cache-primary-key }}
-
-  build-cross-aarch64:
-    if: ${{ github.actor != 'grout-bot' }}
-    permissions:
-      actions: write
-    runs-on: ubuntu-24.04
-    container: debian:stable
-    env:
-      MESON_EXTRA_OPTS: --cross-file=devtools/cross/aarch64.ini
-      DEBIAN_FRONTEND: noninteractive
-      NEEDRESTART_MODE: l
-    steps:
-      - name: install system dependencies
-        run: |
-          set -xe
-          dpkg --add-architecture arm64
-          apt update -qy
-          apt install -qy --no-install-recommends \
-            make gcc ccache git meson scdoc python3-pyelftools python3-dev \
-            ca-certificates pkg-config autoconf automake bison flex patch \
-            libyang3-tools libtool libelf-dev crossbuild-essential-arm64 \
-            libcmocka-dev:arm64 libedit-dev:arm64 libevent-dev:arm64 \
-            libmnl-dev:arm64 libnuma-dev:arm64 libjson-c-dev:arm64 \
-            libprotobuf-c-dev:arm64 protobuf-c-compiler libreadline-dev:arm64 \
-            libcap-dev:arm64 librtr-dev:arm64 libyang-dev:arm64
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          fetch-depth: 0 # force fetch all history
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - run: git config --global --add safe.directory $PWD
-      - run: git fetch --force origin 'refs/tags/v*:refs/tags/v*'
-      - run: echo "CCACHE_DIR=$(ccache -k cache_dir)" >> $GITHUB_ENV
-      - uses: actions/cache/restore@v4
-        id: cache
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ccache-aarch64
-      - run: ccache -z
-      - run: git rebase -x .github/workflows/check.sh "HEAD~${{ github.event.pull_request.commits }}"
-        if: ${{ github.event.pull_request.commits }}
-      - run: .github/workflows/check.sh
-        if: ${{ ! github.event.pull_request.commits }}
-      - run: ccache -sv
-      - name: delete old cache
-        if: ${{ ! github.event.pull_request.commits }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.actions.deleteActionsCacheByKey({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                key: "${{ steps.cache.outputs.cache-primary-key }}"
-              });
-            } catch (error) {
-              if (error.status !== 404) throw error;
-            }
-      - uses: actions/cache/save@v4
-        if: ${{ ! github.event.pull_request.commits }}
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          key: ${{ steps.cache.outputs.cache-primary-key }}
-
   lint:
     if: ${{ github.actor != 'grout-bot' }}
     runs-on: ubuntu-24.04

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -90,7 +90,17 @@ jobs:
     if: ${{ github.actor != 'grout-bot' }}
     permissions:
       actions: write
-    runs-on: ubuntu-24.04
+    name: rpm-${{ matrix.arch_name }}
+    strategy:
+      matrix:
+        # Define the runners you want to use
+        runs_on: [ubuntu-24.04, ubuntu-24.04-arm]
+        include:
+          - runs_on: ubuntu-24.04
+            arch_name: x86_64
+          - runs_on: ubuntu-24.04-arm
+            arch_name: aarch64
+    runs-on: ${{ matrix.runs_on }}
     container: "quay.io/centos/centos:stream10"
     steps:
       - name: install system dependencies
@@ -143,7 +153,7 @@ jobs:
         id: cache
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-x86_64-rpm
+          key: ccache-${{ matrix.runs_on }}-rpm
       - run: ccache -z
       - run: make frr-rpm CC="ccache gcc"
       - run: dnf install -y --nodocs --setopt=install_weak_deps=0 ./frr-headers.noarch.rpm
@@ -170,6 +180,6 @@ jobs:
           key: ${{ steps.cache.outputs.cache-primary-key }}
       - uses: actions/upload-artifact@v4
         with:
-          name: rpm-packages
-          path: '*.rpm'
+          name: rpm-${{ matrix.arch_name }}-packages
+          path: "*.rpm"
           retention-days: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           pattern: "*-packages"
           merge-multiple: true
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -51,7 +53,7 @@ jobs:
         name: Extract metadata for the Docker image
         id: meta-grout
         with:
-          images: "quay.io/grout/grout"
+          images: "quay.io/${{ vars.REGISTRY_NAMESPACE || 'grout' }}/grout"
           tags: |
               type=edge,branch=main
               type=semver,pattern={{version}}
@@ -60,6 +62,7 @@ jobs:
         with:
           context: .
           file: Containerfile.grout
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-grout.outputs.tags }}
           labels: ${{ steps.meta-grout.outputs.labels }}
           push: true
@@ -69,7 +72,7 @@ jobs:
         name: Extract metadata for the Docker image
         id: meta-frr
         with:
-          images: "quay.io/grout/frr"
+          images: "quay.io/${{ vars.REGISTRY_NAMESPACE || 'grout' }}/frr"
           tags: |
             type=edge,branch=main
             type=semver,pattern={{version}}
@@ -80,6 +83,7 @@ jobs:
         with:
           context: .
           file: Containerfile.frr
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta-frr.outputs.tags }}
           labels: ${{ steps.meta-frr.outputs.labels }}
           push: true

--- a/Containerfile.frr
+++ b/Containerfile.frr
@@ -4,13 +4,10 @@
 FROM quay.io/centos/centos:stream10 AS builder
 
 COPY grout-frr.*.rpm frr.*.rpm /tmp
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini_0.19.0.rpm /tmp
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini_0.19.0.rpm.sha256sum /tmp
-RUN cd /tmp && sha256sum -c tini_*.rpm.sha256sum
 RUN mkdir -p /tmp/null
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
 	--releasever 10 --installroot /tmp/null \
-	coreutils-single glibc-minimal-langpack /tmp/*.rpm
+	coreutils-single glibc-minimal-langpack catatonit /tmp/*.rpm
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/tmp/*
 RUN sed -i 's#^zebra_options=.*#zebra_options="-A 127.0.0.1 --log stdout -M dplane_grout"#' /tmp/null/etc/frr/daemons
@@ -18,5 +15,5 @@ RUN sed -i 's#^zebra_options=.*#zebra_options="-A 127.0.0.1 --log stdout -M dpla
 FROM scratch
 COPY --from=builder /tmp/null/ /
 STOPSIGNAL SIGRTMIN+3
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
 CMD ["/bin/sh", "-c", ". /usr/libexec/frr/frrcommon.sh && /usr/libexec/frr/watchfrr $(daemon_list)"]

--- a/Containerfile.frr
+++ b/Containerfile.frr
@@ -7,7 +7,8 @@ COPY grout-frr.*.rpm frr.*.rpm /tmp
 RUN mkdir -p /tmp/null
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
 	--releasever 10 --installroot /tmp/null \
-	coreutils-single glibc-minimal-langpack catatonit /tmp/*.rpm
+	coreutils-single glibc-minimal-langpack catatonit \
+	/tmp/*."`rpm --eval '%_arch'`".rpm
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/tmp/*
 RUN sed -i 's#^zebra_options=.*#zebra_options="-A 127.0.0.1 --log stdout -M dplane_grout"#' /tmp/null/etc/frr/daemons

--- a/Containerfile.grout
+++ b/Containerfile.grout
@@ -3,18 +3,15 @@
 
 FROM quay.io/centos/centos:stream10 AS builder
 COPY grout.*.rpm /tmp
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini_0.19.0.rpm /tmp
-ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini_0.19.0.rpm.sha256sum /tmp
-RUN cd /tmp && sha256sum -c tini_*.rpm.sha256sum
 RUN mkdir -p /tmp/null
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
 	--releasever 10 --installroot /tmp/null \
-	coreutils-single glibc-minimal-langpack /tmp/*.rpm
+	coreutils-single glibc-minimal-langpack catatonit /tmp/*.rpm
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
 
 FROM scratch
 COPY --from=builder /tmp/null/ /
 STOPSIGNAL SIGRTMIN+3
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
 CMD ["/usr/bin/grout"]

--- a/Containerfile.grout
+++ b/Containerfile.grout
@@ -6,7 +6,8 @@ COPY grout.*.rpm /tmp
 RUN mkdir -p /tmp/null
 RUN dnf -y install --nodocs --setopt=install_weak_deps=0 \
 	--releasever 10 --installroot /tmp/null \
-	coreutils-single glibc-minimal-langpack catatonit /tmp/*.rpm
+	coreutils-single glibc-minimal-langpack catatonit \
+	/tmp/*."`rpm --eval '%_arch'`".rpm
 RUN dnf -y --installroot /tmp/null clean all
 RUN rm -rf /tmp/null/var/cache/* /tmp/null/var/log/dnf* /tmp/null/var/log/yum.*
 


### PR DESCRIPTION
Build multiarch container for aarch64 and x86_64 machines, instead of building x86_64 only container.

Use catatonit as a signal-forwarding process manager instead of tini. It is
 available as RPM in standard fedora and centos repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Container Init Process
- Replaced init process `tini` → `catatonit` in Containerfile.grout and Containerfile.frr:
  - Removed external `tini` RPM download/verification.
  - Added `catatonit` to the packages installed into the installroot.
  - Updated ENTRYPOINT from `["/usr/bin/tini", "--"]` to `["/usr/bin/catatonit", "--"]`.
  - Preserved existing STOPSIGNAL and CMD wiring.

## Multiarch Container Builds
- publish.yml:
  - Added QEMU and Buildx setup via `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` before login.
  - Docker metadata images changed to dynamic registry namespace: `quay.io/${{ vars.REGISTRY_NAMESPACE || 'grout' }}/{image}` for both grout and frr images.
  - `docker/build-push-action@v6` calls for Containerfile.grout and Containerfile.frr set `platforms: linux/amd64,linux/arm64` and push the multi-arch images.

- package.yml:
  - Converted `rpm` job into a matrix over runners (`runs_on`: [ubuntu-24.04, ubuntu-24.04-arm]) with `include` mapping `arch_name` to `x86_64` and `aarch64`.
  - Job name set to `rpm-${{ matrix.arch_name }}` and `runs-on` derived from `matrix.runs_on`.
  - ccache restore/save key made per-runner: `ccache-${{ matrix.runs_on }}-rpm`.
  - RPM artifact upload switched to architecture-specific artifact names: `rpm-${{ matrix.arch_name }}-packages`.

- check.yml:
  - Build matrix adds an ARM variant by including `arch: arm` in a matrix entry and computes runner via `runs-on: ubuntu-24.04${{ matrix.conf.arch == 'arm' && '-arm' || '' }}`.
  - ccache cache key changed to include matrix architecture: `ccache-${{ matrix.conf.arch }}-${{ matrix.conf.compiler }}`.

## Package Installation / RPM selection
- Both Containerfile.grout and Containerfile.frr install RPMs into an installroot using an architecture-specific glob: `/tmp/*."$(rpm --eval '%_arch')".rpm`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->