### PR TITLE
cli: fix bash completion and vxlan display bugs

### DIFF
--- a/cli/complete.c
+++ b/cli/complete.c
@@ -92,7 +92,8 @@ int bash_complete(struct ec_node *cmdlist) {
 		return ret;
 	}
 
-	gr_strcpy(buf, i, comp_line);
+	memcpy(buf, comp_line, i);
+	buf[i] = '\0';
 
 	if ((cmdlist = bash_complete_node(cmdlist)) == NULL) {
 		errorf("bash_complete_node: %s", strerror(errno));

--- a/cli/complete.c
+++ b/cli/complete.c
@@ -42,7 +42,7 @@ static struct ec_node *bash_complete_node(struct ec_node *cmdlist) {
 			EC_NO_ID,
 			ec_node("any", "prog_name"),
 			ec_node_option(EC_NO_ID, grcli_options_node()),
-			cmdlist
+			ec_node_clone(cmdlist)
 		)
 	);
 }
@@ -81,22 +81,22 @@ int bash_complete(struct ec_node *cmdlist) {
 
 	if (comp_line == NULL) {
 		errorf("COMP_LINE is not defined");
-		goto end;
+		return ret;
 	}
 	if (comp_point == NULL) {
 		errorf("COMP_POINT is not defined");
-		goto end;
+		return ret;
 	}
 	if (ec_str_parse_ullint(comp_point, 10, 0, strlen(comp_line), &i) < 0) {
 		errorf("invalid COMP_POINT value");
-		goto end;
+		return ret;
 	}
 
 	gr_strcpy(buf, i, comp_line);
 
 	if ((cmdlist = bash_complete_node(cmdlist)) == NULL) {
 		errorf("bash_complete_node: %s", strerror(errno));
-		goto end;
+		return ret;
 	}
 
 	if ((vec = ec_strvec_sh_lex_str(buf, EC_STRVEC_TRAILSP, NULL)) == NULL) {

--- a/modules/l2/cli/vxlan.c
+++ b/modules/l2/cli/vxlan.c
@@ -17,7 +17,7 @@ static void vxlan_show(struct gr_api_client *c, const struct gr_iface *iface, st
 	const struct gr_iface_info_vxlan *vxlan = (const struct gr_iface_info_vxlan *)iface->info;
 
 	gr_object_field(o, "vni", GR_DISP_INT, "%u", vxlan->vni);
-	gr_object_field(o, "local", 0, IP4_F, &vxlan->local);
+	gr_object_field(o, "local", 0, ADDR_F, ADDR_W(vxlan->local.af), &vxlan->local.addr);
 	gr_object_field(o, "encap_vrf", 0, "%s", iface_name_from_id(c, vxlan->encap_vrf_id));
 	gr_object_field(o, "dst_port", GR_DISP_INT, "%u", vxlan->dst_port);
 	gr_object_field(o, "mac", 0, ETH_F, &vxlan->mac);
@@ -30,9 +30,10 @@ vxlan_list_info(struct gr_api_client *c, const struct gr_iface *iface, char *buf
 	snprintf(
 		buf,
 		len,
-		"vni=%u local=" IP4_F " encap_vrf=%s",
+		"vni=%u local=" ADDR_F " encap_vrf=%s",
 		vxlan->vni,
-		&vxlan->local,
+		ADDR_W(vxlan->local.af),
+		&vxlan->local.addr,
 		iface_name_from_id(c, vxlan->encap_vrf_id)
 	);
 }


### PR DESCRIPTION
Fix use-after-free in bash completion mode where `bash_complete_node()` was taking ownership of the caller's `cmdlist` node, causing a double free when `main()` cleans up. Clone the node before passing it to `EC_NODE_SEQ`.

Also fix a truncation issue in bash completion where `gr_strcpy()` was cutting one character past the requested length, and fix the VXLAN local VTEP address display to handle IPv6 underlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## CLI bash completion fixes

Use-after-free in completion node handling:
- bash_complete_node() now calls ec_node_clone(cmdlist) and passes the clone into EC_NODE_SEQ/ec_node_sh_lex_expand; bash_complete() frees the cloned node with ec_node_free(cmdlist). This prevents ownership transfer of the caller's original cmdlist node and eliminates the double-free.

Buffer truncation in completion:
- bash_complete() copies exactly i bytes from COMP_LINE into buf using memcpy(buf, comp_line, i) and then sets buf[i] = '\0' instead of using gr_strcpy(buf, i, comp_line). This stops copying one character past the requested length and preserves correct next-word completion behavior.

Control-flow on error paths:
- Validation failures for COMP_LINE/COMP_POINT and COMP_POINT parsing now return immediately with failure (return ret) rather than falling through to the shared cleanup label; the shared cleanup remains responsible for freeing the cloned cmdlist and any allocated completion state.

## VXLAN display fix

IPv6-capable local VTEP address formatting:
- vxlan_show() and vxlan_list_info() switch from IPv4-specific formatting to address-family-aware formatting: they use ADDR_F with ADDR_W(vxlan->local.af) and pass &vxlan->local.addr (instead of IP4_F and vxlan->local). This allows correct rendering of the local VTEP address when the underlay is IPv6.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DPDK/grout/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->