### PR TITLE
Frr update to 10.16.1 and fix build error on master

### DIFF
--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -115,7 +115,11 @@ void grout_link_change(struct gr_iface *gr_if, bool new, bool startup) {
 	dplane_ctx_set_ifp_zif_type(ctx, zif_type);
 	dplane_ctx_set_ifindex(ctx, ifindex_grout_to_frr(gr_if->id));
 	dplane_ctx_set_ifname(ctx, gr_if->name);
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 7, 0)
+	dplane_ctx_set_startup(ctx, startup);
+#else
 	dplane_ctx_set_ifp_startup(ctx, startup);
+#endif
 	dplane_ctx_set_ifp_family(ctx, AF_UNSPEC);
 	dplane_ctx_set_intf_txqlen(ctx, txqlen);
 

--- a/subprojects/frr-10.6.wrap
+++ b/subprojects/frr-10.6.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.6.0.tar.gz
-source_filename = frr-10.6.0.tar.gz
-source_hash = f575c821f0b6a2c9034eda0b464e6053eadce892d29ccaf54d60e601cc9f59ef
-directory = frr-frr-10.6.0
+source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.6.1.tar.gz
+source_filename = frr-10.6.1.tar.gz
+source_hash = 35f2cb4328617261db687e1d4e400c7c491b41b3aa4a109d7da9ebff0cf7e402
+directory = frr-frr-10.6.1
 patch_directory = frr
 
 [provide]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## FRR 10.6.1 subproject update and dplane startup API compatibility

### FRR dplane context startup API compatibility

Added version-conditional code in `grout_link_change()` to handle API changes between FRR versions. For FRR >= 10.7.0, calls `dplane_ctx_set_startup(ctx, startup)`. For earlier versions, calls `dplane_ctx_set_ifp_startup(ctx, startup)`. The `dplane_ctx_set_startup()` function replaced `dplane_ctx_set_ifp_startup()` in FRR 10.7.0, requiring this conditional to maintain compatibility across versions.

### FRR 10.6 subproject maintenance release

Updated `subprojects/frr-10.6.wrap` from FRR 10.6.0 to 10.6.1:
- `source_url`: updated to reference `frr-10.6.1.tar.gz`
- `source_hash`: updated to `35f2cb4328617261db687e1d4e400c7c491b41b3aa4a109d7da9ebff0cf7e402`
- `directory`: updated to `frr-frr-10.6.1`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->