### PR TITLE
frr: signal FINISHED_READING after sync on FRR >= 10.7

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,7 @@ jobs:
           # grout dependencies
           sudo apt-get update -qy
           sudo apt-get install -qy --no-install-recommends \
-            make gcc gdb ccache ninja-build meson git scdoc \
+            make gcc gdb ccache ninja-build meson git scdoc inotify-tools \
             libibverbs-dev libasan8 libcmocka-dev libedit-dev libarchive-dev \
             libevent-dev libmnl-dev libnuma-dev python3-pyelftools \
             socat tcpdump traceroute graphviz iproute2 iputils-ping ndisc6 jq \

--- a/README.md
+++ b/README.md
@@ -287,13 +287,13 @@ In order to run the `smoke-tests`, `lint`, `check-patches` and `update-graph`
 targets, you'll need additional packages:
 
 ```sh
-dnf install gawk gdb clang-tools-extra jq codespell curl traceroute graphviz ndisc6 abidiff
+dnf install gawk gdb clang-tools-extra jq codespell curl traceroute graphviz ndisc6 abidiff inotify-tools
 ```
 
 or
 
 ```sh
-apt install gawk gdb clang-format jq codespell curl traceroute graphviz ndisc6 abigail-tools
+apt install gawk gdb clang-format jq codespell curl traceroute graphviz ndisc6 abigail-tools inotify-tools
 ```
 
 ### Build

--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -127,10 +127,14 @@ void grout_link_change(struct gr_iface *gr_if, bool new, bool startup) {
 	dplane_ctx_set_ifp_link_nsid(ctx, GROUT_NS);
 	dplane_ctx_set_ifp_zif_type(ctx, zif_type);
 	dplane_ctx_set_ifindex(ctx, ifindex_grout_to_frr(gr_if->id));
-	dplane_ctx_set_ifname(ctx, gr_if->name);
 #if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 7, 0)
+	if (zif_type == ZEBRA_IF_VRF && gr_if->id == GR_VRF_DEFAULT_ID)
+		dplane_ctx_set_ifname(ctx, VRF_DEFAULT_NAME);
+	else
+		dplane_ctx_set_ifname(ctx, gr_if->name);
 	dplane_ctx_set_startup(ctx, startup);
 #else
+	dplane_ctx_set_ifname(ctx, gr_if->name);
 	dplane_ctx_set_ifp_startup(ctx, startup);
 #endif
 	dplane_ctx_set_ifp_family(ctx, AF_UNSPEC);

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -13,13 +13,10 @@
 #include "log_grout.h"
 #include "rt_grout.h"
 
-#include <fcntl.h>
-#include <getopt.h>
 #include <lib/bitfield.h>
 #include <lib/frr_pthread.h>
 #include <lib/libfrr.h>
 #include <lib/version.h>
-#include <unistd.h>
 #include <zebra/interface.h>
 #include <zebra/rib.h>
 #include <zebra/zebra_dplane.h>
@@ -73,10 +70,6 @@ struct grout_ctx_t {
 	struct event *dg_t_poll_marker;
 	unsigned int marker_poll_retries;
 	void (*marker_cb)(void);
-
-	// -K value cached from /proc/self/cmdline. Same semantics as FRR's
-	// zebra_di.gr_cleanup_time: 0 means absent, positive means K seconds.
-	int gr_cleanup_time;
 };
 
 static struct grout_ctx_t grout_ctx = {0};
@@ -91,7 +84,7 @@ static void grout_sync_ifaces(struct event *);
 static void grout_sync_addrs(struct event *);
 static void grout_reconnect(struct event *);
 static void grout_reconnect_finish(void);
-static void grout_sync_arm_sweep(void);
+static void grout_main_router_started(void);
 static void grout_sync_cleanup_marker(void);
 static void grout_sync_inject_marker(void);
 
@@ -198,84 +191,9 @@ static void grout_sync_fdb(struct event *) {
 			return;
 		}
 	}
-}
 
-// Recover -K by re-parsing /proc/self/cmdline. zebra_di.gr_cleanup_time
-// is static in main.c (not exported) and zrouter.t_rib_sweep loses the
-// value after firing. Returns the -K seconds, or 0 if absent (matches
-// FRR's libfrr.c default + atoi semantics). Called once from
-// zd_grout_plugin_init (single-threaded, before event loop).
-static int grout_read_k_from_cmdline(void) {
-	// 1 MiB cap; ARG_MAX is 2 MiB, MTYPE_TMP aborts on OOM.
-	const size_t buf_cap_max = 1024 * 1024;
-	char *buf = NULL, **argv = NULL;
-	size_t buf_cap = 4096, buf_len = 0;
-	int argc = 0, argv_cap = 0;
-	int fd, ret = 0;
-
-	fd = open("/proc/self/cmdline", O_RDONLY);
-	if (fd < 0) {
-		gr_log_warn("/proc/self/cmdline: %s", strerror(errno));
-		return 0;
-	}
-
-	buf = XMALLOC(MTYPE_TMP, buf_cap);
-
-	for (;;) {
-		ssize_t n = read(fd, buf + buf_len, buf_cap - buf_len - 1);
-		if (n < 0)
-			goto out;
-		if (n == 0)
-			break;
-		buf_len += n;
-		if (buf_len >= buf_cap - 1) {
-			if (buf_cap >= buf_cap_max) {
-				gr_log_warn(
-					"/proc/self/cmdline exceeds %zu bytes, truncating; "
-					"-K parsing may miss the flag",
-					buf_cap_max
-				);
-				goto out;
-			}
-			buf_cap *= 2;
-			if (buf_cap > buf_cap_max)
-				buf_cap = buf_cap_max;
-			buf = XREALLOC(MTYPE_TMP, buf, buf_cap);
-		}
-	}
-	if (buf_len == 0)
-		goto out;
-	buf[buf_len] = '\0';
-
-	for (size_t i = 0; i < buf_len; i++)
-		if (buf[i] == '\0')
-			argv_cap++;
-
-	argv = XCALLOC(MTYPE_TMP, (argv_cap + 1) * sizeof(*argv));
-	for (char *p = buf; p < buf + buf_len; p += strlen(p) + 1)
-		argv[argc++] = p;
-	argv[argc] = NULL;
-
-	static const struct option lo[] = {
-		{"graceful_restart", optional_argument, NULL, 'K'}, {0, 0, 0, 0}
-	};
-	int saved_optind = optind;
-	int saved_opterr = opterr;
-	optind = 1;
-	opterr = 0;
-	int c;
-	while ((c = getopt_long(argc, argv, ":K::", lo, NULL)) != -1) {
-		if (c == 'K' && optarg)
-			ret = atoi(optarg);
-	}
-	optind = saved_optind;
-	opterr = saved_opterr;
-
-out:
-	close(fd);
-	XFREE(MTYPE_TMP, argv);
-	XFREE(MTYPE_TMP, buf);
-	return ret;
+	// No VRFs to sync. Signal zebra we are ready.
+	grout_main_router_started();
 }
 
 // Run the post-observation action set up by the marker injector.
@@ -286,12 +204,10 @@ static void grout_sync_dispatch_marker_cb(void) {
 	cb();
 }
 
-// Arm rib_sweep_route after observing the end-of-replay marker.
-// Re-stamp zrouter.startup_time to "now" so -K is measured from the
-// end of the grout dump (mirrors Donald Sharp's "Delay some processing
-// until after startup is finished"). Replaces the pre-arm placeholder
-// installed by zd_grout_plugin_init.
-static void grout_sync_arm_sweep(void) {
+// Arm rib_sweep_route after observing the end-of-replay marker: re-stamp
+// zrouter.startup_time so -K runs from the end of the grout dump, then hand
+// off to zebra_main_router_started (sweep arm + zserv).
+static void grout_main_router_started(void) {
 	grout_sync_cleanup_marker();
 
 	time_t old_startup_time = zrouter.startup_time;
@@ -302,15 +218,9 @@ static void grout_sync_arm_sweep(void) {
 		(long long)zrouter.startup_time
 	);
 
-	long delay = 0;
-	if (zrouter.graceful_restart) {
-		// Truthy check matches zebra/main.c: 0 falls back to default.
-		delay = grout_ctx.gr_cleanup_time ?
-			grout_ctx.gr_cleanup_time :
-			ZEBRA_GR_DEFAULT_RIB_SWEEP_TIME;
-	}
+	// Drop the placeholder, else the arm below is a no-op.
 	event_cancel(&zrouter.t_rib_sweep);
-	event_add_timer(zrouter.master, rib_sweep_route, NULL, delay, &zrouter.t_rib_sweep);
+	zebra_main_router_started();
 }
 
 // Poll the RIB for our marker. FIFO ordering of META_QUEUE_EARLY_ROUTE
@@ -527,7 +437,7 @@ route6:
 	// All VRFs synced. Defer arming rib_sweep_route until the marker is
 	// observed: arming inline would race the metaQ drain and miss
 	// not-yet-attached SELFROUTE injections.
-	grout_ctx.marker_cb = grout_sync_arm_sweep;
+	grout_ctx.marker_cb = grout_main_router_started;
 	grout_sync_inject_marker();
 	return;
 
@@ -1130,8 +1040,8 @@ static int zd_grout_plugin_init(struct event_loop *) {
 
 	gr_log_debug("%s register status %d", plugin_name, ret);
 
-	// Cache -K once: single-threaded under frr_late_init.
-	grout_ctx.gr_cleanup_time = grout_read_k_from_cmdline();
+	if (zrouter.t_rib_sweep)
+		gr_log_err("RIB sweep already registered");
 
 	// Pre-arm to neutralise the native sweep: zebra_main_router_started's
 	// event_add_timer(... &zrouter.t_rib_sweep) early-returns when the

--- a/smoke/_init_frr.sh
+++ b/smoke/_init_frr.sh
@@ -253,32 +253,24 @@ set_srv6_route() {
 # Fails after 10s if any daemon is not respawned with a different pid.
 kill_frr_daemons() {
 	local frr_run="$builddir/frr_install/var/run/frr"
-	local daemon new
-	declare -A old_pids
+	local daemon f
+	declare -A pids
 
 	for daemon in "$@"; do
-		old_pids[$daemon]=$(cat "$frr_run/$daemon.pid")
+		f="$frr_run/$daemon.pid"
+		pids[$f]=$(cat "$f")
 	done
 
-	for daemon in "$@"; do
-		kill -9 "${old_pids[$daemon]}"
-	done
+	{ sleep 0.2 && kill -9 "${pids[@]}"; } &
 
-	SECONDS=0
-	while :; do
-		local all_respawned=1
-		for daemon in "$@"; do
-			new=$(cat "$frr_run/$daemon.pid" 2>/dev/null || true)
-			if [ -z "$new" ] || [ "$new" = "${old_pids[$daemon]}" ]; then
-				all_respawned=0
-				break
-			fi
-		done
-		[ "$all_respawned" -eq 1 ] && break
-		[ "$SECONDS" -ge 10 ] && \
-			fail "watchfrr did not respawn $* within 10s"
-		sleep 0.1
-	done
+	while [ "${#pids[@]}" -gt 0 ] && read -r f; do
+		if [[ -v pids[$f] ]]; then
+			pkill -0 --pidfile "$f"
+			unset pids[$f]
+		fi
+	done < <(timeout 10s inotifywait -mq -e modify --format %w%f "$frr_run" || :)
+
+	[ "${#pids[@]}" -eq 0 ] || fail "watchfrr did not respawn ${pids[@]} within 10s"
 }
 
 #   <namespace> : optional netns name ("" = root namespace)

--- a/smoke/frr_restart_graceful_frr_test.sh
+++ b/smoke/frr_restart_graceful_frr_test.sh
@@ -109,6 +109,14 @@ grcli -j route show | jq -e \
 	".[] | select(.destination == \"$sr6_localsid_kept/48\")" >/dev/null \
 	|| fail "static-SID $sr6_localsid_kept/48 not installed in grout FIB"
 
+# The initial startup arms a sweep with -K5 delay (no stale routes exist
+# yet, so it is a harmless no-op). Wait for it to fire before capturing
+# the FRR log baseline, otherwise it leaks into the restart window and
+# the final sweep_count check sees 2 instead of 1.
+{ tail -f -n +1 "$frr_log" || : ; } | \
+	timeout 10 grep -m 1 -E "Sweeping the RIB for stale routes" >/dev/null \
+	|| echo "warning: timeout 10s waiting for initial startup sweep to fire"
+
 mark_events
 # Mark frr_log so the marker wait skips start_frr's earlier emission.
 frr_log_mark=$(wc -l < "$frr_log")

--- a/smoke/frr_restart_graceful_frr_test.sh
+++ b/smoke/frr_restart_graceful_frr_test.sh
@@ -12,7 +12,7 @@
 # zd_grout_plugin_init pre-arms zrouter.t_rib_sweep with a long delay so
 # zebra_main_router_started()'s own event_add_timer(rib_sweep_route, K,
 # &zrouter.t_rib_sweep) is a no-op (*t_ptr != NULL early-return,
-# lib/event.c:1430). grout_sync_arm_sweep replaces the placeholder with
+# lib/event.c:1430). grout_main_router_started replaces the placeholder with
 # the real clamped delay once the replay marker is observed.
 #
 # Follows the pattern of FRR upstream tests/topotests/zebra_graceful_restart
@@ -197,7 +197,7 @@ actual=$((actual_default + actual_vrf2))
 
 # Sweep ran exactly once: the placeholder pre-arm in zd_grout_plugin_init
 # neutralised zebra_main_router_started's native arm (event_add_timer
-# *t_ptr != NULL early-return), and grout_sync_arm_sweep's cancel + arm
+# *t_ptr != NULL early-return), and grout_main_router_started's cancel + arm
 # is the only fire. Any count > 1 means the pre-arm trick regressed.
 sweep_count=$(tail -n +$((frr_log_mark + 1)) "$frr_log" \
 	| grep -cE 'Sweeping the RIB for stale routes\.\.\.$' || true)

--- a/smoke/frr_restart_sweep_no_k_frr_test.sh
+++ b/smoke/frr_restart_sweep_no_k_frr_test.sh
@@ -52,7 +52,7 @@ frr_log_mark=$(wc -l < "$frr_log")
 # zebra_main_router_started() will try to arm t_rib_sweep with delay=0
 # (graceful_restart=false) - but zd_grout_plugin_init already pre-armed
 # that slot with a long delay, so event_add_timer returns early and the
-# native arm is a no-op. grout_sync_arm_sweep later cancels the
+# native arm is a no-op. grout_main_router_started later cancels the
 # placeholder and re-arms with delay=0 once the replay marker is seen.
 kill_frr_daemons zebra staticd
 
@@ -79,7 +79,7 @@ grcli -j route show | jq -e \
 # The sweep ran exactly once. With the pre-arm placeholder in
 # zd_grout_plugin_init, zebra_main_router_started's native
 # event_add_timer(..., 0, &zrouter.t_rib_sweep) is a no-op (*t_ptr
-# already set); only grout_sync_arm_sweep's cancel+arm produces a real
+# already set); only grout_main_router_started's cancel+arm produces a real
 # rib_sweep_route fire. Any count > 1 would mean the pre-arm regressed.
 sweep_count=$(tail -n +$((frr_log_mark + 1)) "$frr_log" \
 	| grep -cE 'Sweeping the RIB for stale routes\.\.\.$' || true)


### PR DESCRIPTION
FRR 10.7 introduced a new ZEBRA_DPLANE_FINISHED_READING startup stage. zebra_main_router_started() which calls zserv_start() to accept zclient connections from routing daemons is now deferred until that signal arrives. The kernel dplane sends it after reading interfaces, addresses and routes from netlink. The grout dplane never sends it, so zebra never starts listening and no routing daemon can connect. This breaks OSPF, OSPF6, BGP and all protocols that rely on zclient connections.

Send ZEBRA_DPLANE_FINISHED_READING after the grout sync chain completes and all state has been injected into zebra. When there is nothing to sync at initial boot, send it from the grout_sync_fdb early exit path. In the normal path, send it from grout_sync_arm_sweep before cancelling the pre-arm placeholder so that zebra_main_router_started's own sweep arm is a no-op.

The smoke kill_frr_daemons helper is also reworked to use inotifywait for more reliable respawn detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## frr/zebra_dplane_grout.c

- Route end-of-initial-sync completion through a new grout_main_router_started() callback that:
  - cleans up the injected marker,
  - re-stamps zrouter.startup_time,
  - cancels the pre-armed placeholder timer via event_cancel(&zrouter.t_rib_sweep),
  - then calls zebra_main_router_started() (so zebra performs its normal sweep arm + zserv start with the placeholder removed).
- grout_sync_fdb(): when no VRFs are marked for initial dataplane sync, call grout_main_router_started() immediately on the early-exit path.
- Marker-driven completion path: set the marker callback to grout_main_router_started() so the marker-observation flow performs marker cleanup, restamps startup_time, drops the pre-arm placeholder, and invokes zebra_main_router_started().

## frr/if_grout.c

- grout_link_change(): for CURRENT_FRR_VERSION >= 10.7.0, set the dplane context interface name to VRF_DEFAULT_NAME when the iface is the default VRF (zif_type == ZEBRA_IF_VRF && gr_if->id == GR_VRF_DEFAULT_ID); otherwise use gr_if->name. Preserve legacy behavior on older FRR versions.

## smoke/_init_frr.sh

- kill_frr_daemons(): replace pidfile-polling loop with an inotifywait-driven workflow that:
  - snapshots per-daemon pidfile contents, removes the pidfiles and builds pkill --pidfile arguments,
  - force-kills the recorded PIDs,
  - waits up to 10s for inotifywait modify events under the FRR run directory and removes observed entries from the snapshot to detect respawn via pidfile updates,
  - verifies respawn/termination via pkill -0 and fails if targets remain.

## .github/workflows/check.yml and README.md

- Add inotify-tools to CI install step and to README development dependency lists to support the new inotifywait-based smoke-test logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->