### PR TITLE
infra: override default route when running in a netns

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,5 +22,6 @@ RUN echo '#!/bin/sh' > /tmp/null/usr/bin/frr && \
 FROM scratch
 COPY --from=builder /tmp/null/ /
 STOPSIGNAL SIGRTMIN+3
+ENV GROUT_OVERRIDE_DEFAULT_ROUTE=true
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "--"]
 CMD ["/usr/bin/grout"]

--- a/docs/grout.8.scdoc
+++ b/docs/grout.8.scdoc
@@ -76,6 +76,18 @@ Grout is a software router based on DPDK _rte_graph_.
 *-x*, *--trace-packets*
 	Print all ingress/egress packets (for debugging purposes).
 
+# ENVIRONMENT
+
+*GROUT_SOCK_PATH*
+	Path to the control plane API socket. See *-s*.
+
+*GROUT_OVERRIDE_DEFAULT_ROUTE*
+	When set to _1_, _true_, _on_, or _yes_ (case insensitive), override the
+	existing default route in the main routing table with metric 0. This is
+	required when running in a network namespace or a container where
+	another default route (e.g. from Kubernetes) takes priority over grout's
+	own default route.
+
 # EXTRA EAL ARGUMENTS
 
 Any DPDK EAL argument can be specified after an optional *--*. This is an

--- a/main/config.h
+++ b/main/config.h
@@ -21,6 +21,7 @@ struct gr_config {
 	bool poll_mode;
 	bool log_syslog;
 	bool log_packets;
+	bool override_default_route;
 	vec char **eal_extra_args;
 	cpu_set_t control_cpus; // control plane threads allowed CPUs
 	cpu_set_t datapath_cpus; // datapath threads allowed CPUs

--- a/main/grout.default
+++ b/main/grout.default
@@ -4,3 +4,9 @@
 
 # Add grout command line flags here and restart grout.service.
 GROUT_OPTS='--syslog'
+
+# Override the default route in the main routing table. Required when running
+# in a private network namespace (PrivateNetwork=true) or in a container. Must
+# be set to false if removing PrivateNetwork=true from the systemd service and
+# running grout in the main network namespace.
+GROUT_OVERRIDE_DEFAULT_ROUTE=true

--- a/main/main.c
+++ b/main/main.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 
 LOG_TYPE("main");
@@ -173,6 +174,14 @@ static int parse_sock_owner(char *user_group_str) {
 	return 0;
 }
 
+static bool parse_bool_env(const char *name) {
+	const char *val = getenv(name);
+	if (val == NULL)
+		return false;
+	return strcasecmp(val, "1") == 0 || strcasecmp(val, "true") == 0
+		|| strcasecmp(val, "on") == 0 || strcasecmp(val, "yes") == 0;
+}
+
 static int parse_args(int argc, char **argv) {
 	int c;
 
@@ -289,10 +298,14 @@ int main(int argc, char **argv) {
 	if (parse_args(argc, argv) < 0)
 		goto end;
 
+	gr_config.override_default_route = parse_bool_env("GROUT_OVERRIDE_DEFAULT_ROUTE");
+
 	if (dpdk_log_init() < 0)
 		goto end;
 
 	LOG(NOTICE, "starting grout version %s", GROUT_VERSION);
+	if (gr_config.override_default_route)
+		LOG(NOTICE, "GROUT_OVERRIDE_DEFAULT_ROUTE is set, overriding default route");
 	LOG(NOTICE,
 	    "License available at https://git.dpdk.org/apps/grout/plain/licenses/BSD-3-clause.txt");
 

--- a/modules/infra/control/netlink.c
+++ b/modules/infra/control/netlink.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Maxime Leroy, Free Mobile
 
+#include "config.h"
 #include "log.h"
 #include "module.h"
 #include "netlink.h"
@@ -188,8 +189,12 @@ static int netlink_add_del_route_family(uint32_t ifindex, uint32_t table, int fa
 	nlh = mnl_nlmsg_put_header(buf);
 	nlh->nlmsg_type = add ? RTM_NEWROUTE : RTM_DELROUTE;
 	nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
-	if (add)
-		nlh->nlmsg_flags |= NLM_F_CREATE | NLM_F_EXCL;
+	if (add) {
+		if (table == RT_TABLE_MAIN && gr_config.override_default_route)
+			nlh->nlmsg_flags |= NLM_F_CREATE | NLM_F_REPLACE;
+		else
+			nlh->nlmsg_flags |= NLM_F_CREATE | NLM_F_EXCL;
+	}
 
 	rtm = mnl_nlmsg_put_extra_header(nlh, sizeof(*rtm));
 	rtm->rtm_family = family;
@@ -200,7 +205,7 @@ static int netlink_add_del_route_family(uint32_t ifindex, uint32_t table, int fa
 	rtm->rtm_dst_len = 0;
 
 	mnl_attr_put_u32(nlh, RTA_TABLE, table);
-	if (table == RT_TABLE_MAIN) {
+	if (table == RT_TABLE_MAIN && !gr_config.override_default_route) {
 		// avoid clash with other default routes in the default VRF
 		mnl_attr_put_u32(nlh, RTA_PRIORITY, UINT32_MAX);
 	}

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -264,6 +264,7 @@ llocal_addr() {
 
 if [ "$run_grout" = true ]; then
 	smoke_setenv GROUT_SOCK_PATH "$tmp/grout.sock"
+	smoke_setenv GROUT_OVERRIDE_DEFAULT_ROUTE true
 fi
 if [ -n "${builddir}" ]; then
 	smoke_setenv PATH "$builddir:$PATH"


### PR DESCRIPTION
When grout runs inside a k8s pod, the default route installed by k8s has priority over grout's own default route (which uses metric UINT32_MAX). This causes TCP connections to fail over grout.

When the environment variable GROUT_OVERRIDE_DEFAULT_ROUTE is set to a truthy value (1, true, on, yes), install the default route with metric 0 and NLM_F_REPLACE to take over the existing one. Set the variable in the default systemd environment file (which runs with PrivateNetwork=true), in the container quadlet and in the Containerfile.

Link: https://github.com/DPDK/grout/issues/625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
Adds an explicit override mechanism for the default route driven by a new configuration flag (gr_config.override_default_route) and the GROUT_OVERRIDE_DEFAULT_ROUTE environment variable. When enabled, grout will install default routes into the main routing table using NLM_F_REPLACE and without the high-priority metric so the installed default takes precedence over existing defaults (useful for container/netns deployments).

## Changes

- main/config.h
  - Adds bool override_default_route to struct gr_config.

- main/main.c
  - Adds parse_bool_env() helper to parse truthy environment values ("1", "true", "on", "yes", case-insensitive).
  - Reads GROUT_OVERRIDE_DEFAULT_ROUTE into gr_config.override_default_route at startup.
  - Emits a NOTICE log when GROUT_OVERRIDE_DEFAULT_ROUTE is set.

- modules/infra/control/netlink.c
  - When adding routes for RT_TABLE_MAIN, set netlink message flags to include NLM_F_REPLACE (nlmsg_flags |= NLM_F_CREATE | NLM_F_REPLACE) if gr_config.override_default_route is true; otherwise preserve previous behavior using NLM_F_EXCL.
  - Only set RTA_PRIORITY = UINT32_MAX when override_default_route is false (omit the high-priority metric when override is enabled), allowing a route with metric 0 to win.

- Documentation and defaults
  - docs/grout.8.scdoc: Documents GROUT_OVERRIDE_DEFAULT_ROUTE in ENVIRONMENT with accepted truthy values and the effect (override existing default route with metric 0).
  - Containerfile: Sets ENV GROUT_OVERRIDE_DEFAULT_ROUTE=true in the final image.
  - main/grout.default and smoke/_init.sh: Set GROUT_OVERRIDE_DEFAULT_ROUTE=true in defaults/test harness so runtime behavior overrides existing default routes in those environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->