### PR TITLE
ci: allow merge on frr-master test failure

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,11 +39,13 @@ jobs:
             frr: '10.6'
           - compiler: gcc-14
             frr: 'master'
+            allow_fail: true
           - compiler: clang-16
             frr: '10.5'
           - compiler: clang-18
             frr: '10.5'
     runs-on: ubuntu-24.04${{ matrix.conf.arch == 'arm' && '-arm' || '' }}
+    continue-on-error: ${{ matrix.conf.allow_fail || false }}
     env:
       SANITIZE: ${{ case(matrix.conf.asan || false, 'address', 'none') }}
       BUILDTYPE: ${{ case(matrix.conf.debug || false, 'debug', 'debugoptimized') }}


### PR DESCRIPTION
Switch the test with frr-master branch as an "non-voting" job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added `allow_fail: true` to the `gcc-14`/`frr: 'master'` matrix configuration and set `continue-on-error: ${{ matrix.conf.allow_fail || false }}` on the `build-and-tests` job. This allows the frr-master test case to fail without blocking PR merge, while other matrix configurations remain blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->