### PR TITLE
main: allow indirect linking with libsystemd.so

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -321,13 +321,13 @@ int main(int argc, char **argv) {
 		goto shutdown;
 	}
 
-	if (sd_notifyf(0, "READY=1\nSTATUS=grout version %s started", GROUT_VERSION) < 0)
+	if (gr_sd_notifyf(0, "READY=1\nSTATUS=grout version %s started", GROUT_VERSION) < 0)
 		LOG(ERR, "sd_notifyf: %s", strerror(errno));
 
 	// run until signal or fatal error
 	if (event_base_dispatch(ev_base) == 0) {
 		ret = EXIT_SUCCESS;
-		if (sd_notifyf(0, "STOPPING=1\nSTATUS=shutting down...") < 0)
+		if (gr_sd_notifyf(0, "STOPPING=1\nSTATUS=shutting down...") < 0)
 			LOG(ERR, "sd_notifyf: %s", strerror(errno));
 	} else {
 		err = errno;
@@ -345,7 +345,7 @@ shutdown:
 dpdk_stop:
 	dpdk_fini();
 	if (err != 0)
-		sd_notifyf(0, "ERRNO=%i", err);
+		gr_sd_notifyf(0, "ERRNO=%i", err);
 end:
 	vec_free(gr_config.eal_extra_args);
 	return ret;

--- a/main/sd_notify.c
+++ b/main/sd_notify.c
@@ -33,7 +33,7 @@ static void closefd(int *fd) {
 	}
 }
 
-int sd_notifyf(int unset_environment, const char *format, ...) {
+int gr_sd_notifyf(int unset_environment, const char *format, ...) {
 	struct sockaddr_un sun = {.sun_family = AF_UNIX};
 	__attribute__((cleanup(closefd))) int fd = -1;
 	const char *sock_path;

--- a/main/sd_notify.h
+++ b/main/sd_notify.h
@@ -4,4 +4,5 @@
 #pragma once
 
 // Implement the systemd notify protocol without external dependencies.
-int sd_notifyf(int unset_environment, const char *format, ...);
+int gr_sd_notifyf(int unset_environment, const char *format, ...)
+	__attribute__((format(printf, 2, 3)));


### PR DESCRIPTION
Avoid the following error when linking to DPDK dynamic libraries which are indirectly linked to libsystemd:

```
/usr/bin/x86_64-linux-gnu-ld.bfd: /usr/lib/x86_64-linux-gnu/libsystemd.a(src_libsystemd_sd-daemon_sd-daemon.c.o): in function `sd_notifyf':
(.text+0x2030): multiple definition of `sd_notifyf'; grout.p/main_sd_notify.c.o:./obj-x86_64-linux-gnu/../main/sd_notify.c:36: first defined here
```

Define our symbol as weak so that it can be overridden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

- main/sd_notify.h
  - New declaration: int gr_sd_notifyf(int unset_environment, const char *format, ...) __attribute__((format(printf, 2, 3)));

- main/sd_notify.c
  - Implementation renamed to gr_sd_notifyf(...) and moved to use the new header. Internal logic unchanged.

- main/main.c
  - Call sites updated to use gr_sd_notifyf(...) for systemd-style notifications (startup READY, shutdown STOPPING, error messages).

## Rationale / notes

- The sd_notify symbol was renamed to gr_sd_notifyf and annotated with GCC/Clang format checking. No weak attribute or symbol-export changes are present in the displayed diffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->