### PR TITLE
Openmetric stats improvements

### DIFF
--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -236,6 +236,8 @@ METRIC_COUNTER(
 );
 METRIC_COUNTER(m_cp_tx_bytes, "iface_cp_tx_bytes", "Number of bytes transmitted by control plane.");
 
+METRIC_GAUGE(m_speed_bps, "iface_speed_bps", "Interface speed in bits per second.");
+
 static void iface_metrics_collect(struct metrics_writer *w) {
 	struct iface *iface = NULL;
 	struct metrics_ctx ctx;
@@ -309,6 +311,10 @@ static void iface_metrics_collect(struct metrics_writer *w) {
 		metric_emit(&ctx, &m_cp_rx_bytes, cp_rx_bytes);
 		metric_emit(&ctx, &m_cp_tx_packets, cp_tx_pkts);
 		metric_emit(&ctx, &m_cp_tx_bytes, cp_tx_bytes);
+
+		// gr_iface.speed is in Megabit/sec; convert to bit/sec for
+		// the metric. 0 means unknown / link down.
+		metric_emit(&ctx, &m_speed_bps, (uint64_t)iface->speed * 1000000ULL);
 
 		// Dispatch to type-specific collector
 		if (type->metrics_collect != NULL)

--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -7,6 +7,7 @@
 #include "module.h"
 
 #include <gr_infra.h>
+#include <gr_net_types.h>
 #include <gr_string.h>
 
 static struct gr_iface *iface_to_api(const struct iface *priv) {
@@ -242,10 +243,14 @@ static void iface_metrics_collect(struct metrics_writer *w) {
 
 	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
 		const struct iface_type *type = iface_type_get(iface->type);
+		char id_str[8];
 
+		snprintf(id_str, sizeof(id_str), "%u", iface->id);
 		metrics_ctx_init(
 			&ctx,
 			w,
+			"id",
+			id_str,
 			"name",
 			iface->name,
 			"type",
@@ -266,6 +271,14 @@ static void iface_metrics_collect(struct metrics_writer *w) {
 				&ctx, "domain", domain ? domain->name : "[deleted]", NULL
 			);
 		}
+
+		// Attach the MAC as a label so the address is reported on
+		// every per-iface metric without requiring a separate API call.
+		struct rte_ether_addr mac_addr = {0};
+		char mac_str[18] = "00:00:00:00:00:00";
+		if (iface_get_eth_addr(iface, &mac_addr) == 0)
+			snprintf(mac_str, sizeof(mac_str), ETH_F, &mac_addr);
+		metrics_labels_add(&ctx, "mac", mac_str, NULL);
 
 		metric_emit(&ctx, &m_up, !!(iface->flags & GR_IFACE_F_UP));
 		metric_emit(&ctx, &m_running, !!(iface->state & GR_IFACE_S_RUNNING));

--- a/modules/infra/api/iface.c
+++ b/modules/infra/api/iface.c
@@ -241,7 +241,6 @@ METRIC_GAUGE(m_speed_bps, "iface_speed_bps", "Interface speed in bits per second
 static void iface_metrics_collect(struct metrics_writer *w) {
 	struct iface *iface = NULL;
 	struct metrics_ctx ctx;
-	char vrf[16];
 
 	while ((iface = iface_next(GR_IFACE_TYPE_UNDEF, iface)) != NULL) {
 		const struct iface_type *type = iface_type_get(iface->type);
@@ -265,8 +264,10 @@ static void iface_metrics_collect(struct metrics_writer *w) {
 		);
 
 		if (iface->mode == GR_IFACE_MODE_VRF) {
-			snprintf(vrf, sizeof(vrf), "%u", iface->vrf_id);
-			metrics_labels_add(&ctx, "vrf", vrf, NULL);
+			const struct iface *vrf_iface = iface_from_id(iface->vrf_id);
+			metrics_labels_add(
+				&ctx, "vrf", vrf_iface ? vrf_iface->name : "[deleted]", NULL
+			);
 		} else {
 			const struct iface *domain = iface_from_id(iface->domain_id);
 			metrics_labels_add(

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -750,6 +750,40 @@ METRIC_COUNTER(m_rx_errors, "iface_port_rx_errors", "Number of RX packets with e
 METRIC_COUNTER(m_tx_errors, "iface_port_tx_errors", "Number of TX failures.");
 METRIC_COUNTER(m_port_rx_bytes, "iface_port_rx_bytes", "Number of bytes received by HW.");
 METRIC_COUNTER(m_port_tx_bytes, "iface_port_tx_bytes", "Number of bytes transmitted by HW.");
+METRIC_COUNTER(
+	m_port_xstat,
+	"iface_port_xstat",
+	"Raw PMD extended statistic. The xstat label carries the driver-native counter name."
+);
+
+static void port_xstats_emit(struct metrics_ctx *ctx, uint16_t port_id) {
+	int n = rte_eth_xstats_get_names(port_id, NULL, 0);
+	if (n <= 0)
+		return;
+
+	struct rte_eth_xstat_name *names = calloc(n, sizeof(*names));
+	struct rte_eth_xstat *values = calloc(n, sizeof(*values));
+	if (names == NULL || values == NULL)
+		goto out;
+
+	if (rte_eth_xstats_get_names(port_id, names, n) != n)
+		goto out;
+	if (rte_eth_xstats_get(port_id, values, n) != n)
+		goto out;
+
+	// Save the base label set; rewind it between iterations so each emit
+	// replaces (not appends) the xstat label.
+	size_t base_len = ctx->labels_len;
+	for (int i = 0; i < n; i++) {
+		ctx->labels_len = base_len;
+		metrics_labels_add(ctx, "xstat", names[i].name, NULL);
+		metric_emit(ctx, &m_port_xstat, values[i].value);
+	}
+	ctx->labels_len = base_len;
+out:
+	free(names);
+	free(values);
+}
 
 static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
 	const struct iface_info_port *port = iface_info_port(iface);
@@ -773,6 +807,8 @@ static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *if
 		metric_emit(ctx, &m_port_rx_bytes, stats.ibytes);
 		metric_emit(ctx, &m_port_tx_bytes, stats.obytes);
 	}
+
+	port_xstats_emit(ctx, port->port_id);
 }
 
 static struct event *link_event;

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -746,6 +746,7 @@ METRIC_GAUGE(m_txqs, "iface_port_txqs", "Number of TX queues.");
 METRIC_GAUGE(m_rxq_size, "iface_port_rxq_size", "Number of descriptors in RX queues.");
 METRIC_GAUGE(m_txq_size, "iface_port_txq_size", "Number of descriptors in TX queues.");
 METRIC_COUNTER(m_rx_missed, "iface_port_rx_missed", "Number of packets dropped by HW.");
+METRIC_COUNTER(m_rx_errors, "iface_port_rx_errors", "Number of RX packets with errors.");
 METRIC_COUNTER(m_tx_errors, "iface_port_tx_errors", "Number of TX failures.");
 
 static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
@@ -765,6 +766,7 @@ static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *if
 
 	if (rte_eth_stats_get(port->port_id, &stats) == 0) {
 		metric_emit(ctx, &m_rx_missed, stats.imissed);
+		metric_emit(ctx, &m_rx_errors, stats.ierrors);
 		metric_emit(ctx, &m_tx_errors, stats.oerrors);
 	}
 }

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -748,6 +748,8 @@ METRIC_GAUGE(m_txq_size, "iface_port_txq_size", "Number of descriptors in TX que
 METRIC_COUNTER(m_rx_missed, "iface_port_rx_missed", "Number of packets dropped by HW.");
 METRIC_COUNTER(m_rx_errors, "iface_port_rx_errors", "Number of RX packets with errors.");
 METRIC_COUNTER(m_tx_errors, "iface_port_tx_errors", "Number of TX failures.");
+METRIC_COUNTER(m_port_rx_bytes, "iface_port_rx_bytes", "Number of bytes received by HW.");
+METRIC_COUNTER(m_port_tx_bytes, "iface_port_tx_bytes", "Number of bytes transmitted by HW.");
 
 static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
 	const struct iface_info_port *port = iface_info_port(iface);
@@ -768,6 +770,8 @@ static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *if
 		metric_emit(ctx, &m_rx_missed, stats.imissed);
 		metric_emit(ctx, &m_rx_errors, stats.ierrors);
 		metric_emit(ctx, &m_tx_errors, stats.oerrors);
+		metric_emit(ctx, &m_port_rx_bytes, stats.ibytes);
+		metric_emit(ctx, &m_port_tx_bytes, stats.obytes);
 	}
 }
 

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -746,6 +746,8 @@ METRIC_GAUGE(m_txqs, "iface_port_txqs", "Number of TX queues.");
 METRIC_GAUGE(m_rxq_size, "iface_port_rxq_size", "Number of descriptors in RX queues.");
 METRIC_GAUGE(m_txq_size, "iface_port_txq_size", "Number of descriptors in TX queues.");
 METRIC_COUNTER(m_rx_missed, "iface_port_rx_missed", "Number of packets dropped by HW.");
+METRIC_COUNTER(m_rx_errors, "iface_port_rx_errors", "Number of RX packets with errors.");
+METRIC_COUNTER(m_rx_nobufs, "iface_port_rx_nobufs", "Number of RX buffer starvation errors.");
 METRIC_COUNTER(m_tx_errors, "iface_port_tx_errors", "Number of TX failures.");
 
 static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
@@ -765,6 +767,8 @@ static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *if
 
 	if (rte_eth_stats_get(port->port_id, &stats) == 0) {
 		metric_emit(ctx, &m_rx_missed, stats.imissed);
+		metric_emit(ctx, &m_rx_errors, stats.ierrors);
+		metric_emit(ctx, &m_rx_nobufs, stats.rx_nombuf);
 		metric_emit(ctx, &m_tx_errors, stats.oerrors);
 	}
 }

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -749,11 +749,19 @@ METRIC_COUNTER(m_rx_missed, "iface_port_rx_missed", "Number of packets dropped b
 METRIC_COUNTER(m_rx_errors, "iface_port_rx_errors", "Number of RX packets with errors.");
 METRIC_COUNTER(m_rx_nobufs, "iface_port_rx_nobufs", "Number of RX buffer starvation errors.");
 METRIC_COUNTER(m_tx_errors, "iface_port_tx_errors", "Number of TX failures.");
+METRIC_COUNTER(
+	m_port_xstat,
+	"iface_port_xstat",
+	"Raw extended statistic. The xstat label carries the driver-native counter name."
+);
 
 static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
 	const struct iface_info_port *port = iface_info_port(iface);
+	struct rte_eth_xstat_name *names = NULL;
+	struct rte_eth_xstat *values = NULL;
 	struct rte_eth_dev_info dev_info;
 	struct rte_eth_stats stats;
+	int n_xstats;
 
 	if (rte_eth_dev_info_get(port->port_id, &dev_info) == 0)
 		metrics_labels_add(ctx, "driver", dev_info.driver_name, NULL);
@@ -771,6 +779,33 @@ static void port_metrics_collect(struct metrics_ctx *ctx, const struct iface *if
 		metric_emit(ctx, &m_rx_nobufs, stats.rx_nombuf);
 		metric_emit(ctx, &m_tx_errors, stats.oerrors);
 	}
+
+	n_xstats = rte_eth_xstats_get_names(port->port_id, NULL, 0);
+	if (n_xstats <= 0)
+		goto out;
+
+	names = calloc(n_xstats, sizeof(*names));
+	values = calloc(n_xstats, sizeof(*values));
+	if (names == NULL || values == NULL)
+		goto out;
+
+	if (rte_eth_xstats_get_names(port->port_id, names, n_xstats) != n_xstats)
+		goto out;
+	if (rte_eth_xstats_get(port->port_id, values, n_xstats) != n_xstats)
+		goto out;
+
+	// Save the base label set; rewind it between iterations so each emit
+	// replaces (not appends) the xstat label.
+	size_t base_len = ctx->labels_len;
+	for (int i = 0; i < n_xstats; i++) {
+		ctx->labels_len = base_len;
+		metrics_labels_add(ctx, "xstat", names[i].name, NULL);
+		metric_emit(ctx, &m_port_xstat, values[i].value);
+	}
+	ctx->labels_len = base_len;
+out:
+	free(names);
+	free(values);
 }
 
 static struct event *link_event;

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -4,6 +4,7 @@
 #include "event.h"
 #include "iface.h"
 #include "log.h"
+#include "metrics.h"
 #include "module.h"
 #include "rcu.h"
 #include "vlan.h"
@@ -228,6 +229,13 @@ static void vlan_to_api(void *info, const struct iface *iface) {
 	*api = vlan->base;
 }
 
+static void vlan_metrics_collect(struct metrics_ctx *ctx, const struct iface *iface) {
+	const struct iface_info_vlan *vlan = iface_info_vlan(iface);
+	const struct iface *parent = iface_from_id(vlan->parent_id);
+
+	metrics_labels_add(ctx, "parent", parent ? parent->name : "[deleted]", NULL);
+}
+
 static const struct iface_type iface_type_vlan = {
 	.id = GR_IFACE_TYPE_VLAN,
 	.pub_size = sizeof(struct gr_iface_info_vlan),
@@ -242,6 +250,7 @@ static const struct iface_type iface_type_vlan = {
 	.del_eth_addr = iface_vlan_del_eth_addr,
 	.set_promisc = iface_vlan_promisc_set,
 	.to_api = vlan_to_api,
+	.metrics_collect = vlan_metrics_collect,
 };
 
 static void vlan_init(struct event_base *) {

--- a/modules/infra/datapath/bond_output.c
+++ b/modules/infra/datapath/bond_output.c
@@ -204,7 +204,7 @@ bond_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 	const struct iface *member;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(tx);
+	IFACE_STATS_VARS(tx, self);
 
 	for (unsigned i = 0; i < nb_objs; i++) {
 		struct rte_mbuf *mbuf = objs[i];
@@ -224,14 +224,14 @@ bond_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			t->member_iface_id = member->id;
 		}
 
-		IFACE_STATS_INC(tx, mbuf, member);
+		IFACE_STATS_INC(tx, self, mbuf, member);
 
 		edge = PORT_OUTPUT;
 next:
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
-	IFACE_STATS_FLUSH(tx);
+	IFACE_STATS_FLUSH(tx, self);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/iface_input.c
+++ b/modules/infra/datapath/iface_input.c
@@ -57,7 +57,7 @@ iface_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 	uint16_t vlan_id;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(rx);
+	IFACE_STATS_VARS(rx, self);
 
 	last_iface_id = GR_IFACE_ID_UNDEF;
 	last_vlan_id = UINT16_MAX;
@@ -87,7 +87,7 @@ iface_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			goto next;
 		}
 
-		IFACE_STATS_INC(rx, m, d->iface);
+		IFACE_STATS_INC(rx, self, m, d->iface);
 
 		edge = edges[d->iface->mode];
 next:
@@ -100,7 +100,7 @@ next:
 		rte_node_enqueue_x1(graph, node, edge, m);
 	}
 
-	IFACE_STATS_FLUSH(rx);
+	IFACE_STATS_FLUSH(rx, self);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/iface_input.c
+++ b/modules/infra/datapath/iface_input.c
@@ -52,12 +52,14 @@ static uint16_t
 iface_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
 	uint16_t last_iface_id, last_vlan_id;
 	const struct iface *vlan_iface;
+	const struct iface *parent_iface;
 	struct iface_mbuf_data *d;
 	struct rte_mbuf *m;
 	uint16_t vlan_id;
 	rte_edge_t edge;
 
 	IFACE_STATS_VARS(rx, self);
+	IFACE_STATS_VARS(rx, parent);
 
 	last_iface_id = GR_IFACE_ID_UNDEF;
 	last_vlan_id = UINT16_MAX;
@@ -67,6 +69,7 @@ iface_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		m = objs[i];
 		d = iface_mbuf_data(m);
 		vlan_id = d->vlan_id;
+		parent_iface = d->iface;
 
 		if (d->vlan_id != 0 && d->iface->mode == GR_IFACE_MODE_VRF) {
 			if (last_iface_id != d->iface->id || d->vlan_id != last_vlan_id) {
@@ -88,6 +91,8 @@ iface_input_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		}
 
 		IFACE_STATS_INC(rx, self, m, d->iface);
+		if (parent_iface != d->iface)
+			IFACE_STATS_INC(rx, parent, m, parent_iface);
 
 		edge = edges[d->iface->mode];
 next:
@@ -101,6 +106,7 @@ next:
 	}
 
 	IFACE_STATS_FLUSH(rx, self);
+	IFACE_STATS_FLUSH(rx, parent);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/iface_output.c
+++ b/modules/infra/datapath/iface_output.c
@@ -57,21 +57,25 @@ static uint16_t iface_output_process(
 	uint16_t nb_objs
 ) {
 	const struct iface *iface;
+	const struct iface *parent;
 	struct iface_mbuf_data *d;
 	struct rte_mbuf *m;
 	rte_edge_t edge;
 
 	IFACE_STATS_VARS(tx, self);
+	IFACE_STATS_VARS(tx, parent);
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		m = objs[i];
 		d = iface_mbuf_data(m);
 		iface = d->iface;
+		parent = NULL;
 
 		if (iface->type == GR_IFACE_TYPE_VLAN) {
 			const struct iface_info_vlan *vlan = iface_info_vlan(iface);
 			d->vlan_id = vlan->vlan_id;
 			iface = iface_from_id(vlan->parent_id);
+			parent = iface;
 		}
 
 		if (gr_mbuf_is_traced(m)) {
@@ -90,6 +94,8 @@ static uint16_t iface_output_process(
 		}
 
 		IFACE_STATS_INC(tx, self, m, d->iface);
+		if (parent != NULL)
+			IFACE_STATS_INC(tx, parent, m, parent);
 
 		d->iface = iface;
 		edge = iface_type_edges[iface->type];
@@ -98,6 +104,7 @@ next:
 	}
 
 	IFACE_STATS_FLUSH(tx, self);
+	IFACE_STATS_FLUSH(tx, parent);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/iface_output.c
+++ b/modules/infra/datapath/iface_output.c
@@ -61,7 +61,7 @@ static uint16_t iface_output_process(
 	struct rte_mbuf *m;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(tx);
+	IFACE_STATS_VARS(tx, self);
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		m = objs[i];
@@ -89,7 +89,7 @@ static uint16_t iface_output_process(
 			goto next;
 		}
 
-		IFACE_STATS_INC(tx, m, d->iface);
+		IFACE_STATS_INC(tx, self, m, d->iface);
 
 		d->iface = iface;
 		edge = iface_type_edges[iface->type];
@@ -97,7 +97,7 @@ next:
 		rte_node_enqueue_x1(graph, node, edge, m);
 	}
 
-	IFACE_STATS_FLUSH(tx);
+	IFACE_STATS_FLUSH(tx, self);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/rxtx.h
+++ b/modules/infra/datapath/rxtx.h
@@ -80,35 +80,37 @@ uint16_t rx_bond_process(struct rte_graph *, struct rte_node *, void **, uint16_
 uint16_t tx_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 uint16_t tx_shared_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 
-#define IFACE_STATS_VARS(dir)                                                                      \
-	struct iface_stats *dir##_stats;                                                           \
-	uint16_t dir##_last_iface_id = GR_IFACE_ID_UNDEF;                                          \
-	uint16_t dir##_packets = 0;                                                                \
-	uint64_t dir##_bytes = 0;
+#define IFACE_STATS_VARS(dir, acc)                                                                 \
+	struct iface_stats *dir##_##acc##_stats;                                                   \
+	uint16_t dir##_##acc##_last_iface_id = GR_IFACE_ID_UNDEF;                                  \
+	uint16_t dir##_##acc##_packets = 0;                                                        \
+	uint64_t dir##_##acc##_bytes = 0;
 
-#define IFACE_STATS_INC(dir, mbuf, iface)                                                          \
+#define IFACE_STATS_INC(dir, acc, mbuf, iface)                                                     \
 	do {                                                                                       \
-		if (iface->id != dir##_last_iface_id) {                                            \
-			if (dir##_packets != 0) {                                                  \
-				dir##_stats = iface_get_stats(                                     \
-					rte_lcore_id(), dir##_last_iface_id                        \
+		if (iface->id != dir##_##acc##_last_iface_id) {                                    \
+			if (dir##_##acc##_packets != 0) {                                          \
+				dir##_##acc##_stats = iface_get_stats(                             \
+					rte_lcore_id(), dir##_##acc##_last_iface_id                \
 				);                                                                 \
-				dir##_stats->dir##_packets += dir##_packets;                       \
-				dir##_stats->dir##_bytes += dir##_bytes;                           \
-				dir##_packets = 0;                                                 \
-				dir##_bytes = 0;                                                   \
+				dir##_##acc##_stats->dir##_packets += dir##_##acc##_packets;       \
+				dir##_##acc##_stats->dir##_bytes += dir##_##acc##_bytes;           \
+				dir##_##acc##_packets = 0;                                         \
+				dir##_##acc##_bytes = 0;                                           \
 			}                                                                          \
-			dir##_last_iface_id = iface->id;                                           \
+			dir##_##acc##_last_iface_id = iface->id;                                   \
 		}                                                                                  \
-		dir##_packets += 1;                                                                \
-		dir##_bytes += rte_pktmbuf_pkt_len(mbuf);                                          \
+		dir##_##acc##_packets += 1;                                                        \
+		dir##_##acc##_bytes += rte_pktmbuf_pkt_len(mbuf);                                  \
 	} while (0)
 
-#define IFACE_STATS_FLUSH(dir)                                                                     \
+#define IFACE_STATS_FLUSH(dir, acc)                                                                \
 	do {                                                                                       \
-		if (dir##_packets != 0) {                                                          \
-			dir##_stats = iface_get_stats(rte_lcore_id(), dir##_last_iface_id);        \
-			dir##_stats->dir##_packets += dir##_packets;                               \
-			dir##_stats->dir##_bytes += dir##_bytes;                                   \
+		if (dir##_##acc##_packets != 0) {                                                  \
+			dir##_##acc##_stats = iface_get_stats(                                     \
+				rte_lcore_id(), dir##_##acc##_last_iface_id                        \
+			);                                                                         \
+			dir##_##acc##_stats->dir##_packets += dir##_##acc##_packets;               \
+			dir##_##acc##_stats->dir##_bytes += dir##_##acc##_bytes;                   \
 		}                                                                                  \
 	} while (0)

--- a/modules/infra/datapath/xconnect.c
+++ b/modules/infra/datapath/xconnect.c
@@ -20,21 +20,21 @@ xconnect_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 	struct rte_mbuf *mbuf;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(rx);
-	IFACE_STATS_VARS(tx);
+	IFACE_STATS_VARS(rx, self);
+	IFACE_STATS_VARS(tx, self);
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
 		iface = mbuf_data(mbuf)->iface;
 		peer = iface_from_id(iface->domain_id);
 
-		IFACE_STATS_INC(rx, mbuf, iface);
+		IFACE_STATS_INC(rx, self, mbuf, iface);
 
 		if (peer != NULL && peer->type == GR_IFACE_TYPE_PORT) {
 			mbuf_data(mbuf)->iface = peer;
 			edge = OUTPUT;
 
-			IFACE_STATS_INC(tx, mbuf, peer);
+			IFACE_STATS_INC(tx, self, mbuf, peer);
 		} else {
 			edge = NO_PORT;
 		}
@@ -45,8 +45,8 @@ xconnect_process(struct rte_graph *graph, struct rte_node *node, void **objs, ui
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
-	IFACE_STATS_FLUSH(rx);
-	IFACE_STATS_FLUSH(tx);
+	IFACE_STATS_FLUSH(rx, self);
+	IFACE_STATS_FLUSH(tx, self);
 
 	return nb_objs;
 }

--- a/modules/infra/datapath/xvrf.c
+++ b/modules/infra/datapath/xvrf.c
@@ -29,7 +29,7 @@ xvrf_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16
 	struct rte_mbuf *m;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(rx);
+	IFACE_STATS_VARS(rx, self);
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		m = objs[i];
@@ -43,7 +43,7 @@ xvrf_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16
 		eth_data->domain = ETH_DOMAIN_LOCAL;
 
 		// XXX: increment tx stats on source VRF
-		IFACE_STATS_INC(rx, m, eth_data->iface);
+		IFACE_STATS_INC(rx, self, m, eth_data->iface);
 
 		if (gr_mbuf_is_traced(m) || (eth_data->iface->flags & GR_IFACE_F_PACKET_TRACE)) {
 			struct trace_vrf_data *t = gr_mbuf_trace_add(m, node, sizeof(*t));
@@ -53,7 +53,7 @@ xvrf_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16
 		rte_node_enqueue_x1(graph, node, edge, m);
 	}
 
-	IFACE_STATS_FLUSH(rx);
+	IFACE_STATS_FLUSH(rx, self);
 
 	return nb_objs;
 }

--- a/modules/ipip/datapath_in.c
+++ b/modules/ipip/datapath_in.c
@@ -33,7 +33,7 @@ ipip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 	struct iface *ipip;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(rx);
+	IFACE_STATS_VARS(rx, self);
 
 	ipip = NULL;
 	last_src = 0;
@@ -66,7 +66,7 @@ ipip_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, 
 		eth_data->iface = ipip;
 		eth_data->domain = ETH_DOMAIN_LOCAL;
 		edge = IP_INPUT;
-		IFACE_STATS_INC(rx, mbuf, ipip);
+		IFACE_STATS_INC(rx, self, mbuf, ipip);
 next:
 		if (gr_mbuf_is_traced(mbuf) || (ipip && ipip->flags & GR_IFACE_F_PACKET_TRACE)) {
 			struct trace_ipip_data *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
@@ -75,7 +75,7 @@ next:
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
-	IFACE_STATS_FLUSH(rx);
+	IFACE_STATS_FLUSH(rx, self);
 
 	return nb_objs;
 }

--- a/modules/ipip/datapath_out.c
+++ b/modules/ipip/datapath_out.c
@@ -34,7 +34,7 @@ ipip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 	struct rte_mbuf *mbuf;
 	rte_edge_t edge;
 
-	IFACE_STATS_VARS(tx);
+	IFACE_STATS_VARS(tx, self);
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
@@ -72,7 +72,7 @@ ipip_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		}
 		ip_set_fields(outer, &tunnel);
 
-		IFACE_STATS_INC(tx, mbuf, iface);
+		IFACE_STATS_INC(tx, self, mbuf, iface);
 
 		// Resolve nexthop for the encapsulated packet.
 		ip_data->nh = fib4_lookup(iface->vrf_id, ipip->remote);
@@ -82,7 +82,7 @@ next:
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
-	IFACE_STATS_FLUSH(tx);
+	IFACE_STATS_FLUSH(tx, self);
 
 	return nb_objs;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- modules/infra/api/iface.c
  - Added gr_net_types.h include.
  - Added gauge m_speed_bps (iface_speed_bps) and emit path: convert iface->speed from Mbit/s to bits/s (unknown/link-down stays 0) when emitting m_speed_bps.
  - Scrape context extended: vrf label now uses referenced VRF interface name (or "[deleted]" if missing) instead of numeric vrf_id; added mac label derived from interface primary MAC (or "00:00:00:00:00:00" fallback).

- modules/infra/control/port.c
  - Added RX error counters and raw DPDK xstats emission.
  - New counters: m_rx_errors, m_rx_nobufs; m_tx_errors declaration moved/updated.
  - Added m_port_xstat counter: queries DPDK xstat names/values per-collection, emits each xstat value labeled with the driver-native xstat name.
  - Implementation allocates temporary arrays for xstat names/values, resets metric label base between xstat emits to avoid label accumulation, and frees allocations on all paths.

- modules/infra/control/vlan.c
  - Added metrics.h include.
  - Added vlan_metrics_collect() which emits parent label using parent interface name (or "[deleted]" if missing).
  - iface_type_vlan now registers .metrics_collect = vlan_metrics_collect.

- modules/infra/datapath/rxtx.h
  - IFACE_STATS macro API extended to support a second accumulator dimension (acc).
  - Signatures changed:
    - IFACE_STATS_VARS(dir) → IFACE_STATS_VARS(dir, acc)
    - IFACE_STATS_INC(dir, mbuf, iface) → IFACE_STATS_INC(dir, acc, mbuf, iface)
    - IFACE_STATS_FLUSH(dir) → IFACE_STATS_FLUSH(dir, acc)
  - New behavior: per-dir/per-acc pointers and local counters declared; IFACE_STATS_INC ties increments to a specific acc and flushes accumulated counters into iface_get_stats(...) when iface id changes; IFACE_STATS_FLUSH flushes the per-dir/per-acc counters.

- Datapath updates to use new IFACE_STATS API (pass explicit acc/context)
  - modules/infra/datapath/iface_input.c
    - Declares IFACE_STATS_VARS(rx, self) and IFACE_STATS_VARS(rx, parent).
    - Captures original parent_iface before VRF/VLAN reassignment; increments parent stats when parent_iface != final iface via IFACE_STATS_INC(rx, parent, ...).
    - Flushes both with IFACE_STATS_FLUSH(rx, self) and IFACE_STATS_FLUSH(rx, parent).
  - modules/infra/datapath/iface_output.c
    - Declares IFACE_STATS_VARS(tx, self) and IFACE_STATS_VARS(tx, parent).
    - When iface is VLAN, resolves parent and records per-mbuf increments to self and conditionally to parent via IFACE_STATS_INC(tx, self, ...) / IFACE_STATS_INC(tx, parent, ...).
    - Flushes both accumulators after processing.
  - modules/infra/datapath/bond_output.c
    - Transmit stats updated to use instance-scoped IFACE_STATS API requiring self and member where applicable:
      - IFACE_STATS_VARS(tx, self)
      - IFACE_STATS_INC(tx, self, mbuf, member)
      - IFACE_STATS_FLUSH(tx, self)
  - modules/infra/datapath/xconnect.c
    - Switched to IFACE_STATS_VARS(rx, self) / IFACE_STATS_VARS(tx, self).
    - Increments RX with self and TX with self (peer) via IFACE_STATS_INC(..., self, ...).
    - Flushes with IFACE_STATS_FLUSH(rx, self) / IFACE_STATS_FLUSH(tx, self).
  - modules/infra/datapath/xvrf.c
    - Replaced non-scoped IFACE_STATS usage with IFACE_STATS_VARS(rx, self), IFACE_STATS_INC(rx, self, ...), IFACE_STATS_FLUSH(rx, self).
  - modules/ipip/datapath_in.c
    - Switched to IFACE_STATS_VARS(rx, self), IFACE_STATS_INC(rx, self, ...), IFACE_STATS_FLUSH(rx, self).
  - modules/ipip/datapath_out.c
    - Switched to IFACE_STATS_VARS(tx, self), IFACE_STATS_INC(tx, self, ...), IFACE_STATS_FLUSH(tx, self).

- modules/infra/datapath/iface_input.c and iface_output.c (behavioral notes)
  - Both files now capture and increment stats for both the active interface and the original parent when applicable and flush both accumulators; packet forwarding and enqueue logic unchanged.

- modules/infra/datapath/xconnect.c, xvrf.c, ipip/datapath_in.c, ipip/datapath_out.c
  - Instrumentation changes only: migrated to new IFACE_STATS macro signatures with explicit self context; forwarding logic unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->