### PR TITLE
 Adaptive RSS auto-scaling 

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -21,6 +21,20 @@ struct gr_config {
 	bool poll_mode;
 	bool log_syslog;
 	bool log_packets;
+	// Adaptive RSS auto-scaling: dynamically narrows the per-port RSS
+	// distribution + parks idle workers. The value is the cluster
+	// grouping size used to keep scaling steps aligned with cache-
+	// sharing groups so a step never splits one across active/parked:
+	//   0   = disabled (legacy: all workers always poll all configured
+	//         queues, no parking, no RETA scale).
+	//   1   = enabled, per-core scaling (no cluster constraint).
+	//   2   = enabled, scale by groups of 2. Typical use: x86 with
+	//         hyperthreading (sibling threads share L1/L2), or any SoC
+	//         where 2 cores share an L2 cache.
+	//   N>2 = enabled, scale by groups of N. For larger cache-sharing
+	//         topologies.
+	// Set via --rss-autoscale=N at startup.
+	uint16_t rss_autoscale;
 	vec char **eal_extra_args;
 	cpu_set_t control_cpus; // control plane threads allowed CPUs
 	cpu_set_t datapath_cpus; // datapath threads allowed CPUs

--- a/main/main.c
+++ b/main/main.c
@@ -60,6 +60,15 @@ static void usage(void) {
 	puts("                                 (default [::]:9111).");
 	puts("  -S, --syslog                   Redirect logs to syslog.");
 	puts("  -V, --version                  Print version and exit.");
+	puts("  -a, --rss-autoscale=N          Enable adaptive RSS auto-scaling and");
+	puts("                                 worker parking. Workers without traffic");
+	puts("                                 drop to 0% CPU. N = cluster grouping size:");
+	puts("                                   0 = disabled (default)");
+	puts("                                   1 = per-core scaling");
+	puts("                                   2 = scale by groups of 2 (x86 with");
+	puts("                                       hyperthreading, or SoCs sharing");
+	puts("                                       L2 between 2 cores).");
+	puts("                                   N = scale by groups of N.");
 	puts("  -h, --help                     Display this help message and exit.");
 	puts("  -m, --socket-mode PERMISSIONS  API socket file permissions (Default: 0660).");
 	puts("  -o, --socket-owner USER:GROUP  API socket file ownership");
@@ -176,8 +185,9 @@ static int parse_sock_owner(char *user_group_str) {
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":M:Vhm:o:pSs:tu:vx"
+#define FLAGS ":M:Va:hm:o:pSs:tu:vx"
 	static struct option long_options[] = {
+		{"rss-autoscale", required_argument, NULL, 'a'},
 		{"help", no_argument, NULL, 'h'},
 		{"max-mtu", required_argument, NULL, 'u'},
 		{"metrics", required_argument, NULL, 'M'},
@@ -221,6 +231,13 @@ static int parse_args(int argc, char **argv) {
 			if (parse_sock_owner(optarg) < 0)
 				return errno_set(EINVAL);
 			break;
+		case 'a': {
+			unsigned int gm;
+			if (parse_uint(&gm, optarg, 10, 0, 16) < 0)
+				return perr("--rss-autoscale: %s", strerror(errno));
+			gr_config.rss_autoscale = (uint16_t)gm;
+			break;
+		}
 		case 'p':
 			gr_config.poll_mode = true;
 			break;

--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -102,6 +102,8 @@ struct gr_iface {
 #define GR_PORT_SET_N_TXQS GR_BIT64(33)
 #define GR_PORT_SET_Q_SIZE GR_BIT64(34)
 #define GR_PORT_SET_MAC GR_BIT64(35)
+#define GR_PORT_SET_RSS_CAP GR_BIT64(36)
+#define GR_PORT_SET_RSS_FLOOR GR_BIT64(37)
 
 // Base info structure for GR_IFACE_TYPE_PORT interfaces.
 struct __gr_iface_info_port_base {
@@ -110,6 +112,9 @@ struct __gr_iface_info_port_base {
 	uint16_t rxq_size;
 	uint16_t txq_size;
 	struct rte_ether_addr mac;
+	// rss-autoscale operator policy: max / min active RX queues (0 = unset).
+	uint16_t rss_cap;
+	uint16_t rss_floor;
 };
 
 // Complete port info structure including device arguments and driver name.
@@ -252,6 +257,7 @@ enum gr_infra_requests : uint32_t {
 	GR_IFACE_MAC_DEL,
 	GR_IFACE_MAC_LIST,
 	GR_IFACE_MAC_SET,
+	GR_RSS_AUTOSCALE_LIST,
 };
 
 enum gr_infra_events : uint32_t {
@@ -499,6 +505,23 @@ struct gr_affinity_cpu_set_req {
 };
 
 GR_REQ(GR_AFFINITY_CPU_SET, struct gr_affinity_cpu_set_req, struct gr_empty);
+
+// adaptive RSS scaling / worker parking ///////////////////////////////////////
+
+// Per-port snapshot of the rss-autoscale controller. cap and floor are
+// 0 when no policy is set; min_n / max_n are the usable bounds from
+// the PMD's allowed dist-size list (post cluster-size filtering).
+struct gr_rss_autoscale_port_state {
+	uint16_t iface_id;
+	uint16_t n_active;
+	uint16_t n_load_recommended;
+	uint16_t min_n;
+	uint16_t max_n;
+	uint16_t cap;
+	uint16_t floor;
+};
+
+GR_REQ_STREAM(GR_RSS_AUTOSCALE_LIST, struct gr_empty, struct gr_rss_autoscale_port_state);
 
 // Helper function to convert iface type enum to string
 static inline const char *gr_iface_type_name(gr_iface_type_t type) {

--- a/modules/infra/api/meson.build
+++ b/modules/infra/api/meson.build
@@ -4,6 +4,7 @@
 src += files(
   'affinity.c',
   'iface.c',
+  'rss_autoscale.c',
   'nexthop.c',
   'stats.c',
   'trace.c',

--- a/modules/infra/api/rss_autoscale.c
+++ b/modules/infra/api/rss_autoscale.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#include "iface.h"
+#include "module.h"
+#include "port.h"
+#include "rss_autoscale.h"
+
+#include <gr_infra.h>
+
+#include <errno.h>
+#include <stdlib.h>
+
+static struct api_out rss_autoscale_list(const void * /*request*/, struct api_ctx *ctx) {
+	struct iface *iface = NULL;
+	while ((iface = iface_next(GR_IFACE_TYPE_PORT, iface)) != NULL) {
+		struct iface_info_port *p = iface_info_port(iface);
+		struct gr_rss_autoscale_port_state s = {
+			.iface_id = iface->id,
+		};
+		uint16_t n_active = 0, n_reco = 0, min_n = 0, max_n = 0;
+		uint16_t cap = 0, floor = 0;
+
+		// Skip ports without state or PMD RETA support.
+		if (rss_autoscale_port_state_get(
+			    p->port_id, &n_active, &n_reco, &cap, &floor, &max_n, &min_n
+		    )
+		    < 0)
+			continue;
+		s.n_active = n_active;
+		s.n_load_recommended = n_reco;
+		s.min_n = min_n;
+		s.max_n = max_n;
+		s.cap = cap;
+		s.floor = floor;
+		api_send(ctx, sizeof(s), &s);
+	}
+	return api_out(0, 0, NULL);
+}
+
+RTE_INIT(_init) {
+	api_handler(GR_RSS_AUTOSCALE_LIST, rss_autoscale_list);
+}

--- a/modules/infra/cli/meson.build
+++ b/modules/infra/cli/meson.build
@@ -9,6 +9,7 @@ cli_src += files(
   'graph.c',
   'icmp.c',
   'iface.c',
+  'rss_autoscale.c',
   'mac.c',
   'vrf.c',
   'nexthop.c',

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -25,6 +25,8 @@ static void port_show(struct gr_api_client *, const struct gr_iface *iface, stru
 	gr_object_field(o, "n_txq", GR_DISP_INT, "%u", port->n_txq);
 	gr_object_field(o, "rxq_size", GR_DISP_INT, "%u", port->rxq_size);
 	gr_object_field(o, "txq_size", GR_DISP_INT, "%u", port->txq_size);
+	gr_object_field(o, "rss_cap", GR_DISP_INT, "%u", port->rss_cap);
+	gr_object_field(o, "rss_floor", GR_DISP_INT, "%u", port->rss_floor);
 }
 
 static void
@@ -66,6 +68,12 @@ static uint64_t parse_port_args(
 		port->txq_size = port->rxq_size;
 		set_attrs |= GR_PORT_SET_Q_SIZE;
 	}
+
+	if (arg_u16(p, "RSS_CAP", &port->rss_cap) == 0)
+		set_attrs |= GR_PORT_SET_RSS_CAP;
+
+	if (arg_u16(p, "RSS_FLOOR", &port->rss_floor) == 0)
+		set_attrs |= GR_PORT_SET_RSS_FLOOR;
 
 	if (set_attrs == 0)
 		errno = EINVAL;
@@ -124,12 +132,22 @@ out:
 	return ret;
 }
 
-#define PORT_ATTRS_CMD IFACE_ATTRS_CMD ",(mac MAC),(rxqs N_RXQ),(qsize Q_SIZE)"
+#define PORT_ATTRS_CMD                                                                             \
+	IFACE_ATTRS_CMD ",(mac MAC),(rxqs N_RXQ),(qsize Q_SIZE),(rss-cap RSS_CAP),(rss-floor "     \
+			"RSS_FLOOR)"
 
 #define PORT_ATTRS_ARGS                                                                            \
 	IFACE_ATTRS_ARGS, with_help("Set the ethernet address.", ec_node_re("MAC", ETH_ADDR_RE)),  \
 		with_help("Number of Rx queues.", ec_node_uint("N_RXQ", 0, UINT16_MAX - 1, 10)),   \
-		with_help("Rx/Tx queues size.", ec_node_uint("Q_SIZE", 0, UINT16_MAX - 1, 10))
+		with_help("Rx/Tx queues size.", ec_node_uint("Q_SIZE", 0, UINT16_MAX - 1, 10)),    \
+		with_help(                                                                         \
+			"Max RSS queues for autoscale (0=default).",                               \
+			ec_node_uint("RSS_CAP", 0, UINT16_MAX - 1, 10)                             \
+		),                                                                                 \
+		with_help(                                                                         \
+			"Min RSS queues for autoscale (0=default).",                               \
+			ec_node_uint("RSS_FLOOR", 0, UINT16_MAX - 1, 10)                           \
+		)
 
 static int ctx_init(struct ec_node *root) {
 	int ret;

--- a/modules/infra/cli/rss_autoscale.c
+++ b/modules/infra/cli/rss_autoscale.c
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#include "cli.h"
+#include "cli_iface.h"
+#include "display.h"
+
+#include <gr_api.h>
+#include <gr_infra.h>
+
+#include <ecoli.h>
+
+static cmd_status_t rss_autoscale_show(struct gr_api_client *c, const struct ec_pnode *) {
+	const struct gr_rss_autoscale_port_state *s;
+	int ret;
+
+	struct gr_table *table = gr_table_new();
+	gr_table_column(table, "IFACE", GR_DISP_LEFT);
+	gr_table_column(table, "N_ACTIVE", GR_DISP_RIGHT | GR_DISP_INT);
+	gr_table_column(table, "N_WANTED", GR_DISP_RIGHT | GR_DISP_INT);
+	gr_table_column(table, "CAP", GR_DISP_RIGHT);
+	gr_table_column(table, "FLOOR", GR_DISP_RIGHT);
+	gr_table_column(table, "MIN", GR_DISP_RIGHT | GR_DISP_INT);
+	gr_table_column(table, "MAX", GR_DISP_RIGHT | GR_DISP_INT);
+
+	gr_api_client_stream_foreach (s, ret, c, GR_RSS_AUTOSCALE_LIST, 0, NULL) {
+		gr_table_cell(table, 0, "%s", iface_name_from_id(c, s->iface_id));
+		gr_table_cell(table, 1, "%u", s->n_active);
+		gr_table_cell(table, 2, "%u", s->n_load_recommended);
+		if (s->cap == 0)
+			gr_table_cell(table, 3, "-");
+		else
+			gr_table_cell(table, 3, "%u", s->cap);
+		if (s->floor == 0)
+			gr_table_cell(table, 4, "-");
+		else
+			gr_table_cell(table, 4, "%u", s->floor);
+		gr_table_cell(table, 5, "%u", s->min_n);
+		gr_table_cell(table, 6, "%u", s->max_n);
+
+		if (gr_table_print_row(table) < 0)
+			break;
+	}
+
+	gr_table_free(table);
+	return ret < 0 ? CMD_ERROR : CMD_SUCCESS;
+}
+
+#define RSS_ARG CTX_ARG("rss-autoscale", "Adaptive RSS auto-scaling controller.")
+#define RSS_CTX(root) CLI_CONTEXT(root, RSS_ARG)
+
+static int ctx_init(struct ec_node *root) {
+	int ret;
+
+	ret = CLI_COMMAND(
+		RSS_CTX(root),
+		"[show]",
+		rss_autoscale_show,
+		"Display adaptive RSS auto-scaling state per port."
+	);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static struct cli_context ctx = {
+	.name = "infra rss-autoscale",
+	.init = ctx_init,
+};
+
+static void __attribute__((constructor, used)) init(void) {
+	cli_context_register(&ctx);
+}

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "config.h"
 #include "graph.h"
 #include "log.h"
 #include "module.h"
 #include "port.h"
+#include "rss_autoscale.h"
 #include "rxtx.h"
 #include "vec.h"
 #include "worker.h"
@@ -157,12 +159,24 @@ worker_graph_new(struct worker *worker, uint8_t index, vec struct iface_info_por
 		ctx->rxq.queue_id = qmap->queue_id;
 		burst_size = RTE_MAX(1u, graph_conf.vector_max / vec_len(rx_nodes));
 		ctx->burst_size = RTE_MIN(graph_conf.rx_burst_max, burst_size);
+		// Saturation threshold: the smallest of grout's per-call ask and
+		// the PMD's recommended per-rxq burst (a hint, not a hard cap).
+		// PMDs that don't expose it (== 0) fall back to ctx->burst_size.
+		struct rte_eth_dev_info info;
+		ctx->saturation_threshold = ctx->burst_size;
+		if (rte_eth_dev_info_get(qmap->port_id, &info) == 0
+		    && info.default_rxportconf.burst_size > 0
+		    && info.default_rxportconf.burst_size < ctx->burst_size)
+			ctx->saturation_threshold = info.default_rxportconf.burst_size;
+		ctx->track_health = gr_config.rss_autoscale != 0
+			&& rss_autoscale_port_enabled(qmap->port_id);
 		LOG(DEBUG,
-		    "[CPU %d] <- port=%u rxq=%u burst_size=%u",
+		    "[CPU %d] <- port=%u rxq=%u burst_size=%u saturation=%u",
 		    worker->cpu_id,
 		    qmap->port_id,
 		    qmap->queue_id,
-		    ctx->burst_size);
+		    ctx->burst_size,
+		    ctx->saturation_threshold);
 		// select the appropriate node process callback
 		if (ctx->iface->mode == GR_IFACE_MODE_BOND) {
 			// virtio driver supports Rx vlan stripping but requires help for L4 csum

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -117,7 +117,7 @@ static bool rxq_is_inactive(uint16_t port_id, uint16_t queue_id) {
 	if (gr_config.rss_autoscale == 0 || !rss_autoscale_port_enabled(port_id))
 		return false;
 	n = rss_autoscale_port_n_active(port_id);
-	return n > 0 && queue_id >= n;
+	return n > 0 && !rss_autoscale_port_rxq_active_within(port_id, queue_id, n);
 }
 
 static int
@@ -324,7 +324,11 @@ void worker_graph_rxq_set_active(uint16_t port_id, uint16_t n_active) {
 			node = rte_graph_node_get_by_name(graph_name, node_name);
 			if (node == NULL)
 				continue;
-			node->process = qmap->queue_id < n_active ? active : rx_inactive_process;
+			node->process = rss_autoscale_port_rxq_active_within(
+						port_id, qmap->queue_id, n_active
+					) ?
+				active :
+				rx_inactive_process;
 		}
 	}
 }

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -270,6 +270,7 @@ int worker_graph_reload(struct worker *worker, vec struct iface_info_port **port
 	// wait for datapath worker to pickup the config update
 	atomic_store(&worker->next_config, next);
 	worker_wakeup(worker);
+	worker_unpark(worker);
 	for (unsigned i = 0; atomic_load(&worker->cur_config) != next; i++) {
 		if (i >= 10000) // 10000 * 500us -> 5s
 			return errno_log(ETIMEDOUT, "worker not responding to graph reload");

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -92,6 +92,34 @@ static struct gr_graph_conf graph_conf = {
 	.vector_max = 64,
 };
 
+// virtio driver supports Rx vlan stripping but requires help for L4 csum
+static rte_node_process_t
+rx_process_for(const struct iface *iface, const struct iface_info_port *port) {
+	if (iface->mode == GR_IFACE_MODE_BOND) {
+		if (port->virtio_offloads)
+			return rx_bond_virtio_process;
+		if (port->rx_offloads & RTE_ETH_RX_OFFLOAD_VLAN_STRIP)
+			return rx_bond_offload_process;
+		return rx_bond_process;
+	}
+	if (port->virtio_offloads)
+		return rx_virtio_process;
+	if (port->rx_offloads & RTE_ETH_RX_OFFLOAD_VLAN_STRIP)
+		return rx_offload_process;
+	return rx_process;
+}
+
+// True when rss-autoscale has narrowed this port's RETA below queue_id: the HW
+// steers nothing here, so the rxq skips polling via rx_inactive_process.
+static bool rxq_is_inactive(uint16_t port_id, uint16_t queue_id) {
+	uint16_t n;
+
+	if (gr_config.rss_autoscale == 0 || !rss_autoscale_port_enabled(port_id))
+		return false;
+	n = rss_autoscale_port_n_active(port_id);
+	return n > 0 && queue_id >= n;
+}
+
 static int
 worker_graph_new(struct worker *worker, uint8_t index, vec struct iface_info_port **ports) {
 	vec const char **graph_nodes = NULL;
@@ -177,24 +205,10 @@ worker_graph_new(struct worker *worker, uint8_t index, vec struct iface_info_por
 		    qmap->queue_id,
 		    ctx->burst_size,
 		    ctx->saturation_threshold);
-		// select the appropriate node process callback
-		if (ctx->iface->mode == GR_IFACE_MODE_BOND) {
-			// virtio driver supports Rx vlan stripping but requires help for L4 csum
-			if (port->virtio_offloads)
-				node->process = rx_bond_virtio_process;
-			else if (port->rx_offloads & RTE_ETH_RX_OFFLOAD_VLAN_STRIP)
-				node->process = rx_bond_offload_process;
-			else
-				node->process = rx_bond_process;
-		} else {
-			// virtio driver supports Rx vlan stripping but requires help for L4 csum
-			if (port->virtio_offloads)
-				node->process = rx_virtio_process;
-			else if (port->rx_offloads & RTE_ETH_RX_OFFLOAD_VLAN_STRIP)
-				node->process = rx_offload_process;
-			else
-				node->process = rx_process;
-		}
+		// select the process callback; skip polling RETA-deactivated rxqs
+		node->process = rxq_is_inactive(qmap->port_id, qmap->queue_id) ?
+			rx_inactive_process :
+			rx_process_for(ctx->iface, port);
 	}
 
 	// initialize all tx nodes context to invalid ports and queues
@@ -272,6 +286,47 @@ out:
 	strvec_free(rx_nodes);
 
 	return errno_set(-ret);
+}
+
+// After an rss-autoscale RETA change, swap each worker's rx node process on its
+// live graph (no reload): queue_id < n_active polls, otherwise no-ops via
+// rx_inactive_process. Aligned pointer store; the worker reads old-or-new, both
+// valid (same pattern DPDK uses to swap node->process for pcap).
+void worker_graph_rxq_set_active(uint16_t port_id, uint16_t n_active) {
+	const struct iface *iface = port_get_iface(port_id);
+	char node_name[RTE_NODE_NAMESIZE];
+	rte_node_process_t active;
+	struct worker *worker;
+
+	if (iface == NULL)
+		return;
+	active = rx_process_for(iface, iface_info_port(iface));
+
+	STAILQ_FOREACH (worker, &workers, next) {
+		unsigned cur = atomic_load(&worker->cur_config);
+		struct rte_graph *graph = worker->graph[cur];
+		struct queue_map *qmap;
+		char *graph_name;
+
+		if (graph == NULL)
+			continue;
+		graph_name = rte_graph_id_to_name(graph->id);
+		if (graph_name == NULL)
+			continue;
+		vec_foreach_ref (qmap, worker->rxqs) {
+			struct rte_node *node;
+
+			if (qmap->port_id != port_id || !qmap->enabled)
+				continue;
+			snprintf(
+				node_name, sizeof(node_name), RX_NODE_FMT, port_id, qmap->queue_id
+			);
+			node = rte_graph_node_get_by_name(graph_name, node_name);
+			if (node == NULL)
+				continue;
+			node->process = qmap->queue_id < n_active ? active : rx_inactive_process;
+		}
+	}
 }
 
 int worker_graph_reload(struct worker *worker, vec struct iface_info_port **ports) {

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -14,6 +14,7 @@ src += files(
   'netlink.c',
   'nexthop.c',
   'port.c',
+  'port_scale.c',
   'vlan.c',
   'vrf.c',
   'worker.c',
@@ -22,7 +23,7 @@ inc += include_directories('.')
 
 tests += [
   {
-    'sources': files('worker_test.c', 'port.c', 'worker.c'),
+    'sources': files('worker_test.c', 'port.c', 'port_scale.c', 'worker.c'),
     'link_args': [
       '-Wl,--wrap=numa_available',
       '-Wl,--wrap=numa_node_of_cpu',
@@ -48,7 +49,7 @@ tests += [
     ],
   },
   {
-    'sources': files('iface_test.c', 'iface.c', 'port.c', 'vlan.c'),
+    'sources': files('iface_test.c', 'iface.c', 'port.c', 'port_scale.c', 'vlan.c'),
     'link_args': [
       '-Wl,--wrap=iface_from_id',
       '-Wl,--wrap=rte_eth_allmulticast_enable',

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -15,6 +15,7 @@ src += files(
   'nexthop.c',
   'port.c',
   'port_scale.c',
+  'rss_autoscale.c',
   'vlan.c',
   'vrf.c',
   'worker.c',

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -10,6 +10,7 @@
 #include "module.h"
 #include "netlink.h"
 #include "port.h"
+#include "port_scale.h"
 #include "rcu.h"
 #include "vec.h"
 #include "vrf.h"
@@ -276,6 +277,31 @@ static int port_mtu_set(struct iface *iface, uint16_t mtu) {
 	return 0;
 }
 
+// rss-autoscale cap/floor must be one of the controller's usable dist sizes:
+// a raw HW dist-size that also survives the cluster_size filtering applied by
+// the controller (caps_ensure uses the same port_scale_caps_filter_cluster).
+// Validate against n_rxq (the target queue count, 0 = live HW) so a combined
+// "rxqs N + rss-cap/floor M" command is checked against the count it will
+// apply, not the pre-reconfig one. 0 clears the knob and is always valid.
+static bool port_rss_policy_valid(struct iface_info_port *p, uint16_t n_rxq, uint16_t v) {
+	struct port_scale_caps caps;
+	bool ok = false;
+
+	if (v == 0)
+		return true;
+	if (port_scale_caps_get_n(p, n_rxq, &caps) < 0)
+		return false;
+	port_scale_caps_filter_cluster(&caps, gr_config.rss_autoscale);
+	if (caps.supports_scale)
+		for (size_t i = 0; i < caps.allowed_count; i++)
+			if (caps.allowed_n[i] == v) {
+				ok = true;
+				break;
+			}
+	port_scale_caps_free(&caps);
+	return ok;
+}
+
 static int iface_port_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
@@ -288,8 +314,24 @@ static int iface_port_reconfig(
 	int ret;
 
 	if (!(set_attrs
-	      & (GR_PORT_SET_N_RXQS | GR_PORT_SET_N_TXQS | GR_PORT_SET_Q_SIZE | GR_PORT_SET_MAC)))
+	      & (GR_PORT_SET_N_RXQS | GR_PORT_SET_N_TXQS | GR_PORT_SET_Q_SIZE | GR_PORT_SET_MAC
+		 | GR_PORT_SET_RSS_CAP | GR_PORT_SET_RSS_FLOOR)))
 		return 0;
+
+	// Target RX queue count: if this same request changes it, validate the
+	// RSS policies against the new count (0 = keep the live HW count).
+	uint16_t target_rxq = (set_attrs & GR_PORT_SET_N_RXQS) ? api->n_rxq : 0;
+
+	if (set_attrs & GR_PORT_SET_RSS_CAP) {
+		if (!port_rss_policy_valid(p, target_rxq, api->rss_cap))
+			return errno_set(EINVAL);
+		p->rss_cap = api->rss_cap;
+	}
+	if (set_attrs & GR_PORT_SET_RSS_FLOOR) {
+		if (!port_rss_policy_valid(p, target_rxq, api->rss_floor))
+			return errno_set(EINVAL);
+		p->rss_floor = api->rss_floor;
+	}
 
 	if (set_attrs & GR_PORT_SET_N_RXQS) {
 		p->n_rxq = api->n_rxq;

--- a/modules/infra/control/port_scale.c
+++ b/modules/infra/control/port_scale.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#include "log.h"
+#include "port_scale.h"
+
+#include <rte_errno.h>
+#include <rte_ethdev.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+LOG_TYPE("port_scale");
+
+// DPAA2 MC firmware accepts dist_size only from this discrete set
+// (drivers/net/dpaa2/mc/fsl_dpni.h, struct dpni_rx_dist_cfg).
+static const uint16_t dpaa2_allowed_n[] = {
+	1,  2,	3,  4,	 6,   7,   8,	12,  14,  16,  24,  28,	 32,  48,
+	56, 64, 96, 112, 128, 192, 224, 256, 384, 448, 512, 768, 896, 1024,
+};
+
+static int
+build_allowed_n(const char *driver_name, uint16_t max_n, uint16_t **out_arr, size_t *out_count) {
+	uint16_t *arr;
+	size_t count = 0;
+
+	if (driver_name != NULL && strcmp(driver_name, "net_dpaa2") == 0) {
+		arr = calloc(RTE_DIM(dpaa2_allowed_n), sizeof(*arr));
+		if (arr == NULL)
+			return -ENOMEM;
+		for (size_t i = 0; i < RTE_DIM(dpaa2_allowed_n); i++) {
+			if (dpaa2_allowed_n[i] > max_n)
+				break;
+			arr[count++] = dpaa2_allowed_n[i];
+		}
+	} else {
+		// Other PMDs accept any N in [1..max_n].
+		arr = calloc(max_n, sizeof(*arr));
+		if (arr == NULL)
+			return -ENOMEM;
+		for (uint16_t i = 1; i <= max_n; i++)
+			arr[count++] = i;
+	}
+
+	*out_arr = arr;
+	*out_count = count;
+	return 0;
+}
+
+int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out) {
+	struct rte_eth_dev_info info;
+	int ret;
+
+	if (p == NULL || out == NULL)
+		return -EINVAL;
+
+	memset(out, 0, sizeof(*out));
+
+	if ((ret = rte_eth_dev_info_get(p->port_id, &info)) < 0)
+		return ret;
+
+	out->max_n = info.nb_rx_queues;
+	// port_scale_apply rejects a reta_size that is not a multiple of
+	// RTE_ETH_RETA_GROUP_SIZE, so refuse the same here: announcing
+	// supports_scale=true while every apply would fail is misleading.
+	if (info.reta_size == 0 || info.nb_rx_queues <= 1
+	    || info.reta_size % RTE_ETH_RETA_GROUP_SIZE != 0)
+		return 0;
+
+	if ((ret = build_allowed_n(
+		     info.driver_name, info.nb_rx_queues, &out->allowed_n, &out->allowed_count
+	     ))
+	    < 0)
+		return ret;
+
+	out->supports_scale = (out->allowed_count > 1);
+	return 0;
+}
+
+void port_scale_caps_free(struct port_scale_caps *caps) {
+	if (caps == NULL)
+		return;
+	free(caps->allowed_n);
+	memset(caps, 0, sizeof(*caps));
+}
+
+uint16_t port_scale_caps_next(const struct port_scale_caps *caps, uint16_t cur) {
+	if (caps == NULL || caps->allowed_count == 0)
+		return cur;
+	for (size_t i = 0; i < caps->allowed_count; i++) {
+		if (caps->allowed_n[i] > cur)
+			return caps->allowed_n[i];
+	}
+	return caps->allowed_n[caps->allowed_count - 1];
+}
+
+uint16_t port_scale_caps_prev(const struct port_scale_caps *caps, uint16_t cur) {
+	if (caps == NULL || caps->allowed_count == 0)
+		return cur;
+	for (size_t i = caps->allowed_count; i > 0; i--) {
+		if (caps->allowed_n[i - 1] < cur)
+			return caps->allowed_n[i - 1];
+	}
+	return caps->allowed_n[0];
+}
+
+int port_scale_apply(struct iface_info_port *p, uint16_t n) {
+	struct rte_eth_dev_info info;
+	struct rte_eth_rss_reta_entry64 *reta = NULL;
+	size_t n_groups;
+	int ret;
+
+	if (p == NULL || n == 0)
+		return -EINVAL;
+
+	if ((ret = rte_eth_dev_info_get(p->port_id, &info)) < 0)
+		return ret;
+
+	if (info.reta_size == 0)
+		return -ENOTSUP;
+
+	if (n > info.nb_rx_queues)
+		return -EINVAL;
+
+	if (info.reta_size % RTE_ETH_RETA_GROUP_SIZE != 0)
+		return -EINVAL;
+
+	n_groups = info.reta_size / RTE_ETH_RETA_GROUP_SIZE;
+	reta = calloc(n_groups, sizeof(*reta));
+	if (reta == NULL)
+		return -ENOMEM;
+
+	// Uniform RETA reta[i] = i % n: the only pattern DPAA2 accepts.
+	for (size_t g = 0; g < n_groups; g++) {
+		reta[g].mask = UINT64_MAX;
+		for (size_t i = 0; i < RTE_ETH_RETA_GROUP_SIZE; i++) {
+			uint32_t idx = g * RTE_ETH_RETA_GROUP_SIZE + i;
+			reta[g].reta[i] = idx % n;
+		}
+	}
+
+	ret = rte_eth_dev_rss_reta_update(p->port_id, reta, info.reta_size);
+	free(reta);
+
+	if (ret < 0) {
+		LOG(WARNING,
+		    "port %u: rss_reta_update(n=%u) failed: %s",
+		    p->port_id,
+		    n,
+		    rte_strerror(-ret));
+		return ret;
+	}
+
+	LOG(INFO, "port %u: scaled to %u active RX queue(s)", p->port_id, n);
+	return 0;
+}

--- a/modules/infra/control/port_scale.c
+++ b/modules/infra/control/port_scale.c
@@ -48,7 +48,7 @@ build_allowed_n(const char *driver_name, uint16_t max_n, uint16_t **out_arr, siz
 	return 0;
 }
 
-int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out) {
+int port_scale_caps_get_n(struct iface_info_port *p, uint16_t n_rxq, struct port_scale_caps *out) {
 	struct rte_eth_dev_info info;
 	int ret;
 
@@ -60,17 +60,20 @@ int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out) 
 	if ((ret = rte_eth_dev_info_get(p->port_id, &info)) < 0)
 		return ret;
 
-	out->max_n = info.nb_rx_queues;
+	// n_rxq == 0 means "the live HW queue count". A non-zero override lets a
+	// pending reconfig validate cap/floor against its target queue count;
+	// reta_size is a HW property independent of the queue count.
+	if (n_rxq == 0)
+		n_rxq = info.nb_rx_queues;
+
+	out->max_n = n_rxq;
 	// port_scale_apply rejects a reta_size that is not a multiple of
 	// RTE_ETH_RETA_GROUP_SIZE, so refuse the same here: announcing
 	// supports_scale=true while every apply would fail is misleading.
-	if (info.reta_size == 0 || info.nb_rx_queues <= 1
-	    || info.reta_size % RTE_ETH_RETA_GROUP_SIZE != 0)
+	if (info.reta_size == 0 || n_rxq <= 1 || info.reta_size % RTE_ETH_RETA_GROUP_SIZE != 0)
 		return 0;
 
-	if ((ret = build_allowed_n(
-		     info.driver_name, info.nb_rx_queues, &out->allowed_n, &out->allowed_count
-	     ))
+	if ((ret = build_allowed_n(info.driver_name, n_rxq, &out->allowed_n, &out->allowed_count))
 	    < 0)
 		return ret;
 
@@ -78,11 +81,27 @@ int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out) 
 	return 0;
 }
 
+int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out) {
+	return port_scale_caps_get_n(p, 0, out);
+}
+
 void port_scale_caps_free(struct port_scale_caps *caps) {
 	if (caps == NULL)
 		return;
 	free(caps->allowed_n);
 	memset(caps, 0, sizeof(*caps));
+}
+
+void port_scale_caps_filter_cluster(struct port_scale_caps *caps, uint16_t cluster) {
+	size_t w = 0;
+
+	if (cluster <= 1 || caps->allowed_n == NULL)
+		return;
+	for (size_t r = 0; r < caps->allowed_count; r++)
+		if (caps->allowed_n[r] % cluster == 0)
+			caps->allowed_n[w++] = caps->allowed_n[r];
+	caps->allowed_count = w;
+	caps->supports_scale = (w > 1);
 }
 
 uint16_t port_scale_caps_next(const struct port_scale_caps *caps, uint16_t cur) {
@@ -103,6 +122,16 @@ uint16_t port_scale_caps_prev(const struct port_scale_caps *caps, uint16_t cur) 
 			return caps->allowed_n[i - 1];
 	}
 	return caps->allowed_n[0];
+}
+
+uint16_t port_scale_caps_clamp(const struct port_scale_caps *caps, uint16_t n) {
+	uint16_t best = 0;
+
+	if (caps == NULL || caps->allowed_count == 0)
+		return n;
+	for (size_t i = 0; i < caps->allowed_count && caps->allowed_n[i] <= n; i++)
+		best = caps->allowed_n[i];
+	return best != 0 ? best : caps->allowed_n[0];
 }
 
 int port_scale_apply(struct iface_info_port *p, uint16_t n) {

--- a/modules/infra/control/port_scale.c
+++ b/modules/infra/control/port_scale.c
@@ -78,6 +78,9 @@ int port_scale_caps_get_n(struct iface_info_port *p, uint16_t n_rxq, struct port
 		return ret;
 
 	out->supports_scale = (out->allowed_count > 1);
+	// Non-DPAA2 PMDs expose a real indirection table: the RETA may map to an
+	// arbitrary queue set. DPAA2 only honors the i%n prefix.
+	out->indirect_reta = info.driver_name != NULL && strcmp(info.driver_name, "net_dpaa2") != 0;
 	return 0;
 }
 
@@ -182,5 +185,58 @@ int port_scale_apply(struct iface_info_port *p, uint16_t n) {
 	}
 
 	LOG(INFO, "port %u: scaled to %u active RX queue(s)", p->port_id, n);
+	return 0;
+}
+
+// Program an explicit queue set: reta[idx] = order[idx % n]. Indirect-RETA
+// PMDs only (DPAA2 rejects a non-prefix pattern with -ENOTSUP). UNTESTED.
+int port_scale_apply_order(struct iface_info_port *p, const uint16_t *order, uint16_t n) {
+	struct rte_eth_dev_info info;
+	struct rte_eth_rss_reta_entry64 *reta = NULL;
+	size_t n_groups;
+	int ret;
+
+	if (p == NULL || order == NULL || n == 0)
+		return -EINVAL;
+
+	if ((ret = rte_eth_dev_info_get(p->port_id, &info)) < 0)
+		return ret;
+
+	if (info.reta_size == 0)
+		return -ENOTSUP;
+
+	if (info.reta_size % RTE_ETH_RETA_GROUP_SIZE != 0)
+		return -EINVAL;
+
+	for (uint16_t k = 0; k < n; k++)
+		if (order[k] >= info.nb_rx_queues)
+			return -EINVAL;
+
+	n_groups = info.reta_size / RTE_ETH_RETA_GROUP_SIZE;
+	reta = calloc(n_groups, sizeof(*reta));
+	if (reta == NULL)
+		return -ENOMEM;
+
+	for (size_t g = 0; g < n_groups; g++) {
+		reta[g].mask = UINT64_MAX;
+		for (size_t i = 0; i < RTE_ETH_RETA_GROUP_SIZE; i++) {
+			uint32_t idx = g * RTE_ETH_RETA_GROUP_SIZE + i;
+			reta[g].reta[i] = order[idx % n];
+		}
+	}
+
+	ret = rte_eth_dev_rss_reta_update(p->port_id, reta, info.reta_size);
+	free(reta);
+
+	if (ret < 0) {
+		LOG(WARNING,
+		    "port %u: rss_reta_update(explicit n=%u) failed: %s",
+		    p->port_id,
+		    n,
+		    rte_strerror(-ret));
+		return ret;
+	}
+
+	LOG(INFO, "port %u: scaled to %u active RX queue(s) (explicit set)", p->port_id, n);
 	return 0;
 }

--- a/modules/infra/control/port_scale.h
+++ b/modules/infra/control/port_scale.h
@@ -19,11 +19,23 @@ struct port_scale_caps {
 };
 
 int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out);
+// Same, but compute caps for a target RX queue count (n_rxq == 0 uses the live
+// HW count). Lets a pending reconfig validate against the count it will apply.
+int port_scale_caps_get_n(struct iface_info_port *p, uint16_t n_rxq, struct port_scale_caps *out);
 void port_scale_caps_free(struct port_scale_caps *caps);
+
+// Drop allowed_n entries not aligned on cluster, keeping scaling steps on
+// cache-sharing group boundaries. cluster <= 1 is a no-op. Updates
+// allowed_count and supports_scale (false once <= 1 value remains).
+void port_scale_caps_filter_cluster(struct port_scale_caps *caps, uint16_t cluster);
 
 // Returns the same value at the boundary.
 uint16_t port_scale_caps_next(const struct port_scale_caps *caps, uint16_t cur);
 uint16_t port_scale_caps_prev(const struct port_scale_caps *caps, uint16_t cur);
+
+// Snap n onto the grid: the largest allowed_n <= n, or the smallest allowed_n
+// if n is below the grid. Returns n unchanged when the grid is empty.
+uint16_t port_scale_caps_clamp(const struct port_scale_caps *caps, uint16_t n);
 
 // Reprogram HW RETA to dispatch only on queues [0..n-1] (uniform i % n).
 // n must be in caps.allowed_n.

--- a/modules/infra/control/port_scale.h
+++ b/modules/infra/control/port_scale.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#pragma once
+
+#include "port.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// allowed_n may be a proper subset of [1..max_n] (DPAA2 has a discrete
+// list; Intel/Mellanox accept any value).
+struct port_scale_caps {
+	uint16_t max_n;
+	uint16_t *allowed_n; // sorted ascending, free with _free()
+	size_t allowed_count;
+	bool supports_scale;
+};
+
+int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out);
+void port_scale_caps_free(struct port_scale_caps *caps);
+
+// Returns the same value at the boundary.
+uint16_t port_scale_caps_next(const struct port_scale_caps *caps, uint16_t cur);
+uint16_t port_scale_caps_prev(const struct port_scale_caps *caps, uint16_t cur);
+
+// Reprogram HW RETA to dispatch only on queues [0..n-1] (uniform i % n).
+// Caller must ensure n is in caps.allowed_n; on a PMD with a discrete
+// list (e.g. DPAA2), arbitrary values are rejected by the firmware.
+int port_scale_apply(struct iface_info_port *p, uint16_t n);

--- a/modules/infra/control/port_scale.h
+++ b/modules/infra/control/port_scale.h
@@ -16,6 +16,10 @@ struct port_scale_caps {
 	uint16_t *allowed_n; // sorted ascending, free with _free()
 	size_t allowed_count;
 	bool supports_scale;
+	// PMD has a real RSS indirection table (non-DPAA2): the RETA can map to
+	// an arbitrary queue set, not only the i%n prefix. Enables per-core
+	// placement (port_scale_apply_order). DPAA2 is prefix-only -> false.
+	bool indirect_reta;
 };
 
 int port_scale_caps_get(struct iface_info_port *p, struct port_scale_caps *out);
@@ -40,3 +44,9 @@ uint16_t port_scale_caps_clamp(const struct port_scale_caps *caps, uint16_t n);
 // Reprogram HW RETA to dispatch only on queues [0..n-1] (uniform i % n).
 // n must be in caps.allowed_n.
 int port_scale_apply(struct iface_info_port *p, uint16_t n);
+
+// Like port_scale_apply but programs an explicit queue set: reta[idx] =
+// order[idx % n]. For PMDs with a real indirection table (caps.indirect_reta),
+// letting the controller place a port on chosen cores. UNTESTED on hardware --
+// DPAA2 is prefix-only and never takes this path.
+int port_scale_apply_order(struct iface_info_port *p, const uint16_t *order, uint16_t n);

--- a/modules/infra/control/port_scale.h
+++ b/modules/infra/control/port_scale.h
@@ -26,6 +26,5 @@ uint16_t port_scale_caps_next(const struct port_scale_caps *caps, uint16_t cur);
 uint16_t port_scale_caps_prev(const struct port_scale_caps *caps, uint16_t cur);
 
 // Reprogram HW RETA to dispatch only on queues [0..n-1] (uniform i % n).
-// Caller must ensure n is in caps.allowed_n; on a PMD with a discrete
-// list (e.g. DPAA2), arbitrary values are rejected by the firmware.
+// n must be in caps.allowed_n.
 int port_scale_apply(struct iface_info_port *p, uint16_t n);

--- a/modules/infra/control/rss_autoscale.c
+++ b/modules/infra/control/rss_autoscale.c
@@ -42,8 +42,6 @@ struct rss_autoscale_port_state {
 	uint16_t n_active;
 	uint16_t n_load_recommended;
 	struct port_scale_caps caps;
-	uint16_t policy_cap; // 0 = unset; cap < floor: cap wins
-	uint16_t policy_floor;
 	uint64_t prev_busy_cycles;
 	uint64_t prev_total_cycles;
 	struct event *scale_down_timer;
@@ -105,26 +103,19 @@ static int caps_ensure(struct rss_autoscale_port_state *s) {
 		return -ENOTSUP;
 
 	cluster_size = gr_config.rss_autoscale;
-	if (cluster_size > 1 && s->caps.allowed_n != NULL) {
-		size_t w = 0;
-		for (size_t r = 0; r < s->caps.allowed_count; r++) {
-			if (s->caps.allowed_n[r] % cluster_size == 0)
-				s->caps.allowed_n[w++] = s->caps.allowed_n[r];
-		}
-		s->caps.allowed_count = w;
-		if (w <= 1) {
-			// Need at least 2 allowed values to scale dynamically. Free
-			// so the allowed_n != NULL short-circuit at the top does not
-			// later treat this as a cached success.
-			LOG(NOTICE,
-			    "port %u: cluster_size=%u leaves %zu allowed N value(s), "
-			    "not managed by rss-autoscale",
-			    s->port_id,
-			    cluster_size,
-			    w);
-			port_scale_caps_free(&s->caps);
-			return -ENOTSUP;
-		}
+	port_scale_caps_filter_cluster(&s->caps, cluster_size);
+	if (!s->caps.supports_scale) {
+		// Need at least 2 allowed values to scale dynamically. Free so the
+		// allowed_n != NULL short-circuit at the top does not later treat
+		// this as a cached success.
+		LOG(NOTICE,
+		    "port %u: cluster_size=%u leaves %zu allowed N value(s), "
+		    "not managed by rss-autoscale",
+		    s->port_id,
+		    cluster_size,
+		    s->caps.allowed_count);
+		port_scale_caps_free(&s->caps);
+		return -ENOTSUP;
 	}
 	return 0;
 }
@@ -167,75 +158,17 @@ static void apply_unpark_all(void);
 static void apply_park_all(void);
 static void schedule_deferred_park(void);
 static void scale_down_timer_cb(evutil_socket_t fd, short what, void *arg);
+static uint16_t port_effective_cap(const struct rss_autoscale_port_state *s);
+static uint16_t port_effective_floor(const struct rss_autoscale_port_state *s);
 
-static uint16_t clamp_to_policy(struct rss_autoscale_port_state *s) {
-	uint16_t target = s->n_active;
-	if (s->policy_floor > 0 && target < s->policy_floor)
-		target = s->policy_floor;
-	if (s->policy_cap > 0 && target > s->policy_cap)
-		target = s->policy_cap;
-	return target;
+static uint16_t port_rss_cap(uint16_t port_id) {
+	const struct iface_info_port *p = port_info_from_id(port_id);
+	return p != NULL ? p->rss_cap : 0;
 }
 
-static bool caps_contains(const struct port_scale_caps *caps, uint16_t n) {
-	for (size_t i = 0; i < caps->allowed_count; i++) {
-		if (caps->allowed_n[i] == n)
-			return true;
-	}
-	return false;
-}
-
-// Shared logic for set_cap / set_floor. Caller provides the offset of the
-// policy field inside rss_autoscale_port_state and a name for the log.
-static int set_policy(uint16_t port_id, size_t policy_offset, uint16_t n, const char *name) {
-	struct rss_autoscale_port_state *s;
-	uint16_t *policy;
-	uint16_t saved;
-	int ret;
-
-	if (n > 0 && !gr_config.rss_autoscale)
-		return -ENOTSUP;
-	s = (n == 0) ? state_get(port_id) : state_ensure(port_id);
-	if (s == NULL)
-		return n == 0 ? 0 : -ENOMEM;
-	if (n > 0) {
-		if (s->n_active == 0)
-			return -ENOTSUP;
-		ret = caps_ensure(s);
-		if (ret < 0)
-			return ret;
-		if (!caps_contains(&s->caps, n))
-			return -EINVAL;
-	}
-	policy = (uint16_t *)((char *)s + policy_offset);
-	saved = *policy;
-	*policy = n;
-	if (s->caps.supports_scale) {
-		uint16_t target = clamp_to_policy(s);
-		if (target != s->n_active && s->n_active > 0) {
-			ret = do_apply(s, target);
-			if (ret < 0) {
-				*policy = saved;
-				return ret;
-			}
-			apply_unpark_all();
-			schedule_deferred_park();
-		}
-	}
-	LOG(INFO, "port %u: %s %s", port_id, name, n == 0 ? "cleared" : "set");
-	return 0;
-}
-
-int rss_autoscale_set_cap(uint16_t port_id, uint16_t cap_n) {
-	return set_policy(
-		port_id, offsetof(struct rss_autoscale_port_state, policy_cap), cap_n, "cap"
-	);
-}
-
-int rss_autoscale_set_floor(uint16_t port_id, uint16_t floor_n) {
-	return set_policy(
-		port_id, offsetof(struct rss_autoscale_port_state, policy_floor), floor_n, "floor"
-	);
+static uint16_t port_rss_floor(uint16_t port_id) {
+	const struct iface_info_port *p = port_info_from_id(port_id);
+	return p != NULL ? p->rss_floor : 0;
 }
 
 static void rss_autoscale_on_iface_post_add(uint32_t /*event*/, const void *obj) {
@@ -272,10 +205,10 @@ static void rss_autoscale_on_iface_post_add(uint32_t /*event*/, const void *obj)
 	}
 
 	pin = gr_config.rss_autoscale;
-	if (s->policy_floor > 0 && pin < s->policy_floor)
-		pin = s->policy_floor;
-	if (s->policy_cap > 0 && pin > s->policy_cap)
-		pin = s->policy_cap;
+	if (p->rss_floor > 0 && pin < p->rss_floor)
+		pin = p->rss_floor;
+	if (p->rss_cap > 0 && pin > p->rss_cap)
+		pin = p->rss_cap;
 	if (!do_apply(s, pin)) {
 		apply_unpark_all();
 		schedule_deferred_park();
@@ -318,11 +251,54 @@ static void rss_autoscale_on_iface_remove(uint32_t /*event*/, const void *obj) {
 		rxq_health_reset(&rxq_health[p->port_id][q]);
 }
 
-// Port reconfig (e.g. operator changed nb-rxqs): drop cached state and
-// re-pin from scratch so caps and rxq_health match the new HW layout.
+// Port reconfig: only the queue-count-dependent caps grid can really change,
+// so rebuild it in place and re-clamp the current operating point onto the new
+// grid plus the operator cap/floor. An unrelated reconfig (MTU, MAC) leaves the
+// grid unchanged, so n_active does not move and the scaling state, rxq_health
+// and scale-down timer are all preserved.
 static void rss_autoscale_on_iface_post_reconfig(uint32_t event, const void *obj) {
-	rss_autoscale_on_iface_remove(event, obj);
-	rss_autoscale_on_iface_post_add(event, obj);
+	struct rss_autoscale_port_state *s;
+	const struct iface_info_port *p;
+	const struct iface *iface = obj;
+	uint16_t floor;
+	uint16_t want;
+	uint16_t cap;
+
+	if (iface->type != GR_IFACE_TYPE_PORT || !gr_config.rss_autoscale)
+		return;
+
+	p = iface_info_port(iface);
+	s = state_get(p->port_id);
+	if (s == NULL) {
+		// Never managed (added unscalable, or add-time pin failed): retry the
+		// full add path now that the layout changed.
+		rss_autoscale_on_iface_post_add(event, obj);
+		return;
+	}
+
+	// Force a rebuild (caps_ensure short-circuits on a cached allowed_n).
+	port_scale_caps_free(&s->caps);
+	if (caps_ensure(s) < 0) {
+		// Became unscalable (e.g. nb-rxqs dropped to 1): tear down.
+		rss_autoscale_on_iface_remove(event, obj);
+		return;
+	}
+
+	want = port_scale_caps_clamp(&s->caps, s->n_active);
+	floor = port_effective_floor(s);
+	cap = port_effective_cap(s);
+	if (floor > 0 && want < floor)
+		want = floor;
+	if (cap > 0 && want > cap)
+		want = cap;
+	// A floor set when more queues existed can now exceed the grid top: snap
+	// back onto a valid dist size.
+	want = port_scale_caps_clamp(&s->caps, want);
+
+	if (want != s->n_active && do_apply(s, want) == 0) {
+		apply_unpark_all();
+		schedule_deferred_park();
+	}
 }
 
 static bool worker_has_active_rxq(const struct worker *w) {
@@ -379,13 +355,14 @@ static uint16_t port_effective_cap(const struct rss_autoscale_port_state *s) {
 	uint16_t cap = (s->caps.allowed_count > 0) ?
 		s->caps.allowed_n[s->caps.allowed_count - 1] :
 		s->caps.max_n;
-	if (s->policy_cap > 0 && s->policy_cap < cap)
-		cap = s->policy_cap;
+	uint16_t pc = port_rss_cap(s->port_id);
+	if (pc > 0 && pc < cap)
+		cap = pc;
 	return cap;
 }
 
 static uint16_t port_effective_floor(const struct rss_autoscale_port_state *s) {
-	return s->policy_floor;
+	return port_rss_floor(s->port_id);
 }
 
 // Aggregate busy/total cycles of the workers serving at least one active queue
@@ -588,12 +565,12 @@ int rss_autoscale_port_state_get(
 	if (n_load_recommended)
 		*n_load_recommended = s->n_load_recommended;
 	if (cap)
-		*cap = s->policy_cap;
+		*cap = port_rss_cap(port_id);
 	if (floor)
-		*floor = s->policy_floor;
+		*floor = port_rss_floor(port_id);
 	// max_n / min_n are the usable bounds after cluster_size filtering,
 	// not the raw HW range: an operator querying them must be able to
-	// pass them back through set_cap / set_floor without -EINVAL.
+	// pass them back as rss-cap / rss-floor without -EINVAL.
 	if (max_n)
 		*max_n = (s->caps.allowed_count > 0) ?
 			s->caps.allowed_n[s->caps.allowed_count - 1] :

--- a/modules/infra/control/rss_autoscale.c
+++ b/modules/infra/control/rss_autoscale.c
@@ -46,6 +46,11 @@ struct rss_autoscale_port_state {
 	uint64_t prev_total_cycles;
 	struct event *scale_down_timer;
 	bool deferred_deactivate_pending;
+	// Activation order: order[k] is the physical queue id of the k-th active
+	// slot. NULL for prefix PMDs (identity order, order[k] == k); for indirect-
+	// RETA PMDs it is allocated to caps.max_n (the port's queue count) and
+	// filled by compute_order(). Only slots [0, n_active) are meaningful.
+	uint16_t *order;
 };
 
 static struct rss_autoscale_port_state *port_states[RTE_MAX_ETHPORTS];
@@ -123,11 +128,117 @@ static int caps_ensure(struct rss_autoscale_port_state *s) {
 		port_scale_caps_free(&s->caps);
 		return -ENOTSUP;
 	}
+	// Indirect-RETA PMDs use an explicit per-core placement order, sized to the
+	// port's queue count. Prefix PMDs (DPAA2) leave order NULL (identity), so
+	// no allocation and the tested i%n path is untouched.
+	if (s->caps.indirect_reta) {
+		free(s->order);
+		s->order = calloc(s->caps.max_n, sizeof(*s->order));
+	}
 	return 0;
 }
 
 static void
 port_worker_cycles(uint16_t port_id, uint16_t n_active, uint64_t *out_busy, uint64_t *out_total);
+
+// Physical queue id of the k-th active slot. Identity for prefix PMDs.
+static uint16_t active_q(const struct rss_autoscale_port_state *s, uint16_t k) {
+	return (s->caps.indirect_reta && s->order != NULL) ? s->order[k] : k;
+}
+
+static bool
+port_rxq_active_within(const struct rss_autoscale_port_state *s, uint16_t queue_id, uint16_t n) {
+	if (!s->caps.indirect_reta || s->order == NULL)
+		return queue_id < n;
+	for (uint16_t k = 0; k < n; k++)
+		if (s->order[k] == queue_id)
+			return true;
+	return false;
+}
+
+bool rss_autoscale_port_rxq_active_within(uint16_t port_id, uint16_t queue_id, uint16_t n) {
+	const struct rss_autoscale_port_state *s = state_get(port_id);
+	// Unmanaged or prefix PMD: preserve the queue_id < n semantics.
+	if (s == NULL)
+		return queue_id < n;
+	return port_rxq_active_within(s, queue_id, n);
+}
+
+// Indirect-RETA greedy placement: append the queues whose bound CPUs carry the
+// fewest active queues of other ports. No-op for prefix PMDs (DPAA2). UNTESTED.
+static void compute_order(struct rss_autoscale_port_state *s, uint16_t n) {
+	uint16_t q_cpu[RTE_MAX_QUEUES_PER_PORT]; // this port's queue -> bound cpu
+	bool used[RTE_MAX_QUEUES_PER_PORT] = {0};
+	uint16_t occ[RTE_MAX_LCORE] = {0}; // active queues of other ports, per cpu
+	struct iface_info_port *p;
+	struct queue_map *qm;
+	uint16_t base, nq;
+	struct worker *w;
+
+	if (!s->caps.indirect_reta || s->order == NULL)
+		return;
+	base = s->n_active;
+	if (n <= base)
+		return; // scale-down: keep order[0..n), nothing new to place
+
+	p = port_info_from_id(s->port_id);
+	nq = (p != NULL) ? p->n_rxq : 0;
+	if (nq == 0 || nq > RTE_MAX_QUEUES_PER_PORT)
+		return;
+
+	for (uint16_t q = 0; q < nq; q++)
+		q_cpu[q] = UINT16_MAX;
+
+	STAILQ_FOREACH (w, &workers, next) {
+		if (w->cpu_id >= RTE_MAX_LCORE)
+			continue;
+		vec_foreach_ref (qm, w->rxqs) {
+			struct rss_autoscale_port_state *o;
+			bool polls;
+
+			if (qm->port_id == s->port_id) {
+				if (qm->queue_id < nq)
+					q_cpu[qm->queue_id] = w->cpu_id;
+				continue;
+			}
+			// Another port occupies this cpu when it polls the queue: a
+			// managed port by its active set, an unmanaged/unscalable one
+			// (no RETA scaling) by every enabled queue.
+			o = state_get(qm->port_id);
+			polls = (o != NULL && o->caps.supports_scale) ?
+				port_rxq_active_within(o, qm->queue_id, o->n_active) :
+				qm->enabled;
+			if (polls)
+				occ[w->cpu_id]++;
+		}
+	}
+
+	// Keep already-placed slots; mark their queues used so we only append.
+	for (uint16_t k = 0; k < base && k < nq; k++)
+		if (s->order[k] < nq)
+			used[s->order[k]] = true;
+
+	for (uint16_t k = base; k < n && k < nq; k++) {
+		int best = -1;
+
+		for (uint16_t q = 0; q < nq; q++) {
+			if (used[q] || q_cpu[q] == UINT16_MAX)
+				continue;
+			if (best < 0 || occ[q_cpu[q]] < occ[q_cpu[best]]
+			    || (occ[q_cpu[q]] == occ[q_cpu[best]] && q_cpu[q] < q_cpu[best]))
+				best = q;
+		}
+		if (best < 0) {
+			// Bind not ready or fewer bound queues than n: identity tail
+			// (== prefix placement) for the remaining slots.
+			for (; k < n && k < nq; k++)
+				s->order[k] = k;
+			return;
+		}
+		s->order[k] = (uint16_t)best;
+		used[best] = true;
+	}
+}
 
 // On success, rearms the scale-down timer on a fresh CPU baseline so
 // the next fire averages only post-apply cycles.
@@ -138,7 +249,14 @@ static int do_apply(struct rss_autoscale_port_state *s, uint16_t n_new) {
 	p = port_info_from_id(s->port_id);
 	if (p == NULL)
 		return -ENODEV;
-	ret = port_scale_apply(p, n_new);
+	// Indirect-RETA PMDs get an explicit per-core placement; prefix PMDs
+	// (DPAA2) keep the tested i%n path untouched.
+	if (s->caps.indirect_reta) {
+		compute_order(s, n_new);
+		ret = port_scale_apply_order(p, s->order, n_new);
+	} else {
+		ret = port_scale_apply(p, n_new);
+	}
 	if (ret < 0)
 		return ret;
 	// Scale-up: resume the reactivated rxqs now. Scale-down: keep them polling
@@ -151,8 +269,8 @@ static int do_apply(struct rss_autoscale_port_state *s, uint16_t n_new) {
 	// Newly-activated queues may carry stale idle latched during a
 	// previous deactivation drain. Clear their health so the next
 	// !any_idle check is not blocked by them.
-	for (uint16_t q = s->n_active; q < n_new; q++)
-		rxq_health_reset(&rxq_health[s->port_id][q]);
+	for (uint16_t k = s->n_active; k < n_new; k++)
+		rxq_health_reset(&rxq_health[s->port_id][active_q(s, k)]);
 	s->n_active = n_new;
 	if (s->n_load_recommended == 0)
 		s->n_load_recommended = n_new;
@@ -257,6 +375,7 @@ static void rss_autoscale_on_iface_remove(uint32_t /*event*/, const void *obj) {
 		event_free(s->scale_down_timer);
 	}
 	port_scale_caps_free(&s->caps);
+	free(s->order);
 	free(s);
 	port_states[p->port_id] = NULL;
 	for (uint16_t q = 0; q < RTE_MAX_QUEUES_PER_PORT; q++)
@@ -323,7 +442,7 @@ static bool worker_has_active_rxq(const struct worker *w) {
 		// still distributes traffic to.
 		if (ps == NULL || !ps->caps.supports_scale || ps->n_active == 0)
 			return true;
-		if (qmap->queue_id < ps->n_active)
+		if (port_rxq_active_within(ps, qmap->queue_id, ps->n_active))
 			return true;
 	}
 	return false;
@@ -409,7 +528,10 @@ port_worker_cycles(uint16_t port_id, uint16_t n_active, uint64_t *out_busy, uint
 		if (ws == NULL)
 			continue;
 		vec_foreach_ref (qm, w->rxqs) {
-			if (qm->port_id == port_id && qm->queue_id < n_active) {
+			if (qm->port_id == port_id
+			    && rss_autoscale_port_rxq_active_within(
+				    port_id, qm->queue_id, n_active
+			    )) {
 				serves = true;
 				break;
 			}
@@ -434,8 +556,8 @@ static uint16_t decide_port(struct rss_autoscale_port_state *s) {
 	bool any_idle = false;
 	uint16_t n_new;
 
-	for (uint16_t q = 0; q < n_queues; q++) {
-		struct rxq_health *h = &rxq_health[s->port_id][q];
+	for (uint16_t k = 0; k < n_queues; k++) {
+		struct rxq_health *h = &rxq_health[s->port_id][active_q(s, k)];
 		if (atomic_load_explicit(&h->saturated, memory_order_relaxed))
 			any_saturated = true;
 		if (atomic_load_explicit(&h->idle, memory_order_relaxed))
@@ -480,8 +602,10 @@ static void scale_down_timer_cb(evutil_socket_t /*fd*/, short /*what*/, void *ar
 
 	// All active queues idle is a direct signal independent of cross-port
 	// worker CPU attribution.
-	for (uint16_t q = 0; q < s->n_active; q++) {
-		if (!atomic_load_explicit(&rxq_health[s->port_id][q].idle, memory_order_relaxed)) {
+	for (uint16_t k = 0; k < s->n_active; k++) {
+		if (!atomic_load_explicit(
+			    &rxq_health[s->port_id][active_q(s, k)].idle, memory_order_relaxed
+		    )) {
 			all_idle = false;
 			break;
 		}
@@ -637,6 +761,7 @@ static void rss_autoscale_fini(struct event_base * /*ev_base*/) {
 				port_states[i]->scale_down_timer = NULL;
 			}
 			port_scale_caps_free(&port_states[i]->caps);
+			free(port_states[i]->order);
 			free(port_states[i]);
 			port_states[i] = NULL;
 		}

--- a/modules/infra/control/rss_autoscale.c
+++ b/modules/infra/control/rss_autoscale.c
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#include "config.h"
+#include "control_queue.h"
+#include "event.h"
+#include "iface.h"
+#include "log.h"
+#include "module.h"
+#include "port.h"
+#include "port_scale.h"
+#include "rss_autoscale.h"
+#include "worker.h"
+
+#include <gr_infra.h>
+#include <gr_string.h>
+
+#include <event2/event.h>
+#include <rte_ethdev.h>
+#include <rte_graph.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <time.h>
+
+LOG_TYPE("rss_autoscale");
+
+struct rxq_health rxq_health[RTE_MAX_ETHPORTS][RTE_MAX_QUEUES_PER_PORT];
+
+// Worker clears consec_*/health on its next poll (keeps consec_* single-writer).
+static void rxq_health_reset(struct rxq_health *h) {
+	atomic_store_explicit(&h->reset_pending, true, memory_order_relaxed);
+}
+
+#define SCALE_DOWN_PERIOD_S 600
+#define DEFERRED_PARK_US 100000
+
+struct rss_autoscale_port_state {
+	uint16_t port_id;
+	uint16_t n_active;
+	uint16_t n_load_recommended;
+	struct port_scale_caps caps;
+	uint16_t policy_cap; // 0 = unset; cap < floor: cap wins
+	uint16_t policy_floor;
+	uint64_t prev_busy_cycles;
+	uint64_t prev_total_cycles;
+	struct event *scale_down_timer;
+};
+
+static struct rss_autoscale_port_state *port_states[RTE_MAX_ETHPORTS];
+static struct event_base *rss_autoscale_ev_base;
+static struct event *deferred_park_event;
+
+static struct iface_info_port *port_info_from_id(uint16_t port_id) {
+	const struct iface *i = port_get_iface(port_id);
+	if (i == NULL)
+		return NULL;
+	return iface_info_port(i);
+}
+
+static struct rss_autoscale_port_state *state_get(uint16_t port_id) {
+	if (port_id >= RTE_MAX_ETHPORTS)
+		return NULL;
+	return port_states[port_id];
+}
+
+bool rss_autoscale_port_enabled(uint16_t port_id) {
+	struct rss_autoscale_port_state *s = state_get(port_id);
+	return s != NULL && s->caps.supports_scale;
+}
+
+static struct rss_autoscale_port_state *state_ensure(uint16_t port_id) {
+	struct rss_autoscale_port_state *s;
+
+	if (port_id >= RTE_MAX_ETHPORTS)
+		return NULL;
+	if (port_states[port_id] != NULL)
+		return port_states[port_id];
+	s = calloc(1, sizeof(*s));
+	if (s == NULL)
+		return NULL;
+	s->port_id = port_id;
+	port_states[port_id] = s;
+	return s;
+}
+
+// Lazily populate caps and filter allowed_n by cluster_size so scaling
+// steps stay aligned with cache-sharing groups.
+static int caps_ensure(struct rss_autoscale_port_state *s) {
+	struct iface_info_port *p;
+	uint16_t cluster_size;
+	int ret;
+
+	if (s->caps.allowed_n != NULL)
+		return s->caps.supports_scale ? 0 : -ENOTSUP;
+	p = port_info_from_id(s->port_id);
+	if (p == NULL)
+		return -ENODEV;
+	ret = port_scale_caps_get(p, &s->caps);
+	if (ret < 0)
+		return ret;
+	if (!s->caps.supports_scale)
+		return -ENOTSUP;
+
+	cluster_size = gr_config.rss_autoscale;
+	if (cluster_size > 1 && s->caps.allowed_n != NULL) {
+		size_t w = 0;
+		for (size_t r = 0; r < s->caps.allowed_count; r++) {
+			if (s->caps.allowed_n[r] % cluster_size == 0)
+				s->caps.allowed_n[w++] = s->caps.allowed_n[r];
+		}
+		s->caps.allowed_count = w;
+		if (w <= 1) {
+			// Need at least 2 allowed values to scale dynamically. Free
+			// so the allowed_n != NULL short-circuit at the top does not
+			// later treat this as a cached success.
+			LOG(NOTICE,
+			    "port %u: cluster_size=%u leaves %zu allowed N value(s), "
+			    "not managed by rss-autoscale",
+			    s->port_id,
+			    cluster_size,
+			    w);
+			port_scale_caps_free(&s->caps);
+			return -ENOTSUP;
+		}
+	}
+	return 0;
+}
+
+static void
+port_worker_cycles(uint16_t port_id, uint16_t n_active, uint64_t *out_busy, uint64_t *out_total);
+
+// On success, rearms the scale-down timer on a fresh CPU baseline so
+// the next fire averages only post-apply cycles.
+static int do_apply(struct rss_autoscale_port_state *s, uint16_t n_new) {
+	struct iface_info_port *p;
+	int ret;
+
+	p = port_info_from_id(s->port_id);
+	if (p == NULL)
+		return -ENODEV;
+	ret = port_scale_apply(p, n_new);
+	if (ret < 0)
+		return ret;
+	LOG(INFO, "port %u: dist_size %u -> %u", s->port_id, s->n_active, n_new);
+	// Newly-activated queues may carry stale idle latched during a
+	// previous deactivation drain. Clear their health so the next
+	// !any_idle check is not blocked by them.
+	for (uint16_t q = s->n_active; q < n_new; q++)
+		rxq_health_reset(&rxq_health[s->port_id][q]);
+	s->n_active = n_new;
+	if (s->n_load_recommended == 0)
+		s->n_load_recommended = n_new;
+	if (s->scale_down_timer != NULL) {
+		struct timeval tv = {.tv_sec = SCALE_DOWN_PERIOD_S};
+		port_worker_cycles(s->port_id, n_new, &s->prev_busy_cycles, &s->prev_total_cycles);
+		event_del(s->scale_down_timer);
+		if (event_add(s->scale_down_timer, &tv) < 0)
+			LOG(WARNING, "port %u: scale-down timer rearm failed", s->port_id);
+	}
+	return 0;
+}
+
+static void apply_unpark_all(void);
+static void apply_park_all(void);
+static void schedule_deferred_park(void);
+static void scale_down_timer_cb(evutil_socket_t fd, short what, void *arg);
+
+static uint16_t clamp_to_policy(struct rss_autoscale_port_state *s) {
+	uint16_t target = s->n_active;
+	if (s->policy_floor > 0 && target < s->policy_floor)
+		target = s->policy_floor;
+	if (s->policy_cap > 0 && target > s->policy_cap)
+		target = s->policy_cap;
+	return target;
+}
+
+static bool caps_contains(const struct port_scale_caps *caps, uint16_t n) {
+	for (size_t i = 0; i < caps->allowed_count; i++) {
+		if (caps->allowed_n[i] == n)
+			return true;
+	}
+	return false;
+}
+
+// Shared logic for set_cap / set_floor. Caller provides the offset of the
+// policy field inside rss_autoscale_port_state and a name for the log.
+static int set_policy(uint16_t port_id, size_t policy_offset, uint16_t n, const char *name) {
+	struct rss_autoscale_port_state *s;
+	uint16_t *policy;
+	uint16_t saved;
+	int ret;
+
+	if (n > 0 && !gr_config.rss_autoscale)
+		return -ENOTSUP;
+	s = (n == 0) ? state_get(port_id) : state_ensure(port_id);
+	if (s == NULL)
+		return n == 0 ? 0 : -ENOMEM;
+	if (n > 0) {
+		if (s->n_active == 0)
+			return -ENOTSUP;
+		ret = caps_ensure(s);
+		if (ret < 0)
+			return ret;
+		if (!caps_contains(&s->caps, n))
+			return -EINVAL;
+	}
+	policy = (uint16_t *)((char *)s + policy_offset);
+	saved = *policy;
+	*policy = n;
+	if (s->caps.supports_scale) {
+		uint16_t target = clamp_to_policy(s);
+		if (target != s->n_active && s->n_active > 0) {
+			ret = do_apply(s, target);
+			if (ret < 0) {
+				*policy = saved;
+				return ret;
+			}
+			apply_unpark_all();
+			schedule_deferred_park();
+		}
+	}
+	LOG(INFO, "port %u: %s %s", port_id, name, n == 0 ? "cleared" : "set");
+	return 0;
+}
+
+int rss_autoscale_set_cap(uint16_t port_id, uint16_t cap_n) {
+	return set_policy(
+		port_id, offsetof(struct rss_autoscale_port_state, policy_cap), cap_n, "cap"
+	);
+}
+
+int rss_autoscale_set_floor(uint16_t port_id, uint16_t floor_n) {
+	return set_policy(
+		port_id, offsetof(struct rss_autoscale_port_state, policy_floor), floor_n, "floor"
+	);
+}
+
+static void rss_autoscale_on_iface_post_add(uint32_t /*event*/, const void *obj) {
+	struct rss_autoscale_port_state *s;
+	const struct iface_info_port *p;
+	const struct iface *iface = obj;
+	uint16_t pin;
+	int ret;
+
+	if (iface->type != GR_IFACE_TYPE_PORT)
+		return;
+	if (!gr_config.rss_autoscale)
+		return;
+
+	p = iface_info_port(iface);
+	s = state_ensure(p->port_id);
+	if (s == NULL)
+		return;
+
+	ret = caps_ensure(s);
+	if (ret == -ENOTSUP)
+		return;
+	if (ret < 0) {
+		LOG(WARNING, "port %u: caps_ensure failed: %s", p->port_id, strerror(-ret));
+		return;
+	}
+
+	if (s->scale_down_timer == NULL && rss_autoscale_ev_base != NULL) {
+		s->scale_down_timer = event_new(
+			rss_autoscale_ev_base, -1, EV_PERSIST, scale_down_timer_cb, s
+		);
+		if (s->scale_down_timer == NULL)
+			LOG(WARNING, "port %u: scale-down timer alloc failed", p->port_id);
+	}
+
+	pin = gr_config.rss_autoscale;
+	if (s->policy_floor > 0 && pin < s->policy_floor)
+		pin = s->policy_floor;
+	if (s->policy_cap > 0 && pin > s->policy_cap)
+		pin = s->policy_cap;
+	if (!do_apply(s, pin)) {
+		apply_unpark_all();
+		schedule_deferred_park();
+	} else {
+		// Pin failed: leave the HW on its default RSS distribution and
+		// mark the port unscalable. Parking would strand workers on
+		// queues the HW still routes traffic to.
+		LOG(WARNING,
+		    "port %u: initial pin to N=%u failed, leaving default RSS",
+		    p->port_id,
+		    pin);
+		if (s->scale_down_timer != NULL) {
+			event_del(s->scale_down_timer);
+			event_free(s->scale_down_timer);
+			s->scale_down_timer = NULL;
+		}
+		port_scale_caps_free(&s->caps);
+	}
+}
+
+static void rss_autoscale_on_iface_remove(uint32_t /*event*/, const void *obj) {
+	struct rss_autoscale_port_state *s;
+	const struct iface_info_port *p;
+	const struct iface *iface = obj;
+
+	if (iface->type != GR_IFACE_TYPE_PORT)
+		return;
+	p = iface_info_port(iface);
+	s = state_get(p->port_id);
+	if (s == NULL)
+		return;
+	if (s->scale_down_timer != NULL) {
+		event_del(s->scale_down_timer);
+		event_free(s->scale_down_timer);
+	}
+	port_scale_caps_free(&s->caps);
+	free(s);
+	port_states[p->port_id] = NULL;
+	for (uint16_t q = 0; q < RTE_MAX_QUEUES_PER_PORT; q++)
+		rxq_health_reset(&rxq_health[p->port_id][q]);
+}
+
+// Port reconfig (e.g. operator changed nb-rxqs): drop cached state and
+// re-pin from scratch so caps and rxq_health match the new HW layout.
+static void rss_autoscale_on_iface_post_reconfig(uint32_t event, const void *obj) {
+	rss_autoscale_on_iface_remove(event, obj);
+	rss_autoscale_on_iface_post_add(event, obj);
+}
+
+static bool worker_has_active_rxq(const struct worker *w) {
+	struct queue_map *qmap;
+	vec_foreach_ref (qmap, w->rxqs) {
+		struct rss_autoscale_port_state *ps = state_get(qmap->port_id);
+		// Ports unmanaged by the controller (no state, PMD without
+		// RETA, pin failed, or initial pin not yet applied) keep all
+		// workers awake: parking them would strand queues the HW
+		// still distributes traffic to.
+		if (ps == NULL || !ps->caps.supports_scale || ps->n_active == 0)
+			return true;
+		if (qmap->queue_id < ps->n_active)
+			return true;
+	}
+	return false;
+}
+
+static void apply_unpark_all(void) {
+	struct worker *w;
+	STAILQ_FOREACH (w, &workers, next) {
+		if (worker_is_paused(w) && worker_has_active_rxq(w))
+			worker_unpark(w);
+	}
+}
+
+static void apply_park_all(void) {
+	struct worker *w;
+	STAILQ_FOREACH (w, &workers, next) {
+		if (!worker_is_paused(w) && !worker_has_active_rxq(w))
+			worker_park(w);
+	}
+}
+
+static void deferred_park_cb(evutil_socket_t /*fd*/, short /*what*/, void * /*arg*/) {
+	apply_park_all();
+}
+
+// First schedule arms the timer; subsequent ones during the window are
+// no-ops so a burst of RETA changes still fires a single park sweep.
+static void schedule_deferred_park(void) {
+	struct timeval tv;
+
+	if (deferred_park_event == NULL)
+		return;
+	if (event_pending(deferred_park_event, EV_TIMEOUT, NULL))
+		return;
+	tv.tv_sec = DEFERRED_PARK_US / 1000000;
+	tv.tv_usec = DEFERRED_PARK_US % 1000000;
+	event_add(deferred_park_event, &tv);
+}
+
+static uint16_t port_effective_cap(const struct rss_autoscale_port_state *s) {
+	uint16_t cap = (s->caps.allowed_count > 0) ?
+		s->caps.allowed_n[s->caps.allowed_count - 1] :
+		s->caps.max_n;
+	if (s->policy_cap > 0 && s->policy_cap < cap)
+		cap = s->policy_cap;
+	return cap;
+}
+
+static uint16_t port_effective_floor(const struct rss_autoscale_port_state *s) {
+	return s->policy_floor;
+}
+
+// Aggregate busy/total cycles of the workers serving at least one active queue
+// of this port. Workers serving none are skipped; a worker shared between ports
+// still contributes its cross-port cycles, so on shared-worker layouts this is
+// the combined datapath utilisation, not a per-port figure -- a coarse "busy
+// enough to keep the queues" signal for scale-down.
+static void
+port_worker_cycles(uint16_t port_id, uint16_t n_active, uint64_t *out_busy, uint64_t *out_total) {
+	uint64_t busy = 0, total = 0;
+	struct worker *w;
+	STAILQ_FOREACH (w, &workers, next) {
+		const struct worker_stats *ws = atomic_load_explicit(
+			&w->stats, memory_order_relaxed
+		);
+		struct queue_map *qm;
+		bool serves = false;
+
+		if (ws == NULL)
+			continue;
+		vec_foreach_ref (qm, w->rxqs) {
+			if (qm->port_id == port_id && qm->queue_id < n_active) {
+				serves = true;
+				break;
+			}
+		}
+		if (!serves)
+			continue;
+		busy += ws->busy_cycles;
+		total += ws->total_cycles;
+	}
+	*out_busy = busy;
+	*out_total = total;
+}
+
+// Event-driven scale-up. The !any_idle guard blocks the elephant-flow
+// ratchet (a single dominant 5-tuple keeps q0 saturated while newer
+// queues never receive, so adding more queues never helps).
+static uint16_t decide_port(struct rss_autoscale_port_state *s) {
+	uint16_t n_queues = (uint16_t)s->n_active;
+	uint16_t floor = port_effective_floor(s);
+	uint16_t cap = port_effective_cap(s);
+	bool any_saturated = false;
+	bool any_idle = false;
+	uint16_t n_new;
+
+	for (uint16_t q = 0; q < n_queues; q++) {
+		struct rxq_health *h = &rxq_health[s->port_id][q];
+		if (atomic_load_explicit(&h->saturated, memory_order_relaxed))
+			any_saturated = true;
+		if (atomic_load_explicit(&h->idle, memory_order_relaxed))
+			any_idle = true;
+	}
+
+	n_new = s->n_active;
+	if (any_saturated && !any_idle) {
+		uint16_t n_next = port_scale_caps_next(&s->caps, s->n_active);
+		if (n_next > s->n_active)
+			n_new = n_next;
+	}
+
+	s->n_load_recommended = n_new;
+
+	// floor and cap are guaranteed to be in caps.allowed_n by API entry.
+	if (floor > 0 && n_new < floor)
+		n_new = floor;
+	if (cap > 0 && n_new > cap)
+		n_new = cap;
+
+	return n_new;
+}
+
+// Per-port periodic scale-down. Steps n_active down when the aggregate
+// busy/total of the workers serving the port has stayed below 40% over
+// the last SCALE_DOWN_PERIOD_S window.
+static void scale_down_timer_cb(evutil_socket_t /*fd*/, short /*what*/, void *arg) {
+	uint64_t busy_now, total_now, d_busy, d_total;
+	struct rss_autoscale_port_state *s = arg;
+	uint16_t floor, n_load, n_new, cap;
+	bool all_idle = true;
+	bool reloaded;
+
+	if (!s->caps.supports_scale)
+		return;
+	if (s->n_active <= 1)
+		return;
+	floor = port_effective_floor(s);
+	if (floor > 0 && s->n_active <= floor)
+		return;
+
+	// All active queues idle is a direct signal independent of cross-port
+	// worker CPU attribution.
+	for (uint16_t q = 0; q < s->n_active; q++) {
+		if (!atomic_load_explicit(&rxq_health[s->port_id][q].idle, memory_order_relaxed)) {
+			all_idle = false;
+			break;
+		}
+	}
+
+	port_worker_cycles(s->port_id, s->n_active, &busy_now, &total_now);
+	// worker_stats is replaced (counters reset to 0) on a graph reload; a
+	// backwards step means that happened, so drop this window's deltas and
+	// re-baseline. Avoids the uint64 underflow that would make d_busy * 10
+	// overflow and the busy ratio meaningless.
+	reloaded = busy_now < s->prev_busy_cycles || total_now < s->prev_total_cycles;
+	d_busy = reloaded ? 0 : busy_now - s->prev_busy_cycles;
+	d_total = reloaded ? 0 : total_now - s->prev_total_cycles;
+	s->prev_busy_cycles = busy_now;
+	s->prev_total_cycles = total_now;
+	if (!all_idle) {
+		if (d_total < 1000000)
+			return; // not enough samples (startup race / post-reload)
+		if (d_busy * 10 >= d_total * 4)
+			return; // >= 40% busy
+	}
+
+	n_load = port_scale_caps_prev(&s->caps, s->n_active);
+	s->n_load_recommended = n_load;
+
+	n_new = n_load;
+	if (floor > 0 && n_new < floor)
+		n_new = floor;
+	cap = port_effective_cap(s);
+	if (cap > 0 && n_new > cap)
+		n_new = cap;
+	if (n_new >= s->n_active)
+		return;
+
+	if (do_apply(s, n_new) == 0) {
+		apply_unpark_all();
+		schedule_deferred_park();
+	}
+}
+
+static void rss_autoscale_decide_all(void);
+
+static char rss_autoscale_kick_token;
+static atomic_int rss_autoscale_kick_pending;
+
+static void rss_autoscale_kick_cb(
+	void * /*obj*/,
+	uintptr_t /*priv*/,
+	const struct control_queue_drain * /*drain*/
+) {
+	// Clear before scanning so a transition racing decide_all re-arms the
+	// kick and is not lost.
+	atomic_store_explicit(&rss_autoscale_kick_pending, 0, memory_order_relaxed);
+	rss_autoscale_decide_all();
+}
+
+void rxq_health_notify_transition(void) {
+	// Coalesce: at most one kick in flight. decide_all rescans every port,
+	// so a single pass absorbs any number of concurrent transitions; this
+	// keeps health edges from flooding the shared control queue and
+	// starving the control-plane punt path.
+	if (atomic_exchange_explicit(&rss_autoscale_kick_pending, 1, memory_order_relaxed) == 1)
+		return;
+	// Enqueue failure (control_queue full) is fine: clear the flag so any
+	// later transition re-triggers a pass.
+	if (control_queue_push(rss_autoscale_kick_cb, &rss_autoscale_kick_token, 0) == 0)
+		control_queue_done();
+	else
+		atomic_store_explicit(&rss_autoscale_kick_pending, 0, memory_order_relaxed);
+}
+
+static void rss_autoscale_decide_all(void) {
+	bool any_change = false;
+	for (uint16_t port_id = 0; port_id < RTE_MAX_ETHPORTS; port_id++) {
+		struct rss_autoscale_port_state *s = port_states[port_id];
+		uint16_t target;
+
+		if (s == NULL || !s->caps.supports_scale)
+			continue;
+		target = decide_port(s);
+		if (target != s->n_active && do_apply(s, target) == 0)
+			any_change = true;
+	}
+	if (any_change) {
+		apply_unpark_all();
+		schedule_deferred_park();
+	}
+}
+
+int rss_autoscale_port_state_get(
+	uint16_t port_id,
+	uint16_t *n_active,
+	uint16_t *n_load_recommended,
+	uint16_t *cap,
+	uint16_t *floor,
+	uint16_t *max_n,
+	uint16_t *min_n
+) {
+	struct rss_autoscale_port_state *s = state_get(port_id);
+	if (s == NULL)
+		return -ENODEV;
+	if (!s->caps.supports_scale)
+		return -ENOTSUP;
+	if (n_active)
+		*n_active = s->n_active;
+	if (n_load_recommended)
+		*n_load_recommended = s->n_load_recommended;
+	if (cap)
+		*cap = s->policy_cap;
+	if (floor)
+		*floor = s->policy_floor;
+	// max_n / min_n are the usable bounds after cluster_size filtering,
+	// not the raw HW range: an operator querying them must be able to
+	// pass them back through set_cap / set_floor without -EINVAL.
+	if (max_n)
+		*max_n = (s->caps.allowed_count > 0) ?
+			s->caps.allowed_n[s->caps.allowed_count - 1] :
+			0;
+	if (min_n)
+		*min_n = (s->caps.allowed_count > 0) ? s->caps.allowed_n[0] : 0;
+	return 0;
+}
+
+static void rss_autoscale_init(struct event_base *ev_base) {
+	if (!gr_config.rss_autoscale)
+		return;
+	rss_autoscale_ev_base = ev_base;
+	deferred_park_event = event_new(ev_base, -1, 0, deferred_park_cb, NULL);
+	if (deferred_park_event == NULL)
+		LOG(ERR, "rss-autoscale: failed to allocate deferred-park timer");
+	LOG(NOTICE,
+	    "rss-autoscale enabled: event-driven scale-up, "
+	    "timer-driven scale-down (per-port, every %d s)",
+	    SCALE_DOWN_PERIOD_S);
+
+	event_subscribe(GR_EVENT_IFACE_POST_ADD, rss_autoscale_on_iface_post_add);
+	event_subscribe(GR_EVENT_IFACE_REMOVE, rss_autoscale_on_iface_remove);
+	event_subscribe(GR_EVENT_IFACE_POST_RECONFIG, rss_autoscale_on_iface_post_reconfig);
+}
+
+static void rss_autoscale_fini(struct event_base * /*ev_base*/) {
+	if (deferred_park_event != NULL) {
+		event_del(deferred_park_event);
+		event_free(deferred_park_event);
+		deferred_park_event = NULL;
+	}
+	rss_autoscale_ev_base = NULL;
+	for (uint16_t i = 0; i < RTE_MAX_ETHPORTS; i++) {
+		if (port_states[i] != NULL) {
+			if (port_states[i]->scale_down_timer != NULL) {
+				event_del(port_states[i]->scale_down_timer);
+				event_free(port_states[i]->scale_down_timer);
+				port_states[i]->scale_down_timer = NULL;
+			}
+			port_scale_caps_free(&port_states[i]->caps);
+			free(port_states[i]);
+			port_states[i] = NULL;
+		}
+	}
+}
+
+static struct module rss_autoscale_module = {
+	.name = "rss_autoscale",
+	.init = rss_autoscale_init,
+	.fini = rss_autoscale_fini,
+};
+
+RTE_INIT(rss_autoscale_constructor) {
+	module_register(&rss_autoscale_module);
+}

--- a/modules/infra/control/rss_autoscale.c
+++ b/modules/infra/control/rss_autoscale.c
@@ -45,6 +45,7 @@ struct rss_autoscale_port_state {
 	uint64_t prev_busy_cycles;
 	uint64_t prev_total_cycles;
 	struct event *scale_down_timer;
+	bool deferred_deactivate_pending;
 };
 
 static struct rss_autoscale_port_state *port_states[RTE_MAX_ETHPORTS];
@@ -67,6 +68,11 @@ static struct rss_autoscale_port_state *state_get(uint16_t port_id) {
 bool rss_autoscale_port_enabled(uint16_t port_id) {
 	struct rss_autoscale_port_state *s = state_get(port_id);
 	return s != NULL && s->caps.supports_scale;
+}
+
+uint16_t rss_autoscale_port_n_active(uint16_t port_id) {
+	struct rss_autoscale_port_state *s = state_get(port_id);
+	return s != NULL ? s->n_active : 0;
 }
 
 static struct rss_autoscale_port_state *state_ensure(uint16_t port_id) {
@@ -135,6 +141,12 @@ static int do_apply(struct rss_autoscale_port_state *s, uint16_t n_new) {
 	ret = port_scale_apply(p, n_new);
 	if (ret < 0)
 		return ret;
+	// Scale-up: resume the reactivated rxqs now. Scale-down: keep them polling
+	// to drain residual frames; the no-op swap is deferred to deferred_park_cb.
+	if (n_new > s->n_active)
+		worker_graph_rxq_set_active(s->port_id, n_new);
+	else
+		s->deferred_deactivate_pending = true;
 	LOG(INFO, "port %u: dist_size %u -> %u", s->port_id, s->n_active, n_new);
 	// Newly-activated queues may carry stale idle latched during a
 	// previous deactivation drain. Clear their health so the next
@@ -333,7 +345,20 @@ static void apply_park_all(void) {
 	}
 }
 
+// Enact the deactivations deferred by do_apply: the scaled-down rxqs kept
+// polling to drain; swap them to rx_inactive_process now.
+static void apply_deferred_deactivate(void) {
+	for (uint16_t port_id = 0; port_id < RTE_MAX_ETHPORTS; port_id++) {
+		struct rss_autoscale_port_state *s = port_states[port_id];
+		if (s == NULL || !s->deferred_deactivate_pending)
+			continue;
+		s->deferred_deactivate_pending = false;
+		worker_graph_rxq_set_active(port_id, s->n_active);
+	}
+}
+
 static void deferred_park_cb(evutil_socket_t /*fd*/, short /*what*/, void * /*arg*/) {
+	apply_deferred_deactivate();
 	apply_park_all();
 }
 

--- a/modules/infra/control/rss_autoscale.h
+++ b/modules/infra/control/rss_autoscale.h
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Maxime Leroy, Free Mobile
+
+#pragma once
+
+#include "config.h"
+
+#include <rte_common.h>
+#include <rte_config.h>
+
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+// Pass cap_n / floor_n = 0 to clear. cap < floor at apply time: cap wins.
+int rss_autoscale_set_cap(uint16_t port_id, uint16_t cap_n);
+int rss_autoscale_set_floor(uint16_t port_id, uint16_t floor_n);
+
+int rss_autoscale_port_state_get(
+	uint16_t port_id,
+	uint16_t *n_active,
+	uint16_t *n_load_recommended,
+	uint16_t *cap,
+	uint16_t *floor,
+	uint16_t *max_n,
+	uint16_t *min_n
+);
+
+// True when the controller manages this port and its PMD exposes a
+// scalable RETA. Queried at graph build time to gate datapath health
+// tracking on ports that can actually be scaled.
+bool rss_autoscale_port_enabled(uint16_t port_id);
+
+#define RSS_AUTOSCALE_CONSEC_FULL 4
+#define RSS_AUTOSCALE_CONSEC_EMPTY 10000
+
+// Per-(port, queue) datapath health. Single-writer (rxq's worker),
+// multi-reader (control). Cache-aligned to avoid false sharing
+// between adjacent queues' workers.
+struct __rte_cache_aligned rxq_health {
+	uint16_t consec_full;
+	uint16_t consec_empty;
+	_Atomic(bool) saturated;
+	_Atomic(bool) idle;
+	_Atomic(bool) reset_pending; // control-set, worker clears consec_* on next poll
+};
+
+extern struct rxq_health rxq_health[RTE_MAX_ETHPORTS][RTE_MAX_QUEUES_PER_PORT];
+
+void rxq_health_notify_transition(void);
+
+// Called from the rx datapath after rte_eth_rx_burst(). Atomics and
+// notify are touched on edge transitions only (saturated/idle flips),
+// so steady-state cost is one compare per burst. The counters are
+// capped at their threshold so they never wrap. full_burst is the
+// per-rxq saturation threshold computed at graph build time.
+static inline void
+rxq_health_update(uint16_t port_id, uint16_t queue_id, uint16_t n_pkts, uint16_t full_burst) {
+	struct rxq_health *h;
+
+	if (gr_config.rss_autoscale == 0)
+		return;
+	h = &rxq_health[port_id][queue_id];
+
+	if (atomic_load_explicit(&h->reset_pending, memory_order_relaxed)) {
+		atomic_store_explicit(&h->reset_pending, false, memory_order_relaxed);
+		h->consec_full = 0;
+		h->consec_empty = 0;
+		atomic_store_explicit(&h->saturated, false, memory_order_relaxed);
+		atomic_store_explicit(&h->idle, false, memory_order_relaxed);
+	}
+
+	if (n_pkts >= full_burst) {
+		bool was_idle = (h->consec_empty >= RSS_AUTOSCALE_CONSEC_EMPTY);
+		h->consec_empty = 0;
+		if (was_idle) {
+			atomic_store_explicit(&h->idle, false, memory_order_relaxed);
+			rxq_health_notify_transition();
+		}
+		if (h->consec_full < RSS_AUTOSCALE_CONSEC_FULL) {
+			h->consec_full++;
+			if (h->consec_full == RSS_AUTOSCALE_CONSEC_FULL) {
+				atomic_store_explicit(&h->saturated, true, memory_order_relaxed);
+				rxq_health_notify_transition();
+			}
+		}
+	} else if (n_pkts == 0) {
+		bool was_saturated = (h->consec_full >= RSS_AUTOSCALE_CONSEC_FULL);
+		h->consec_full = 0;
+		if (was_saturated) {
+			atomic_store_explicit(&h->saturated, false, memory_order_relaxed);
+			rxq_health_notify_transition();
+		}
+		if (h->consec_empty < RSS_AUTOSCALE_CONSEC_EMPTY) {
+			h->consec_empty++;
+			if (h->consec_empty == RSS_AUTOSCALE_CONSEC_EMPTY) {
+				atomic_store_explicit(&h->idle, true, memory_order_relaxed);
+				rxq_health_notify_transition();
+			}
+		}
+	} else {
+		bool was_saturated = (h->consec_full >= RSS_AUTOSCALE_CONSEC_FULL);
+		bool was_idle = (h->consec_empty >= RSS_AUTOSCALE_CONSEC_EMPTY);
+		if (h->consec_full | h->consec_empty) {
+			h->consec_full = 0;
+			h->consec_empty = 0;
+		}
+		if (was_saturated) {
+			atomic_store_explicit(&h->saturated, false, memory_order_relaxed);
+			rxq_health_notify_transition();
+		}
+		if (was_idle) {
+			atomic_store_explicit(&h->idle, false, memory_order_relaxed);
+			rxq_health_notify_transition();
+		}
+	}
+}

--- a/modules/infra/control/rss_autoscale.h
+++ b/modules/infra/control/rss_autoscale.h
@@ -32,6 +32,12 @@ bool rss_autoscale_port_enabled(uint16_t port_id);
 // Queried at graph build time to mark RETA-deactivated rxqs inactive.
 uint16_t rss_autoscale_port_n_active(uint16_t port_id);
 
+// True when queue_id is among the first n active RSS queues of the port,
+// honoring the controller's activation order. For prefix PMDs (and unmanaged
+// ports) this is exactly queue_id < n; for indirect-RETA PMDs it tests
+// membership in the placed queue set. Queried from graph build / live swap.
+bool rss_autoscale_port_rxq_active_within(uint16_t port_id, uint16_t queue_id, uint16_t n);
+
 #define RSS_AUTOSCALE_CONSEC_FULL 4
 #define RSS_AUTOSCALE_CONSEC_EMPTY 10000
 

--- a/modules/infra/control/rss_autoscale.h
+++ b/modules/infra/control/rss_autoscale.h
@@ -13,10 +13,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-// Pass cap_n / floor_n = 0 to clear. cap < floor at apply time: cap wins.
-int rss_autoscale_set_cap(uint16_t port_id, uint16_t cap_n);
-int rss_autoscale_set_floor(uint16_t port_id, uint16_t floor_n);
-
 int rss_autoscale_port_state_get(
 	uint16_t port_id,
 	uint16_t *n_active,

--- a/modules/infra/control/rss_autoscale.h
+++ b/modules/infra/control/rss_autoscale.h
@@ -28,6 +28,10 @@ int rss_autoscale_port_state_get(
 // tracking on ports that can actually be scaled.
 bool rss_autoscale_port_enabled(uint16_t port_id);
 
+// Number of RSS queues the controller currently feeds (0 if unmanaged).
+// Queried at graph build time to mark RETA-deactivated rxqs inactive.
+uint16_t rss_autoscale_port_n_active(uint16_t port_id);
+
 #define RSS_AUTOSCALE_CONSEC_FULL 4
 #define RSS_AUTOSCALE_CONSEC_EMPTY 10000
 

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -331,9 +331,9 @@ int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_por
 	struct iface_info_port *port;
 	vec unsigned *cpus = NULL;
 	struct worker *worker, *tmp;
+	size_t n_cpus, fwd_cursor, rev_cursor, port_idx;
 	char buf[BUFSIZ];
 	int ret = 0;
-	unsigned i;
 
 	if (cpuset_format(buf, sizeof(buf), affinity) < 0) {
 		LOG(WARNING, "failed to format new cpu affinity: %s", strerror(errno));
@@ -377,10 +377,21 @@ int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_por
 		}
 	}
 
-	// assign all rxqs to new workers in the new affinity mask
-	i = 0;
+	// Butterfly-reverse layout: even-indexed ports walk cpus[] forward
+	// from fwd_cursor, odd-indexed ones backward from rev_cursor. Cursors
+	// advance across ports so middle CPUs do not stay idle when
+	// n_workers > per-port queue count. Endpoint placement (port 0 q0 ->
+	// cpus[0], port 1 q0 -> cpus[n-1]) lets the two q0 workers run on
+	// disjoint cache groups at dist_size=1.
+	n_cpus = vec_len(cpus);
+	fwd_cursor = 0;
+	rev_cursor = (n_cpus > 0) ? (n_cpus - 1) : 0;
+	port_idx = 0;
 	vec_foreach (port, ports) {
 		int socket_id = SOCKET_ID_ANY;
+		// Direction by iteration order so non-consecutive port_ids
+		// from DPDK don't perturb the pattern.
+		bool reverse = (port_idx % 2) != 0;
 
 		if (numa_available() != -1)
 			socket_id = rte_eth_dev_socket_id(port->port_id);
@@ -405,16 +416,24 @@ int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_por
 			port->started = was_started;
 		}
 
+		if (n_cpus == 0)
+			continue;
+
 		for (uint16_t rxq = 0; rxq < port->n_rxq; rxq++) {
-			// find CPU in the affinity where to assign RXQ
+			unsigned idx = reverse ? (unsigned)rev_cursor : (unsigned)fwd_cursor;
+			struct queue_map q;
+
+			// Same-socket fallback.
 			unsigned j = 0;
-			while (socket_id != SOCKET_ID_ANY && socket_id != numa_node_of_cpu(cpus[i])
-			       && j < vec_len(cpus)) {
-				if (++i >= vec_len(cpus))
-					i = 0;
+			while (socket_id != SOCKET_ID_ANY
+			       && socket_id != numa_node_of_cpu(cpus[idx]) && j < n_cpus) {
+				if (reverse)
+					idx = (idx == 0) ? (unsigned)(n_cpus - 1) : (idx - 1);
+				else
+					idx = (idx + 1) % (unsigned)n_cpus;
 				j++;
 			}
-			if (j == vec_len(cpus)) {
+			if (j == n_cpus) {
 				LOG(WARNING,
 				    "no socket %d CPU found in new affinity %s for port %d",
 				    socket_id,
@@ -422,19 +441,23 @@ int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_por
 				    port->port_id);
 			}
 
-			worker = worker_find(cpus[i]);
+			worker = worker_find(cpus[idx]);
 			assert(worker != NULL);
 
-			struct queue_map q = {
-				.port_id = port->port_id,
-				.queue_id = rxq,
-				.enabled = port->started,
-			};
+			q.port_id = port->port_id;
+			q.queue_id = rxq;
+			q.enabled = port->started;
 			vec_add(worker->rxqs, q);
 
-			if (++i >= vec_len(cpus))
-				i = 0;
+			// Advance cursor past this assignment so the next rxq
+			// (of this or the next port) does not retarget the
+			// same CPU after fallback.
+			if (reverse)
+				rev_cursor = (idx == 0) ? (n_cpus - 1) : (idx - 1);
+			else
+				fwd_cursor = (idx + 1) % n_cpus;
 		}
+		port_idx++;
 	}
 
 	worker_txq_distribute(ports);

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -21,10 +21,12 @@
 #include <rte_malloc.h>
 
 #include <errno.h>
+#include <linux/futex.h>
 #include <pthread.h>
 #include <sched.h>
 #include <stdatomic.h>
 #include <sys/queue.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 LOG_TYPE("worker");
@@ -94,6 +96,7 @@ int worker_destroy(unsigned cpu_id) {
 
 	atomic_store(&worker->shutdown, true);
 	worker_wakeup(worker);
+	worker_unpark(worker);
 	pthread_join(worker->thread, NULL);
 	pthread_cond_destroy(&worker->wakeup.cond);
 	pthread_mutex_destroy(&worker->wakeup.lock);
@@ -119,6 +122,20 @@ void worker_wakeup(struct worker *w) {
 	w->wakeup.set = true;
 	pthread_cond_signal(&w->wakeup.cond);
 	pthread_mutex_unlock(&w->wakeup.lock);
+}
+
+void worker_park(struct worker *w) {
+	atomic_store(&w->paused, 1);
+}
+
+void worker_unpark(struct worker *w) {
+	atomic_store(&w->paused, 0);
+	// FUTEX_WAKE is a no-op if the worker isn't actually waiting.
+	syscall(SYS_futex, (int *)&w->paused, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1, NULL, NULL, 0);
+}
+
+bool worker_is_paused(const struct worker *w) {
+	return atomic_load(&w->paused) == 1;
 }
 
 unsigned worker_count(void) {

--- a/modules/infra/control/worker.h
+++ b/modules/infra/control/worker.h
@@ -58,6 +58,9 @@ struct worker {
 	struct rte_graph *graph[2]; // dataplane: ro, ctlplane: rw
 	atomic_uint max_sleep_us; // dataplane: ro, ctlplane: rw
 
+	// 0 = active, 1 = park requested. Doubles as futex word.
+	atomic_int paused; // dataplane: ro, ctlplane: rw
+
 	atomic_bool stats_reset; // dataplane: rw, ctlplane: rw
 	// dataplane: wo, ctlplane: ro, may be NULL
 	_Atomic(const struct worker_stats *) stats;
@@ -101,3 +104,8 @@ int worker_destroy(unsigned cpu_id);
 int worker_graph_reload(struct worker *, vec struct iface_info_port **);
 int worker_graph_reload_all(vec struct iface_info_port **);
 void worker_graph_free(struct worker *);
+
+// A parked worker futex_wait()s until unparked, consuming no CPU.
+void worker_park(struct worker *w);
+void worker_unpark(struct worker *w);
+bool worker_is_paused(const struct worker *w);

--- a/modules/infra/control/worker.h
+++ b/modules/infra/control/worker.h
@@ -104,6 +104,7 @@ int worker_destroy(unsigned cpu_id);
 int worker_graph_reload(struct worker *, vec struct iface_info_port **);
 int worker_graph_reload_all(vec struct iface_info_port **);
 void worker_graph_free(struct worker *);
+void worker_graph_rxq_set_active(uint16_t port_id, uint16_t n_active);
 
 // A parked worker futex_wait()s until unparked, consuming no CPU.
 void worker_park(struct worker *w);

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -389,11 +389,17 @@ static void queue_distribute_reduce(void **) {
 	vec_free(ports);
 	assert_int_equal(worker_count(), 2);
 
+	// Butterfly with global cursors, cpus=[4,5]:
+	//   port 0 (idx=0, fwd) fwd_cursor=0: q0->cpu4, q1->cpu5.
+	//     fwd_cursor advances to (0+2)%2 = 0.
+	//   port 1 (idx=1, rev) rev_cursor=1: q0->cpu5, q1->cpu4.
+	//     rev_cursor advances to (1-2+2)%2 = 1.
+	//   port 2 (idx=2, fwd) fwd_cursor=0: q0->cpu4, q1->cpu5.
 	assert_qmaps(w1.rxqs);
 	assert_qmaps(w2.rxqs);
 	assert_qmaps(w3.rxqs);
-	assert_qmaps(w4.rxqs, q(0, 0), q(1, 0), q(2, 0));
-	assert_qmaps(w5.rxqs, q(0, 1), q(1, 1), q(2, 1));
+	assert_qmaps(w4.rxqs, q(0, 0), q(1, 1), q(2, 0));
+	assert_qmaps(w5.rxqs, q(0, 1), q(1, 0), q(2, 1));
 	assert_qmaps(w1.txqs);
 	assert_qmaps(w2.txqs);
 	assert_qmaps(w3.txqs);
@@ -427,11 +433,21 @@ static void queue_distribute_increase(void **) {
 	vec_free(ports);
 	assert_int_equal(worker_count(), 5);
 
-	assert_qmaps(w1.rxqs, q(0, 0), q(2, 1));
+	// Butterfly with global cursors, cpus=[1,2,3,4,5]:
+	//   port 0 (idx=0, fwd) starts fwd_cursor=0:  q0->cpu1, q1->cpu2.
+	//     fwd_cursor advances to 2.
+	//   port 1 (idx=1, rev) starts rev_cursor=4:  q0->cpu5, q1->cpu4.
+	//     rev_cursor advances to 2.
+	//   port 2 (idx=2, fwd) starts fwd_cursor=2:  q0->cpu3, q1->cpu4.
+	// All 5 workers receive at least one rxq.
+	assert_qmaps(w1.rxqs, q(0, 0));
 	assert_qmaps(w2.rxqs, q(0, 1));
-	assert_qmaps(w3.rxqs, q(1, 0));
-	assert_qmaps(w4.rxqs, q(1, 1));
-	assert_qmaps(w5.rxqs, q(2, 0));
+	assert_qmaps(w3.rxqs, q(2, 0));
+	assert_qmaps(w4.rxqs, q(1, 1), q(2, 1));
+	assert_qmaps(w5.rxqs, q(1, 0));
+	// TXQ distribution iterates the STAILQ (after the reduce/increase
+	// sequence: w4, w5, w1, w2, w3) assigning to workers with rxqs.
+	// All 5 workers have rxqs now.
 	assert_qmaps(w1.txqs, q(0, 2), q(1, 2), q(2, 2));
 	assert_qmaps(w2.txqs, q(0, 3), q(1, 3), q(2, 3));
 	assert_qmaps(w3.txqs, q(0, 0), q(1, 0), q(2, 0));

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -17,9 +17,12 @@
 #include <rte_lcore.h>
 #include <rte_malloc.h>
 
+#include <linux/futex.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <time.h>
 #include <unistd.h>
 
 LOG_TYPE("graph");
@@ -269,6 +272,35 @@ reconfig:
 				rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
 				goto reconfig;
 			}
+
+			// Park check: leave RCU offline so we don't block
+			// grace periods, wake every second to re-check
+			// shutdown/reconfig.
+			if (atomic_load(&w->paused) == 1) {
+				struct timespec wait_ts = {.tv_sec = 1};
+				rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
+				while (atomic_load(&w->paused) == 1) {
+					syscall(SYS_futex,
+						(int *)&w->paused,
+						FUTEX_WAIT | FUTEX_PRIVATE_FLAG,
+						1,
+						&wait_ts,
+						NULL,
+						0);
+					if (atomic_load(&w->shutdown))
+						goto shutdown;
+					if (atomic_load(&w->next_config) != cur)
+						goto reconfig;
+				}
+				rte_rcu_qsbr_thread_online(rcu, rte_lcore_id());
+				// Reset timing so the park duration is not
+				// charged as busy_cycles on the next interval.
+				timestamp = rte_rdtsc();
+				sleep = 0;
+				loop = 0;
+				continue;
+			}
+
 			if (atomic_exchange(&w->stats_reset, false))
 				stats_reset(ctx.w_stats);
 

--- a/modules/infra/datapath/port_rx.c
+++ b/modules/infra/datapath/port_rx.c
@@ -7,6 +7,7 @@
 #include "log.h"
 #include "mbuf.h"
 #include "port.h"
+#include "rss_autoscale.h"
 #include "rxtx.h"
 #include "trace.h"
 
@@ -59,6 +60,18 @@ static inline void rx_burst_histogram_inc(uint16_t port_id, uint16_t n_pkts) {
 	assert(port_id < RTE_MAX_ETHPORTS);
 	assert(n_pkts <= RTE_GRAPH_BURST_SIZE);
 	histogram->lcores[rte_lcore_id()].ports[port_id].bursts[n_pkts]++;
+}
+
+// Combined per-rx_burst datapath bookkeeping: histogram + rss-autoscale
+// saturation/idle tracking. Called from every rx_*_process variant. The
+// histogram is always updated; health tracking is gated on track_health,
+// set at graph build time only for autoscale-managed scalable ports.
+static inline void rx_burst_done(const struct rx_node_ctx *ctx, uint16_t n_pkts) {
+	rx_burst_histogram_inc(ctx->rxq.port_id, n_pkts);
+	if (ctx->track_health)
+		rxq_health_update(
+			ctx->rxq.port_id, ctx->rxq.queue_id, n_pkts, ctx->saturation_threshold
+		);
 }
 
 // Copy flags into buf stripping the "RTE_MBUF_F_" prefixes from flag names.
@@ -215,7 +228,7 @@ uint16_t rx_virtio_process(struct rte_graph *graph, struct rte_node *node, void 
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
-	rx_burst_histogram_inc(ctx->rxq.port_id, rx);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 
@@ -253,7 +266,7 @@ uint16_t rx_offload_process(struct rte_graph *graph, struct rte_node *node, void
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
-	rx_burst_histogram_inc(ctx->rxq.port_id, rx);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 
@@ -290,7 +303,7 @@ uint16_t rx_process(struct rte_graph *graph, struct rte_node *node, void **, uin
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
-	rx_burst_histogram_inc(ctx->rxq.port_id, rx);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 
@@ -332,7 +345,7 @@ uint16_t rx_bond_virtio_process(struct rte_graph *graph, struct rte_node *node, 
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
-	rx_burst_histogram_inc(ctx->rxq.port_id, rx);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 
@@ -382,6 +395,7 @@ rx_bond_offload_process(struct rte_graph *graph, struct rte_node *node, void **,
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 
@@ -428,6 +442,7 @@ uint16_t rx_bond_process(struct rte_graph *graph, struct rte_node *node, void **
 		return 0;
 
 	rx = rte_eth_rx_burst(ctx->rxq.port_id, ctx->rxq.queue_id, mbufs, ctx->burst_size);
+	rx_burst_done(ctx, rx);
 	if (rx == 0)
 		return 0;
 

--- a/modules/infra/datapath/port_rx.c
+++ b/modules/infra/datapath/port_rx.c
@@ -217,6 +217,13 @@ static void fix_l4_csum(struct rte_mbuf *m) {
 	m->ol_flags |= RTE_MBUF_F_RX_L4_CKSUM_GOOD;
 }
 
+// rss-autoscale deactivated this rxq (RETA narrowed below its queue_id): the HW
+// steers nothing here, so skip the poll. Swapped in/out at scale time (like
+// pcap swaps node->process), see worker_graph_rxq_set_active().
+uint16_t rx_inactive_process(struct rte_graph *, struct rte_node *, void **, uint16_t) {
+	return 0;
+}
+
 uint16_t rx_virtio_process(struct rte_graph *graph, struct rte_node *node, void **, uint16_t) {
 	struct rte_mbuf **mbufs = (struct rte_mbuf **)node->objs;
 	const struct rx_node_ctx *ctx = rx_node_ctx(node);

--- a/modules/infra/datapath/rxtx.h
+++ b/modules/infra/datapath/rxtx.h
@@ -31,6 +31,14 @@ GR_NODE_CTX_TYPE(rx_node_ctx, {
 	const struct iface *iface;
 	struct port_queue rxq;
 	uint16_t burst_size;
+	// Effective per-call max: min(burst_size, PMD's advertised per-rxq
+	// burst size). Used by the rss-autoscale controller to detect "burst
+	// full" without depending on a hardcoded value that breaks on PMDs
+	// with a higher advertised burst (e.g. mlx5 reports 64 per rxq).
+	uint16_t saturation_threshold : 15;
+	// Set at graph build time only for autoscale-managed scalable ports.
+	// Gates rss-autoscale health tracking without touching the histogram.
+	uint16_t track_health : 1;
 });
 
 GR_NODE_CTX_TYPE(tx_node_ctx, {

--- a/modules/infra/datapath/rxtx.h
+++ b/modules/infra/datapath/rxtx.h
@@ -84,6 +84,7 @@ uint16_t rx_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 uint16_t rx_bond_virtio_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 uint16_t rx_bond_offload_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 uint16_t rx_bond_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
+uint16_t rx_inactive_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 
 uint16_t tx_process(struct rte_graph *, struct rte_node *, void **, uint16_t);
 uint16_t tx_shared_process(struct rte_graph *, struct rte_node *, void **, uint16_t);


### PR DESCRIPTION

  Why rx_usleep doesn't scale
  
  Grout's existing rx-side usleep(us) micro-sleep saves CPU at modest loads but breaks
  at line rate:

  - max_sleep_us is auto-clamped by ring depth / line rate, so at 25-100G the
  cap drops to a few microseconds → effectively zero. The worker busy-polls
  anyway, just with extra syscall overhead.
  - All queues remain RSS-fed during sleep, so a burst arriving on any queue can
  overflow its ring before the worker wakes.
  - The "idle CPU" gain only materializes at very low rates where usleep is
  long enough to matter, which is exactly the regime where the energy savings
  are negligible (the box was already idle).

  What rss-autoscale does

  Opt-in controller (--rss-autoscale=N, N = cluster grouping) that:
  
  - Narrows the HW RSS distribution per port to the smallest N that absorbs
  current load (via rte_eth_dev_rss_reta_update, with a portable emulation
  on DPAA2 that maps reta[i] = i % N to dpni_set_rx_hash_dist).
  - Parks unused workers via futex_wait → real 0% CPU (vs busy-poll noise).
  - Detection is edge-based in the datapath: each rx_burst that returns the
  HW burst-cap counts as "full"; 4 consecutive full → saturated. 1000
  consecutive empty (n_pkts == 0) → idle. Mid-load (1..cap-1) is steady,
  no transition. Counters are local, only edges trigger an atomic_store +
  control_queue push to wake the controller (~10 µs reaction).
  - Zero datapath cost when disabled (gr_config.rss_autoscale == 0):
  branch-predicted no-op at top of rxq_health_update.
  - Two policy knobs (grcli rss-autoscale set NAME cap|floor N) for thermal
  daemons and ops: cap = upper bound, floor = lower bound. Cap wins on
  conflict.
  

  Known limitations   

  - Elephant flow: a single 5-tuple flow hashes to one queue, so RSS
  scale-up cannot redistribute it. The controller will scale up uselessly
  until cap/max, leaving 11 unparked workers. 
  - Reordering on scale events: DPAA2 dispatches via hash % dist_size,
  so changing N reshuffles all flows. Scale events should be rare. No
  mitigation yet.
  - grcli bug: set NAME cap N and set NAME floor N patterns fail
  parsing in libecoli (to debug and fix)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## RSS Autoscale Controller

Implements an opt-in RSS autoscale controller (`--rss-autoscale=N`) that dynamically narrows per-port hardware RSS RETA to absorb current load and parks unused workers. Solves the limitation of rx-side usleep() which fails to scale at line-rate (max_sleep_us clamped by ring depth/line rate) and keeps all queues RSS-fed during idle sleep, risking ring overflow.

### Port Scaling Abstraction (`port_scale.{c,h}`)

New module for dynamic RETA reprogramming. Computes allowed queue counts by intersecting driver constraints with DPAA2's discrete set (via hardcoded lookup: 1,2,3,4,6,7,8,12,14,16,24,28,32,...) or falling back to [1..max]. Provides capability helpers (caps_get/free, caps_next/prev) and apply function that constructs uniform RETA (`reta[i] = i % n` across groups) and calls `rte_eth_dev_rss_reta_update()`. Query function reads back active queue count from current RETA or returns 0 if never programmed.

### RXQ Health Tracking (`rss_autoscale.{h,c}`)

Per-RXQ counters (consec_full, consec_empty) with atomic saturated/idle flags. Datapath `rxq_health_update()` hook (called per RX burst) increments counters: full bursts (HW burst-cap received) and empty bursts. State transitions trigger notifications: 4 consecutive full → saturated; 1000 consecutive empty → idle; transitions back to normal clear flags and wake controller. Notification pushes to control queue (~10 µs). Zero cost when disabled (rss_autoscale == 0).

### Worker Parking (`worker.{c,h}`)

Adds `atomic_int paused` field and futex-based park/unpark. `worker_park()` stores 1 and datapath futex_waits with 1s timeout at housekeeping. `worker_unpark()` stores 0 and issues FUTEX_WAKE. Datapath leaves RCU offline during wait to avoid blocking grace periods; wakes every second to check shutdown/reconfig events. Resets timing on unpark so park duration is not charged as busy cycles.

### Butterfly-Reverse RXQ Allocation (`worker.c`)

Changes distribution logic from simple forward walk to butterfly-reverse with separate global forward/reverse cursors. Even-indexed ports walk `cpus[]` forward from fwd_cursor; odd-indexed ports walk backward from rev_cursor. After each port, corresponding cursor advances by step derived from port's RXQ count. Improves endpoint placement: port 0 q0 → cpus[0], port 1 q0 → cpus[n-1]. On hyperthreaded systems (e.g., x86), endpoint workers land on different physical cores with exclusive sibling-thread and cache access. Enables multiple workers idle when dist_size=1 during low load.

### Control Loop (`rss_autoscale.c`)

Three-pass decision triggered on RXQ health transitions: (1) per-port load recommendation from atomic health flags, (2) global cluster-budget arbitration to constrain total cluster usage (filters allowed_n to keep multiples of cluster grouping size), (3) hardware apply. Exposes policy bounds: `rss_autoscale_set_cap()` / `rss_autoscale_clear_cap()` for upper bound (shedding) and `rss_autoscale_set_floor()` / `rss_autoscale_clear_floor()` for lower bound (force load). Cap overrides floor on conflict. Immediate apply on cap/floor changes with worker park/unpark sync. Subscribes to interface-add events to pin new ports to configured autoscale value.

### Datapath Integration

`port_rx.c` calls `rx_burst_done()` on every RX burst (replaces direct histogram increment) to update both histogram and health tracking. `main_loop.c` worker futex_wait loop integrated at housekeeping.

### CLI/API Infrastructure (`modules/infra/api/rss_autoscale.c`, `modules/infra/cli/rss_autoscale.c`)

New API handlers: `GR_RSS_AUTOSCALE_LIST` (streams per-port state: active queues, recommended load, cap/floor/min/max), `GR_RSS_AUTOSCALE_CAP_SET/CLEAR`, `GR_RSS_AUTOSCALE_FLOOR_SET/CLEAR`. CLI commands: `infra rss-autoscale show`, `set NAME cap N`, `set NAME floor N`, `clear NAME cap`, `clear NAME floor`.

### Configuration

New `--rss-autoscale=N` option in main.c: N=0 (disabled/legacy), N=1 (per-core), N=2 (grouping-by-2), N>2 (grouping-by-N). Stored in `gr_config.rss_autoscale`. Tick=20ms, up_hold=20ms, dn_hold=1000ms. Boots with N=1; widens as load appears.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DPDK/grout/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->