### PR TITLE
fix: the grout router daemon's control api accepts c... in api.c

### DIFF
--- a/main/api.c
+++ b/main/api.c
@@ -344,6 +344,7 @@ send:
 	bufferevent_flush(bev, EV_WRITE, BEV_FLUSH);
 
 	free(req_payload);
+	req_payload = NULL;
 	free(out.payload);
 
 	if (evbuffer_get_length(input) >= sizeof(ctx->header)) {
@@ -382,6 +383,19 @@ static void accept_conn_cb(
 	struct event_base *base = priv;
 	struct bufferevent *bev;
 	struct api_ctx *ctx;
+	struct ucred cred = {0};
+	socklen_t cred_len = sizeof(cred);
+
+	if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &cred_len) == -1) {
+		LOG(ERR, "getsockopt SO_PEERCRED: %s", strerror(errno));
+		close(fd);
+		return;
+	}
+	if (cred.uid != 0 && cred.uid != gr_config.api_sock_uid) {
+		LOG(ERR, "rejected connection from uid=%u pid=%u", cred.uid, cred.pid);
+		close(fd);
+		return;
+	}
 
 	bev = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
 	if (bev == NULL) {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `main/api.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `main/api.c:253` |

**Description**: The grout router daemon's control API accepts connections and processes configuration commands without any authentication mechanism. Any entity with network access to the API socket can connect and issue arbitrary commands including modifying routing tables, deleting IP addresses from interfaces, updating VxLAN configurations, and changing nexthop entries. This effectively grants full administrative control over the router to any network-adjacent attacker.

## Changes
- `main/api.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## main/api.c

**Authentication validation in `accept_conn_cb`:**
Added peer credential validation using `getsockopt(fd, SOL_SOCKET, SO_PEERCRED, ...)` to retrieve the connecting process's UID. Connections are rejected (socket closed, callback returns) unless the peer UID equals `0` (root) or matches `gr_config.api_sock_uid`. Failed credential validation is logged as an error.

**Null assignment in `read_cb`:**
After freeing `req_payload` in the response sending section, the pointer is explicitly set to NULL before the function returns, ensuring safe state in cleanup paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DPDK/grout/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->