### PR TITLE
ctlplane: fix confusing vlan header in traces

### DIFF
--- a/modules/dhcp/datapath/dhcp_input.c
+++ b/modules/dhcp/datapath/dhcp_input.c
@@ -102,6 +102,10 @@ dhcp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 			iface_get_eth_addr(iface, &eth->dst_addr);
 			eth->ether_type = RTE_BE16(RTE_ETHER_TYPE_IPV4);
 
+			// No VLAN header is written to the TAP. Clear the residual
+			// mbuf metadata so traces reflect the actual frame bytes.
+			iface_mbuf_data(mbuf)->vlan_id = 0;
+
 			control_output_set_cb(mbuf, iface_cp_tx, 0);
 		}
 

--- a/modules/l4/ospf_redirect.c
+++ b/modules/l4/ospf_redirect.c
@@ -6,6 +6,7 @@
 #include "ip4_datapath.h"
 #include "ip6_datapath.h"
 #include "port.h"
+#include "rxtx.h"
 
 #include <gr_infra.h>
 
@@ -110,6 +111,10 @@ static uint16_t ospf_redirect_process(
 		eth->ether_type = ether_type;
 		eth->src_addr = src;
 		eth->dst_addr = dst;
+
+		// No VLAN header is written to the TAP. Clear the residual
+		// mbuf metadata so traces reflect the actual frame bytes.
+		iface_mbuf_data(mbuf)->vlan_id = 0;
 next:
 		if (gr_mbuf_is_traced(mbuf)) {
 			gr_mbuf_trace_add(mbuf, node, 0);


### PR DESCRIPTION
When receiving an OSPF packet, the transmitted trace on the control plane interface sometimes shows a VLAN header which wasn't present on reception:

```
TRACE: [rx p0] 02:e3:ad:74:50:9b > 01:00:5e:00:00:05 / IP 172.16.0.2 > 224.0.0.5 ttl=1 proto=OSPF(89), (pkt_len=78)
TRACE: [cp tx p0] 52:54:00:00:00:01 > 01:00:5e:00:00:05 / VLAN id=4268 / IP 172.16.0.2 > 224.0.0.5 ttl=1 proto=OSPF(89), (pkt_len=78)
```

There is no VLAN in the packet and the packet lengths are equal. Nothing was inserted. The trace function just displays a garbage iface_mbuf_data->vlan_id value which wasn't reset.

Reset vlan_id before sending the packets to iface_cp_tx() like it is done in l4_loopback_output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Bug Fix

VLAN metadata was not being cleared before control-plane transmit, causing stale `vlan_id` values to appear in traces for packets that did not have VLAN headers.

## Changes

**modules/dhcp/datapath/dhcp_input.c**
- Clear `iface_mbuf_data(mbuf)->vlan_id` after prepending Ethernet and IP headers, before handing the packet to the control-plane transmit path.

**modules/l4/ospf_redirect.c**
- Clear `iface_mbuf_data(mbuf)->vlan_id` after writing the Ethernet header, before handing the packet to the control-plane transmit path.

Both changes ensure vlan_id is reset in code paths that prepend Ethernet headers, preventing stale VLAN metadata from being traced or sent via TAP frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->