### PR TITLE
l4: ensure packet type is set before L4 processing

### DIFF
--- a/modules/ip/datapath/ip_local.c
+++ b/modules/ip/datapath/ip_local.c
@@ -48,6 +48,7 @@ static uint16_t ip_input_local_process(
 			data->vrf_id = iface->vrf_id;
 			data->proto = ip->next_proto_id;
 			data->ttl = ip->time_to_live;
+			mbuf->packet_type = RTE_PTYPE_L3_IPV4;
 			rte_pktmbuf_adj(mbuf, rte_ipv4_hdr_len(ip));
 		}
 		rte_node_enqueue_x1(graph, node, edge, mbuf);

--- a/modules/ip6/datapath/ip6_local.c
+++ b/modules/ip6/datapath/ip6_local.c
@@ -92,6 +92,7 @@ static uint16_t ip6_input_local_process(
 		case IPPROTO_TCP:
 		case IPPROTO_SCTP:
 		case IPPROTO_DCCP:
+			m->packet_type = RTE_PTYPE_L3_IPV6;
 			// These protocols have checksum fields to be verified.
 			break;
 		default:


### PR DESCRIPTION
The L4 nodes (l4_input_local, l4_loopback_output, ospf_redirect) use mbuf->packet_type to determine whether a packet comes from IPv4 or IPv6. However, the ip_input_local and ip6_input_local nodes never set this field explicitly before forwarding to L4. When the NIC does not classify packets or when the value is stale, L4 nodes cannot determine the correct protocol and drop the packet.

Set packet_type to RTE_PTYPE_L3_IPV4 or RTE_PTYPE_L3_IPV6 in each ip*_input_local node before stripping the IP header.

Link: https://github.com/DPDK/grout/issues/625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
L4 nodes use mbuf->packet_type to distinguish IPv4 vs IPv6. ip_input_local and ip6_input_local now explicitly set that field before advancing the mbuf past the IP header so downstream L4 nodes receive a correct packet_type when NICs do not provide classification or when the field is stale.

modules/ip/datapath/ip_local.c: after filling ip_local_mbuf_data (src, dst, len, vrf_id, proto, ttl) and when a next-node edge for ip->next_proto_id is registered, set mbuf->packet_type = RTE_PTYPE_L3_IPV4, then call rte_pktmbuf_adj(mbuf, rte_ipv4_hdr_len(ip)) and enqueue to the next node.

modules/ip6/datapath/ip6_local.c: after parsing IPv6 headers/extensions and resolving an L4 protocol handler (IPPROTO_UDP, IPPROTO_TCP, IPPROTO_SCTP, IPPROTO_DCCP), set m->packet_type = RTE_PTYPE_L3_IPV6 before performing L4 checksum verification; subsequently adjust the mbuf (rte_pktmbuf_adj) and enqueue to the next node.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->