### PR TITLE
icmp rate limiter

### DIFF
--- a/modules/infra/cli/icmp.c
+++ b/modules/infra/cli/icmp.c
@@ -6,6 +6,7 @@
 #include "cli_l3.h"
 
 #include <gr_api.h>
+#include <gr_ip4.h>
 #include <gr_net_types.h>
 
 #include <ecoli.h>
@@ -37,6 +38,18 @@ static cmd_status_t ping(struct gr_api_client *c, const struct ec_pnode *p) {
 
 	errno = ENOPROTOOPT;
 	return CMD_ERROR;
+}
+
+static cmd_status_t icmp_rate_limit(struct gr_api_client *c, const struct ec_pnode *p) {
+	struct gr_ip4_icmp_rl_req req;
+
+	if (arg_u32(p, "INTERVAL", &req.rate_limit))
+		return CMD_ERROR;
+
+	if (gr_api_client_send_recv(c, GR_IP4_ICMP_RATE_LIMIT, sizeof(req), &req, NULL) < 0)
+		return CMD_ERROR;
+
+	return CMD_SUCCESS;
 }
 
 static cmd_status_t traceroute(struct gr_api_client *c, const struct ec_pnode *p) {
@@ -92,6 +105,19 @@ static int ctx_init(struct ec_node *root) {
 		with_help(
 			"Icmp ident field (default: random).",
 			ec_node_uint("IDENT", 1, UINT16_MAX, 10)
+		)
+	);
+	if (ret < 0)
+		return ret;
+
+	ret = CLI_COMMAND(
+		CLI_CONTEXT(root, CTX_ARG("icmp", "Icmp rate limit config")),
+		"rate-limit (INTERVAL)",
+		icmp_rate_limit,
+		"Set the icmp rate limiter",
+		with_help(
+			"The time space interval in milliseconds",
+			ec_node_uint("INTERVAL", 1, UINT32_MAX, 10)
 		)
 	);
 

--- a/modules/ip/api/gr_ip4.h
+++ b/modules/ip/api/gr_ip4.h
@@ -39,6 +39,7 @@ enum gr_ip4_requests : uint32_t {
 	GR_IP4_ICMP_RECV,
 	GR_IP4_FIB_DEFAULT_SET,
 	GR_IP4_FIB_INFO_LIST,
+	GR_IP4_ICMP_RATE_LIMIT,
 };
 
 // routes //////////////////////////////////////////////////////////////////////
@@ -147,6 +148,12 @@ struct gr_ip4_icmp_recv_resp {
 };
 
 GR_REQ(GR_IP4_ICMP_RECV, struct gr_ip4_icmp_recv_req, struct gr_ip4_icmp_recv_resp);
+
+struct gr_ip4_icmp_rl_req {
+	uint32_t rate_limit;
+};
+
+GR_REQ(GR_IP4_ICMP_RATE_LIMIT, struct gr_ip4_icmp_rl_req, struct gr_empty);
 
 // fib info ////////////////////////////////////////////////////////////////////
 

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Christophe Fontaine
 
+#include "icmp_rl.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "log.h"
@@ -87,6 +88,13 @@ static struct rte_mbuf *get_icmp_response(uint16_t ident, uint16_t seq_num, cloc
 	return errno_set_null(ENOENT);
 }
 
+static struct api_out icmp_rate_limit(const void *request, struct api_ctx *) {
+	const struct gr_ip4_icmp_rl_req *rl = request;
+	icmp_rl_init(rl->rate_limit);
+
+	return api_out(0, 0, NULL);
+}
+
 static struct api_out icmp_send(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_send_req *req = request;
 	const struct nexthop *nh;
@@ -167,6 +175,7 @@ static void icmp_init(struct event_base *) {
 		SOCKET_ID_ANY,
 		0 // flags
 	);
+
 	if (pool == NULL)
 		ABORT("rte_mempool_create(icmp_queue) failed");
 }
@@ -191,6 +200,7 @@ RTE_INIT(icmp_module_init) {
 	module_register(&icmp_module);
 	api_handler(GR_IP4_ICMP_SEND, icmp_send);
 	api_handler(GR_IP4_ICMP_RECV, icmp_recv);
+	api_handler(GR_IP4_ICMP_RATE_LIMIT, icmp_rate_limit);
 	icmp_input_register_callback(RTE_ICMP_TYPE_DEST_UNREACHABLE, icmp_input_cb);
 	icmp_input_register_callback(RTE_ICMP_TYPE_TTL_EXCEEDED, icmp_input_cb);
 	icmp_input_register_callback(RTE_ICMP_TYPE_ECHO_REPLY, icmp_input_cb);

--- a/modules/ip/control/icmp_rl.c
+++ b/modules/ip/control/icmp_rl.c
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Farid Mihoub
+
+#include "icmp_rl.h"
+
+#include <gr_clock.h>
+
+#include <stdint.h>
+#include <time.h>
+
+static struct time_space icmp_rl = {0};
+
+void icmp_rl_init(uint32_t interval_ms) {
+	icmp_rl.interval_ms = interval_ms;
+	icmp_rl.last_ts = gr_clock_us();
+}
+
+bool icmp_rl_allow() {
+	uint64_t now = gr_clock_us();
+
+	if ((now - icmp_rl.last_ts) < (icmp_rl.interval_ms * 1000))
+		return false;
+
+	icmp_rl.last_ts = now;
+	return true;
+}

--- a/modules/ip/control/icmp_rl.h
+++ b/modules/ip/control/icmp_rl.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Farid Mihoub
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+struct time_space {
+	uint64_t last_ts;
+	uint32_t interval_ms;
+};
+
+void icmp_rl_init(uint32_t interval_ms);
+bool icmp_rl_allow();

--- a/modules/ip/control/meson.build
+++ b/modules/ip/control/meson.build
@@ -6,5 +6,6 @@ src += files(
   'icmp.c',
   'nexthop.c',
   'route.c',
+  'icmp_rl.c',
 )
 inc += include_directories('.')

--- a/modules/ip/datapath/icmp_input.c
+++ b/modules/ip/datapath/icmp_input.c
@@ -3,6 +3,7 @@
 
 #include "control_output.h"
 #include "graph.h"
+#include "icmp_rl.h"
 #include "ip4_datapath.h"
 #include "log.h"
 #include "mbuf.h"
@@ -17,6 +18,7 @@ enum {
 	CONTROL,
 	INVALID,
 	UNSUPPORTED,
+	RATE_LIMITED,
 	EDGE_COUNT,
 };
 
@@ -47,6 +49,10 @@ icmp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		if (icmp->icmp_type == RTE_ICMP_TYPE_ECHO_REQUEST) {
 			if (icmp->icmp_code != 0) {
 				edge = INVALID;
+				goto next;
+			}
+			if (!icmp_rl_allow()) {
+				edge = RATE_LIMITED;
 				goto next;
 			}
 			icmp->icmp_type = RTE_ICMP_TYPE_ECHO_REPLY;
@@ -95,6 +101,7 @@ static struct rte_node_register icmp_input_node = {
 		[CONTROL] = "control_output",
 		[INVALID] = "icmp_input_invalid",
 		[UNSUPPORTED] = "icmp_input_unsupported",
+		[RATE_LIMITED] = "icmp_rate_limited",
 	},
 };
 
@@ -109,3 +116,4 @@ GR_NODE_REGISTER(icmp_input_info);
 
 GR_DROP_REGISTER(icmp_input_invalid);
 GR_DROP_REGISTER(icmp_input_unsupported);
+GR_DROP_REGISTER(icmp_rate_limited);


### PR DESCRIPTION
Hello,

I've been studying the grout codebase and I'm looking forward to contributing to it.
As a first step, I have implemented a basic ICMP rate limiter based on time-spacing.

Before extending it, I would like your feedback on:

- Use token bucket instead of or alongside time-spacing, to support burst tolerance
- Per-type granularity via type mask, allowing independent limits per ICMP message type
- Any specifics to ICMPv6 rate limiting support

Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ICMP Rate Limiter Implementation

Implements a basic global ICMP rate limiter based on minimum time spacing between Echo Request responses.

### Core Implementation

**modules/ip/control/icmp_rl.h** and **modules/ip/control/icmp_rl.c**
- Introduces a time-spacing rate limiter with a static `time_space` structure tracking `last_ts` (microsecond timestamp) and `interval_ms` (millisecond interval).
- `icmp_rl_init(interval_ms)` initializes the limiter with caller-provided interval and captures current time via `gr_clock_us()`.
- `icmp_rl_allow()` compares elapsed microseconds against the configured interval; rejects requests occurring before the interval elapses (returns `false`), updates timestamp on acceptance (returns `true`).

### Control Plane Integration

**modules/ip/api/gr_ip4.h**
- Adds `GR_IP4_ICMP_RATE_LIMIT` request type with `struct gr_ip4_icmp_rl_req` containing a `uint32_t rate_limit` field.

**modules/ip/control/icmp.c**
- Registers `icmp_rate_limit()` API handler that receives the interval value and calls `icmp_rl_init()`.

### Data Path Integration

**modules/ip/datapath/icmp_input.c**
- Adds `RATE_LIMITED` edge to the ICMP input node state machine.
- Gates Echo Request handling with `icmp_rl_allow()` check.
- Routes rate-limited packets to dedicated `icmp_rate_limited` drop path instead of echo reply output.

### User Interface

**modules/infra/cli/icmp.c**
- Adds `icmp rate-limit (INTERVAL)` CLI command accepting interval in milliseconds (1 to UINT32_MAX).
- Parses argument and sends API request; returns error on parsing or API failure.

**modules/ip/control/meson.build**
- Adds `icmp_rl.c` to build source list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->