### PR TITLE
Adaptive interrupt

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,10 @@ jobs:
             arch: aarch64
           - compiler: gcc-14
             dpdk: '25.11'
+            frr: '10.5'
+            adaptive_irq: true
+          - compiler: gcc-14
+            dpdk: '25.11'
             frr: '10.6'
           - compiler: gcc-14
             dpdk: '25.11'
@@ -61,7 +65,7 @@ jobs:
           - compiler: clang-18
             dpdk: '25.11'
             frr: '10.5'
-    name: build-and-tests (${{ matrix.conf.arch || 'x86_64' }}, ${{ matrix.conf.compiler }}, DPDK ${{ matrix.conf.dpdk }}, FRR ${{ matrix.conf.frr }})
+    name: build-and-tests (${{ matrix.conf.arch || 'x86_64' }}, ${{ matrix.conf.compiler }}, DPDK ${{ matrix.conf.dpdk }}, FRR ${{ matrix.conf.frr }}${{ matrix.conf.adaptive_irq && ', adaptive-irq' || '' }})
     runs-on: ubuntu-24.04${{ matrix.conf.arch == 'aarch64' && '-arm' || '' }}
     continue-on-error: ${{ matrix.conf.allow_fail || false }}
     env:
@@ -73,6 +77,7 @@ jobs:
       FRR: ${{ matrix.conf.frr }}
       DPDK: ${{ matrix.conf.dpdk }}
       DPDK_CPU: generic
+      ADAPTIVE_IRQ: ${{ matrix.conf.adaptive_irq && 'true' || '' }}
     steps:
       - name: install system dependencies
         run: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -53,7 +53,7 @@ $(smoke_scripts):
 	$Q log=$(BUILDDIR)/$@.log; \
 	time=$(BUILDDIR)/$@.time; \
 	printf '%s\n' $@; \
-	time -qf '%E' -o "$$time" sudo timeout 5m $@ $(BUILDDIR) </dev/null >"$$log" 2>&1; \
+	time -qf '%E' -o "$$time" sudo $(if $(ADAPTIVE_IRQ),adaptive_irq=$(ADAPTIVE_IRQ)) timeout 5m $@ $(BUILDDIR) </dev/null >"$$log" 2>&1; \
 	rc=$$?; \
 	if [ "$$rc" -ne 0 ]; then \
 		printf '%s\n' '==================================================='; \

--- a/docs/grout.8.scdoc
+++ b/docs/grout.8.scdoc
@@ -51,6 +51,14 @@ Grout is a software router based on DPDK _rte_graph_.
 *-p*, *--poll-mode*
 	Disable automatic micro-sleep.
 
+*-a*, *--adaptive-irq*
+	Make idle workers block on their RX queue interrupts instead of
+	busy-polling, so the CPU can idle during quiet periods. An incoming
+	packet raises the interrupt and the worker resumes polling. It
+	requires PMD support for RX queue interrupts; without it a worker
+	falls back to the micro-sleep ramp, unless *--poll-mode* is also
+	given.
+
 *-S*, *--syslog*
 	Redirect logs to syslog.
 

--- a/main/config.h
+++ b/main/config.h
@@ -19,6 +19,7 @@ struct gr_config {
 	unsigned max_mtu;
 	bool test_mode;
 	bool poll_mode;
+	bool adaptive_irq; // --adaptive-irq: adaptive interrupt rx
 	bool log_syslog;
 	bool log_packets;
 	bool override_default_route;

--- a/main/main.c
+++ b/main/main.c
@@ -61,6 +61,7 @@ static void usage(void) {
 	puts("                                 (default [::]:9111).");
 	puts("  -S, --syslog                   Redirect logs to syslog.");
 	puts("  -V, --version                  Print version and exit.");
+	puts("  -a, --adaptive-irq             Idle workers block on rxq interrupts.");
 	puts("  -h, --help                     Display this help message and exit.");
 	puts("  -m, --socket-mode PERMISSIONS  API socket file permissions (Default: 0660).");
 	puts("  -o, --socket-owner USER:GROUP  API socket file ownership");
@@ -185,8 +186,9 @@ static bool parse_bool_env(const char *name) {
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":M:Vhm:o:pSs:tu:vx"
+#define FLAGS ":aM:Vhm:o:pSs:tu:vx"
 	static struct option long_options[] = {
+		{"adaptive-irq", no_argument, NULL, 'a'},
 		{"help", no_argument, NULL, 'h'},
 		{"max-mtu", required_argument, NULL, 'u'},
 		{"metrics", required_argument, NULL, 'M'},
@@ -218,6 +220,9 @@ static int parse_args(int argc, char **argv) {
 
 	while ((c = getopt_long(argc, argv, FLAGS, long_options, NULL)) != -1) {
 		switch (c) {
+		case 'a':
+			gr_config.adaptive_irq = true;
+			break;
 		case 'h':
 			usage();
 			exit(EXIT_SUCCESS);

--- a/meson.build
+++ b/meson.build
@@ -141,6 +141,11 @@ elif compiler.has_function(
   grout_cflags += ['-DHAVE_RTE_FIB_TBL8_GET_STATS']
 endif
 
+# glibc >= 2.41 provides struct sched_attr and the sched_setattr() wrapper.
+if compiler.has_header_symbol('sched.h', 'sched_setattr', args: '-D_GNU_SOURCE')
+  grout_cflags += ['-DHAVE_SCHED_SETATTR']
+endif
+
 src = []
 inc = []
 

--- a/modules/infra/control/bond.c
+++ b/modules/infra/control/bond.c
@@ -339,6 +339,8 @@ void bond_update_active_members(struct iface *iface) {
 	}
 
 	vec_free(active_ids);
+	// wake idle adaptive-irq workers so the datapath observes the new active member
+	worker_wakeup_all();
 }
 
 static int bond_up_down(struct iface *iface, bool up) {

--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -43,6 +43,7 @@ bool vrf_has_interfaces(uint16_t) {
 	return false;
 }
 void control_queue_drain(uint32_t, const void *) { }
+void worker_wakeup_all(void) { }
 mock_func(struct iface *, __wrap_iface_from_id(uint16_t));
 mock_func(int, port_unplug(struct iface_info_port *));
 mock_func(int, port_plug(struct iface_info_port *));

--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -44,6 +44,7 @@ bool vrf_has_interfaces(uint16_t) {
 }
 void control_queue_drain(uint32_t, const void *) { }
 void worker_wakeup_all(void) { }
+void worker_rearm_all(void) { }
 mock_func(struct iface *, __wrap_iface_from_id(uint16_t));
 mock_func(int, port_unplug(struct iface_info_port *));
 mock_func(int, port_plug(struct iface_info_port *));

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -272,7 +272,7 @@ static int port_mtu_set(struct iface *iface, uint16_t mtu) {
 	if ((ret = rte_eth_dev_start(p->port_id)) < 0)
 		return errno_log(-ret, "rte_eth_dev_start");
 	p->started = true;
-	worker_wakeup_all(); // let workers (re)arm now that the port is started
+	worker_rearm_all(); // let workers (re)arm now that the port is started
 	iface->mtu = mtu;
 
 	vec_foreach (struct iface *s, iface->subinterfaces)
@@ -365,7 +365,7 @@ static int iface_port_reconfig(
 		return errno_log(-ret, "rte_eth_dev_start");
 
 	p->started = true;
-	worker_wakeup_all(); // let workers (re)arm now that the port is started
+	worker_rearm_all(); // let workers (re)arm now that the port is started
 
 	return 0;
 }

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -152,6 +152,9 @@ int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
 	if (info.dev_flags != NULL && *info.dev_flags & RTE_ETH_DEV_INTR_LSC) {
 		conf.intr_conf.lsc = 1;
 	}
+	// Request RX queue interrupts so idle workers can block on them.
+	if (gr_config.adaptive_irq)
+		conf.intr_conf.rxq = 1;
 
 	if ((ret = rte_eth_dev_configure(p->port_id, p->n_rxq, p->n_txq, &conf)) < 0)
 		return errno_log(-ret, "rte_eth_dev_configure");
@@ -269,6 +272,7 @@ static int port_mtu_set(struct iface *iface, uint16_t mtu) {
 	if ((ret = rte_eth_dev_start(p->port_id)) < 0)
 		return errno_log(-ret, "rte_eth_dev_start");
 	p->started = true;
+	worker_wakeup_all(); // let workers (re)arm now that the port is started
 	iface->mtu = mtu;
 
 	vec_foreach (struct iface *s, iface->subinterfaces)
@@ -361,6 +365,7 @@ static int iface_port_reconfig(
 		return errno_log(-ret, "rte_eth_dev_start");
 
 	p->started = true;
+	worker_wakeup_all(); // let workers (re)arm now that the port is started
 
 	return 0;
 }

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -32,6 +32,8 @@ LOG_TYPE("worker");
 
 struct workers workers = STAILQ_HEAD_INITIALIZER(workers);
 
+atomic_uint gr_worker_active;
+
 int worker_create(unsigned cpu_id) {
 	bool attr_inited = false, thread_created = false, inserted = false;
 	struct worker *worker = rte_zmalloc(__func__, sizeof(*worker), 0);
@@ -132,9 +134,7 @@ void worker_wait_wakeup(struct worker *w) {
 	pthread_mutex_unlock(&w->wakeup.lock);
 }
 
-void worker_wakeup(struct worker *w) {
-	uint64_t one = 1;
-
+static void worker_kick(struct worker *w, uint64_t val) {
 	pthread_mutex_lock(&w->wakeup.lock);
 	w->wakeup.set = true;
 	pthread_cond_signal(&w->wakeup.cond);
@@ -144,15 +144,41 @@ void worker_wakeup(struct worker *w) {
 	// worker idle on rte_epoll_wait is woken through the eventfd instead.
 	// EAGAIN means a kick is already pending and undrained, which is enough.
 	if (gr_config.adaptive_irq
-	    && write(w->adaptive_irq.wakeup_fd, &one, sizeof(one)) != sizeof(one)
+	    && write(w->adaptive_irq.wakeup_fd, &val, sizeof(val)) != sizeof(val)
 	    && errno != EAGAIN)
 		LOG(ERR, "worker %u wakeup_fd write: %s", w->cpu_id, strerror(errno));
+}
+
+void worker_wakeup(struct worker *w) {
+	worker_kick(w, 1);
 }
 
 void worker_wakeup_all(void) {
 	struct worker *worker;
 	STAILQ_FOREACH (worker, &workers, next)
 		worker_wakeup(worker);
+}
+
+// Wake one rxq-owning worker to drain the control input ring, if none is active.
+void worker_wakeup_any(void) {
+	struct worker *worker;
+
+	if (worker_active_count() != 0)
+		return;
+
+	STAILQ_FOREACH (worker, &workers, next) {
+		if (vec_len(worker->rxqs) > 0) {
+			worker_wakeup(worker);
+			return;
+		}
+	}
+}
+
+// Re-arm every worker's rxq interrupts after a port stop/start dropped them.
+void worker_rearm_all(void) {
+	struct worker *worker;
+	STAILQ_FOREACH (worker, &workers, next)
+		worker_kick(worker, WORKER_KICK_REARM);
 }
 
 unsigned worker_count(void) {

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -24,6 +24,7 @@
 #include <pthread.h>
 #include <sched.h>
 #include <stdatomic.h>
+#include <sys/eventfd.h>
 #include <sys/queue.h>
 #include <unistd.h>
 
@@ -43,8 +44,15 @@ int worker_create(unsigned cpu_id) {
 
 	worker->cpu_id = cpu_id;
 	worker->lcore_id = LCORE_ID_ANY;
+	worker->adaptive_irq.wakeup_fd = -1;
 	pthread_mutex_init(&worker->wakeup.lock, NULL);
 	pthread_cond_init(&worker->wakeup.cond, NULL);
+
+	worker->adaptive_irq.wakeup_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+	if (worker->adaptive_irq.wakeup_fd < 0) {
+		ret = errno;
+		goto end;
+	}
 
 	CPU_ZERO(&cpuset);
 	CPU_SET(cpu_id, &cpuset);
@@ -83,6 +91,8 @@ end:
 				pthread_cancel(worker->thread);
 			pthread_cond_destroy(&worker->wakeup.cond);
 			pthread_mutex_destroy(&worker->wakeup.lock);
+			if (worker->adaptive_irq.wakeup_fd >= 0)
+				close(worker->adaptive_irq.wakeup_fd);
 			rte_free(worker);
 		}
 		LOG(ERR, "worker %u start failed: %s", cpu_id, strerror(ret));
@@ -104,6 +114,7 @@ int worker_destroy(unsigned cpu_id) {
 	pthread_join(worker->thread, NULL);
 	pthread_cond_destroy(&worker->wakeup.cond);
 	pthread_mutex_destroy(&worker->wakeup.lock);
+	close(worker->adaptive_irq.wakeup_fd);
 	worker_graph_free(worker);
 	vec_free(worker->rxqs);
 	vec_free(worker->txqs);
@@ -122,10 +133,26 @@ void worker_wait_wakeup(struct worker *w) {
 }
 
 void worker_wakeup(struct worker *w) {
+	uint64_t one = 1;
+
 	pthread_mutex_lock(&w->wakeup.lock);
 	w->wakeup.set = true;
 	pthread_cond_signal(&w->wakeup.cond);
 	pthread_mutex_unlock(&w->wakeup.lock);
+
+	// The condvar above only reaches a worker parked on graph == NULL. An adaptive-irq
+	// worker idle on rte_epoll_wait is woken through the eventfd instead.
+	// EAGAIN means a kick is already pending and undrained, which is enough.
+	if (gr_config.adaptive_irq
+	    && write(w->adaptive_irq.wakeup_fd, &one, sizeof(one)) != sizeof(one)
+	    && errno != EAGAIN)
+		LOG(ERR, "worker %u wakeup_fd write: %s", w->cpu_id, strerror(errno));
+}
+
+void worker_wakeup_all(void) {
+	struct worker *worker;
+	STAILQ_FOREACH (worker, &workers, next)
+		worker_wakeup(worker);
 }
 
 unsigned worker_count(void) {

--- a/modules/infra/control/worker.c
+++ b/modules/infra/control/worker.c
@@ -32,6 +32,7 @@ LOG_TYPE("worker");
 struct workers workers = STAILQ_HEAD_INITIALIZER(workers);
 
 int worker_create(unsigned cpu_id) {
+	bool attr_inited = false, thread_created = false, inserted = false;
 	struct worker *worker = rte_zmalloc(__func__, sizeof(*worker), 0);
 	pthread_attr_t attr;
 	cpu_set_t cpuset;
@@ -48,13 +49,16 @@ int worker_create(unsigned cpu_id) {
 	CPU_ZERO(&cpuset);
 	CPU_SET(cpu_id, &cpuset);
 	pthread_attr_init(&attr);
+	attr_inited = true;
 	if (!!(ret = pthread_attr_setaffinity_np(&attr, sizeof(cpuset), &cpuset)))
 		goto end;
 
 	if (!!(ret = pthread_create(&worker->thread, &attr, gr_datapath_loop, worker)))
 		goto end;
+	thread_created = true;
 
 	STAILQ_INSERT_TAIL(&workers, worker, next);
+	inserted = true;
 
 	// wait until thread has initialized lcore_id
 	for (unsigned i = 0; !atomic_load(&worker->started); i++) {
@@ -66,14 +70,17 @@ int worker_create(unsigned cpu_id) {
 	}
 
 end:
-	pthread_attr_destroy(&attr);
+	if (attr_inited)
+		pthread_attr_destroy(&attr);
 
 	if (ret == 0) {
 		LOG(INFO, "worker %u started", cpu_id);
 	} else {
 		if (worker != NULL) {
-			STAILQ_REMOVE(&workers, worker, worker, next);
-			pthread_cancel(worker->thread);
+			if (inserted)
+				STAILQ_REMOVE(&workers, worker, worker, next);
+			if (thread_created)
+				pthread_cancel(worker->thread);
 			pthread_cond_destroy(&worker->wakeup.cond);
 			pthread_mutex_destroy(&worker->wakeup.lock);
 			rte_free(worker);

--- a/modules/infra/control/worker.h
+++ b/modules/infra/control/worker.h
@@ -8,6 +8,7 @@
 
 #include <rte_common.h>
 #include <rte_graph.h>
+#include <rte_interrupts.h>
 
 #include <pthread.h>
 #include <sched.h>
@@ -66,6 +67,12 @@ struct worker {
 	unsigned cpu_id;
 	unsigned lcore_id;
 	pid_t tid;
+	// adaptive-irq only: idle worker wakeup through an rxq-interrupt epoll set
+	struct {
+		int wakeup_fd; // eventfd: ctlplane writes, dataplane epoll-waits + drains
+		struct rte_epoll_event wakeup_ev; // dataplane: wakeup_fd's epoll registration
+		bool wakeup_registered; // dataplane: wakeup_fd added to the epoll set?
+	} adaptive_irq;
 
 	struct {
 		pthread_mutex_t lock;
@@ -87,6 +94,7 @@ int worker_rxq_assign(uint16_t port_id, uint16_t rxq_id, uint16_t cpu_id);
 int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_port **ports);
 void worker_wait_wakeup(struct worker *);
 void worker_wakeup(struct worker *);
+void worker_wakeup_all(void);
 vec struct gr_stat *worker_dump_stats(uint16_t cpu_id);
 
 int port_unplug(struct iface_info_port *);

--- a/modules/infra/control/worker.h
+++ b/modules/infra/control/worker.h
@@ -24,6 +24,10 @@ struct queue_map {
 
 #define GR_MAX_NODE_XSTATS 4
 
+// wakeup_fd encoding: a plain wakeup writes 1; a re-arm kick sets a high bit so
+// the adaptive-irq worker re-registers its rxqs after reading it.
+#define WORKER_KICK_REARM (1ULL << 32)
+
 struct node_stats {
 	rte_node_t node_id;
 	rte_node_t parent_id;
@@ -95,6 +99,25 @@ int worker_queue_distribute(const cpu_set_t *affinity, vec struct iface_info_por
 void worker_wait_wakeup(struct worker *);
 void worker_wakeup(struct worker *);
 void worker_wakeup_all(void);
+void worker_wakeup_any(void);
+void worker_rearm_all(void);
+
+// Number of workers running the graph; post_to_stack reads it to decide whether
+// to kick an idle worker to drain the control input ring.
+extern atomic_uint gr_worker_active;
+
+static inline void worker_active_inc(void) {
+	atomic_fetch_add_explicit(&gr_worker_active, 1, memory_order_seq_cst);
+}
+
+static inline void worker_active_dec(void) {
+	atomic_fetch_sub_explicit(&gr_worker_active, 1, memory_order_seq_cst);
+}
+
+static inline unsigned worker_active_count(void) {
+	return atomic_load_explicit(&gr_worker_active, memory_order_seq_cst);
+}
+
 vec struct gr_stat *worker_dump_stats(uint16_t cpu_id);
 
 int port_unplug(struct iface_info_port *);

--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Christophe Fontaine
 
+#include "config.h"
 #include "control_input.h"
 #include "graph.h"
 #include "log.h"
 #include "mbuf.h"
 #include "mempool.h"
 #include "trace.h"
+#include "worker.h"
 
 LOG_TYPE("graph");
 
@@ -47,7 +49,15 @@ int post_to_stack(control_input_t type, void *data) {
 	if (ret < 0)
 		return errno_set(-ret);
 
+	// adaptive-irq only: kick an idle worker blocked on rte_epoll_wait to drain it.
+	if (gr_config.adaptive_irq)
+		worker_wakeup_any();
+
 	return 0;
+}
+
+bool control_input_pending(void) {
+	return rte_ring_count(control_input_ring) > 0;
 }
 
 static uint16_t control_input_process(

--- a/modules/infra/datapath/control_input.h
+++ b/modules/infra/datapath/control_input.h
@@ -14,3 +14,6 @@ typedef uint8_t control_input_t;
 control_input_t gr_control_input_register_handler(const char *node_name, bool data_is_mbuf);
 
 __rte_warn_unused_result int post_to_stack(control_input_t type, void *data);
+
+// True if the control input ring has packets waiting to be drained by a worker.
+bool control_input_pending(void);

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -21,9 +21,11 @@
 #include <rte_malloc.h>
 
 #include <pthread.h>
+#include <sched.h>
 #include <stdatomic.h>
 #include <sys/epoll.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 LOG_TYPE("graph");
@@ -188,6 +190,9 @@ static struct rte_rcu_qsbr *rcu;
 
 #define ADAPTIVE_IRQ_EMPTY_WINDOWS 2
 #define ADAPTIVE_IRQ_MAX_EVENTS 32
+// short settle waits let schedutil drop the clock before the worker blocks for good
+#define ADAPTIVE_IRQ_SETTLE_MS 100
+#define ADAPTIVE_IRQ_SETTLE_TRIES 3
 
 // --adaptive-irq: an idle worker arms its rxqs via rte_eth_dev_rx_intr_* and blocks on
 // their eventfds through this thread's epoll until one fires. Arm -EAGAIN means
@@ -199,7 +204,7 @@ adaptive_irq_wait(struct worker *w, vec struct queue_map *rxqs, vec struct queue
 	struct rte_epoll_event events[ADAPTIVE_IRQ_MAX_EVENTS];
 	vec struct queue_map *armed = NULL;
 	struct queue_map *qm, *e;
-	int ret, status = 0;
+	int n, ret, status = 0;
 	bool rearm = false;
 
 	// add the wakeup_fd to the same per-thread epfd rte_epoll_wait uses; done here,
@@ -273,7 +278,21 @@ adaptive_irq_wait(struct worker *w, vec struct queue_map *rxqs, vec struct queue
 	}
 
 	rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
-	rte_epoll_wait(RTE_EPOLL_PER_THREAD, events, ADAPTIVE_IRQ_MAX_EVENTS, -1);
+	// a few short waits let schedutil ratchet the frequency down from the uclamp_min
+	// max before blocking for good. Each is one wait, not a drain loop: epoll_wait
+	// leaves the events (the graph walk pulls frames), so a loop would spin.
+	for (unsigned i = 0; i < ADAPTIVE_IRQ_SETTLE_TRIES; i++) {
+		n = rte_epoll_wait(
+			RTE_EPOLL_PER_THREAD,
+			events,
+			ADAPTIVE_IRQ_MAX_EVENTS,
+			ADAPTIVE_IRQ_SETTLE_MS
+		);
+		if (n != 0)
+			break;
+	}
+	if (n == 0)
+		n = rte_epoll_wait(RTE_EPOLL_PER_THREAD, events, ADAPTIVE_IRQ_MAX_EVENTS, -1);
 	rte_rcu_qsbr_thread_online(rcu, rte_lcore_id());
 
 	// drain the wakeup_fd; a WORKER_KICK_REARM (high bit) means our rxq epoll
@@ -292,6 +311,53 @@ disarm:
 		rte_eth_dev_rx_intr_disable(e->port_id, e->queue_id);
 	vec_free(armed);
 	return status;
+}
+
+// Pin uclamp_min to max: an idle adaptive-irq worker blocks on the IRQ, so schedutil
+// would downclock the core; keep it at full speed while runnable. glibc < 2.41
+// lacks sched_setattr()/struct sched_attr (see HAVE_SCHED_SETATTR), so define locally.
+#ifndef HAVE_SCHED_SETATTR
+struct sched_attr {
+	uint32_t size;
+	uint32_t sched_policy;
+	uint64_t sched_flags;
+	int32_t sched_nice;
+	uint32_t sched_priority;
+	uint64_t sched_runtime;
+	uint64_t sched_deadline;
+	uint64_t sched_period;
+	uint32_t sched_util_min;
+	uint32_t sched_util_max;
+};
+static inline int sched_setattr(pid_t pid, struct sched_attr *attr, unsigned int flags) {
+	return syscall(SYS_sched_setattr, pid, attr, flags);
+}
+#endif
+#ifndef SCHED_FLAG_KEEP_ALL
+#define SCHED_FLAG_KEEP_POLICY 0x08
+#define SCHED_FLAG_KEEP_PARAMS 0x10
+#define SCHED_FLAG_KEEP_ALL (SCHED_FLAG_KEEP_POLICY | SCHED_FLAG_KEEP_PARAMS)
+#endif
+#ifndef SCHED_FLAG_UTIL_CLAMP_MIN
+#define SCHED_FLAG_UTIL_CLAMP_MIN 0x20
+#endif
+
+static void worker_perf_floor(const struct worker *w) {
+	struct sched_attr attr = {
+		.size = sizeof(attr),
+		.sched_flags = SCHED_FLAG_KEEP_ALL | SCHED_FLAG_UTIL_CLAMP_MIN,
+		.sched_util_min = 1024, // SCHED_CAPACITY_SCALE
+	};
+
+	if (sched_setattr(0, &attr, 0) < 0) {
+		if (errno == EOPNOTSUPP || errno == ENOSYS || errno == EPERM || errno == EINVAL)
+			LOG(NOTICE,
+			    "[CPU %d] uclamp_min unavailable: %s",
+			    w->cpu_id,
+			    strerror(errno));
+		else
+			LOG(WARNING, "[CPU %d] uclamp_min: %s", w->cpu_id, strerror(errno));
+	}
 }
 
 void *gr_datapath_loop(void *priv) {
@@ -334,6 +400,8 @@ void *gr_datapath_loop(void *priv) {
 			return NULL;
 		}
 	}
+	if (gr_config.adaptive_irq)
+		worker_perf_floor(w);
 
 	log(INFO, "lcore_id = %d", w->lcore_id);
 

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Robin Jarry
 
 #include "config.h"
+#include "control_input.h"
 #include "datapath.h"
 #include "log.h"
 #include "module.h"
@@ -199,6 +200,7 @@ adaptive_irq_wait(struct worker *w, vec struct queue_map *rxqs, vec struct queue
 	vec struct queue_map *armed = NULL;
 	struct queue_map *qm, *e;
 	int ret, status = 0;
+	bool rearm = false;
 
 	// add the wakeup_fd to the same per-thread epfd rte_epoll_wait uses; done here,
 	// not at worker start, so it lands on the epfd the block actually uses.
@@ -260,27 +262,31 @@ adaptive_irq_wait(struct worker *w, vec struct queue_map *rxqs, vec struct queue
 			vec_add(*registered, *qm);
 	}
 
-	// a packet may have arrived while arming; recheck and resume polling instead
-	// of blocking. rx_queue_count is safe against a concurrent stop (returns -ENOTSUP).
+	// about to block: drop the active count, then recheck the ring and rxqs so a
+	// packet that arrived while arming resumes polling. seq_cst pairs post_to_stack.
+	worker_active_dec();
+	if (control_input_pending())
+		goto wake;
 	vec_foreach_ref (qm, armed) {
 		if (rte_eth_rx_queue_count(qm->port_id, qm->queue_id) > 0)
-			goto disarm;
+			goto wake;
 	}
 
 	rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
 	rte_epoll_wait(RTE_EPOLL_PER_THREAD, events, ADAPTIVE_IRQ_MAX_EVENTS, -1);
 	rte_rcu_qsbr_thread_online(rcu, rte_lcore_id());
 
-	// drain the wakeup_fd; a kick means a reconfig/shutdown or a port stop/start,
-	// which may have dropped our rxq epoll registration, so re-register next time.
+	// drain the wakeup_fd; a WORKER_KICK_REARM (high bit) means our rxq epoll
+	// registration was dropped, so re-register next time.
 	uint64_t kick;
-	if (read(w->adaptive_irq.wakeup_fd, &kick, sizeof(kick)) > 0) {
+	while (read(w->adaptive_irq.wakeup_fd, &kick, sizeof(kick)) > 0)
+		if (kick >= WORKER_KICK_REARM)
+			rearm = true;
+	if (rearm)
 		vec_free(*registered);
-		*registered = NULL;
-		while (read(w->adaptive_irq.wakeup_fd, &kick, sizeof(kick)) > 0)
-			;
-	}
 
+wake:
+	worker_active_inc();
 disarm:
 	vec_foreach_ref (e, armed)
 		rte_eth_dev_rx_intr_disable(e->port_id, e->queue_id);
@@ -378,6 +384,8 @@ reconfig:
 		for (uint32_t i = 0; i < vec_len(w->rxqs); i++)
 			vec_add(airq_rxqs, w->rxqs[i]);
 	}
+	// this worker now runs the graph and drains the control input ring
+	worker_active_inc();
 
 	for (;;) {
 		rte_graph_walk(graph);
@@ -388,6 +396,7 @@ reconfig:
 			rte_rcu_qsbr_quiescent(rcu, rte_lcore_id());
 
 			if (atomic_load(&w->shutdown) || atomic_load(&w->next_config) != cur) {
+				worker_active_dec();
 				rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
 				goto reconfig;
 			}

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -13,12 +13,15 @@
 #include <rte_common.h>
 #include <rte_eal.h>
 #include <rte_errno.h>
+#include <rte_ethdev.h>
 #include <rte_graph_worker.h>
+#include <rte_interrupts.h>
 #include <rte_lcore.h>
 #include <rte_malloc.h>
 
 #include <pthread.h>
 #include <stdatomic.h>
+#include <sys/epoll.h>
 #include <sys/prctl.h>
 #include <unistd.h>
 
@@ -182,6 +185,109 @@ err:
 
 static struct rte_rcu_qsbr *rcu;
 
+#define ADAPTIVE_IRQ_EMPTY_WINDOWS 2
+#define ADAPTIVE_IRQ_MAX_EVENTS 32
+
+// --adaptive-irq: an idle worker arms its rxqs via rte_eth_dev_rx_intr_* and blocks on
+// their eventfds through this thread's epoll until one fires. Arm -EAGAIN means
+// traffic was pending (not armed): poll and retry; other errors disable adaptive-irq.
+// epoll entries are never removed (queues may share one portal eventfd); the
+// wakeup_fd is in the set too, so a reconfig/shutdown kick breaks the block.
+static int
+adaptive_irq_wait(struct worker *w, vec struct queue_map *rxqs, vec struct queue_map **registered) {
+	struct rte_epoll_event events[ADAPTIVE_IRQ_MAX_EVENTS];
+	vec struct queue_map *armed = NULL;
+	struct queue_map *qm, *e;
+	int ret, status = 0;
+
+	// add the wakeup_fd to the same per-thread epfd rte_epoll_wait uses; done here,
+	// not at worker start, so it lands on the epfd the block actually uses.
+	if (!w->adaptive_irq.wakeup_registered) {
+		w->adaptive_irq.wakeup_ev.epdata.event = EPOLLIN;
+		ret = rte_epoll_ctl(
+			RTE_EPOLL_PER_THREAD,
+			EPOLL_CTL_ADD,
+			w->adaptive_irq.wakeup_fd,
+			&w->adaptive_irq.wakeup_ev
+		);
+		if (ret == 0 || errno == EEXIST)
+			w->adaptive_irq.wakeup_registered = true;
+	}
+
+	vec_foreach_ref (qm, rxqs) {
+		const struct iface *iface = port_get_iface(qm->port_id);
+		// skip a port not yet registered or not started
+		if (iface == NULL || !iface_info_port(iface)->started)
+			continue;
+		ret = rte_eth_dev_rx_intr_enable(qm->port_id, qm->queue_id);
+		// -EAGAIN: transient (traffic pending), poll and retry next window
+		if (ret == -EAGAIN)
+			goto disarm;
+		// terminal: disable adaptive-irq for this worker and fall back to the
+		// micro-sleep ramp, a reconfig re-enables it
+		if (ret < 0) {
+			LOG(NOTICE,
+			    "[CPU %d] rte_eth_dev_rx_intr_enable(port=%u queue=%u): %s, disabling "
+			    "adaptive-irq",
+			    w->cpu_id,
+			    qm->port_id,
+			    qm->queue_id,
+			    rte_strerror(-ret));
+			status = ret;
+			goto disarm;
+		}
+		vec_add(armed, *qm);
+	}
+
+	// register each armed rxq once; *registered caches it (a PMD may drop it on dev_stop)
+	vec_foreach_ref (qm, armed) {
+		bool reg = false;
+
+		for (uint32_t i = 0; i < vec_len(*registered); i++) {
+			if ((*registered)[i].port_id == qm->port_id
+			    && (*registered)[i].queue_id == qm->queue_id) {
+				reg = true;
+				break;
+			}
+		}
+		if (reg)
+			continue;
+		ret = rte_eth_dev_rx_intr_ctl_q(
+			qm->port_id, qm->queue_id, RTE_EPOLL_PER_THREAD, RTE_INTR_EVENT_ADD, NULL
+		);
+		// -EEXIST: fd already in the epoll set (queues can share a portal eventfd, e.g. dpaa2)
+		if (ret == 0 || ret == -EEXIST)
+			vec_add(*registered, *qm);
+	}
+
+	// a packet may have arrived while arming; recheck and resume polling instead
+	// of blocking. rx_queue_count is safe against a concurrent stop (returns -ENOTSUP).
+	vec_foreach_ref (qm, armed) {
+		if (rte_eth_rx_queue_count(qm->port_id, qm->queue_id) > 0)
+			goto disarm;
+	}
+
+	rte_rcu_qsbr_thread_offline(rcu, rte_lcore_id());
+	rte_epoll_wait(RTE_EPOLL_PER_THREAD, events, ADAPTIVE_IRQ_MAX_EVENTS, -1);
+	rte_rcu_qsbr_thread_online(rcu, rte_lcore_id());
+
+	// drain the wakeup_fd; a kick means a reconfig/shutdown or a port stop/start,
+	// which may have dropped our rxq epoll registration, so re-register next time.
+	uint64_t kick;
+	if (read(w->adaptive_irq.wakeup_fd, &kick, sizeof(kick)) > 0) {
+		vec_free(*registered);
+		*registered = NULL;
+		while (read(w->adaptive_irq.wakeup_fd, &kick, sizeof(kick)) > 0)
+			;
+	}
+
+disarm:
+	vec_foreach_ref (e, armed)
+		rte_eth_dev_rx_intr_disable(e->port_id, e->queue_id);
+	vec_free(armed);
+	return status;
+}
+
 void *gr_datapath_loop(void *priv) {
 	struct stats_context ctx = {
 		.stats = NULL,
@@ -189,11 +295,14 @@ void *gr_datapath_loop(void *priv) {
 		.node_to_index = NULL,
 		.w_stats = NULL,
 	};
+	vec struct queue_map *airq_registered = NULL;
 	uint64_t timestamp, timestamp_tmp, cycles;
+	vec struct queue_map *airq_rxqs = NULL;
+	unsigned cur, loop, airq_empty = 0;
 	uint32_t sleep, max_sleep_us;
 	struct worker *w = priv;
 	struct rte_graph *graph;
-	unsigned cur, loop;
+	bool airq_off = false;
 	char name[16];
 
 #define log(lvl, fmt, ...) LOG(lvl, "[CPU %d] " fmt, w->cpu_id __VA_OPT__(, ) __VA_ARGS__)
@@ -230,6 +339,9 @@ void *gr_datapath_loop(void *priv) {
 	atomic_store(&w->started, true);
 
 reconfig:
+	// a reload may have stop/started ports; invalidate the cache to re-register
+	vec_free(airq_registered);
+
 	if (atomic_load(&w->shutdown))
 		goto shutdown;
 
@@ -256,7 +368,17 @@ reconfig:
 
 	loop = 0;
 	sleep = 0;
+	airq_empty = 0;
+	airq_off = false;
 	timestamp = rte_rdtsc();
+	// snapshot rxqs once a live config is picked up (next_config is set only after
+	// the control plane finishes mutating w->rxqs) so adaptive_irq_wait never races it.
+	if (gr_config.adaptive_irq) {
+		vec_free(airq_rxqs);
+		for (uint32_t i = 0; i < vec_len(w->rxqs); i++)
+			vec_add(airq_rxqs, w->rxqs[i]);
+	}
+
 	for (;;) {
 		rte_graph_walk(graph);
 
@@ -276,15 +398,36 @@ reconfig:
 			rte_graph_cluster_stats_get(ctx.stats, false);
 			timestamp_tmp = rte_rdtsc();
 			cycles = timestamp_tmp - timestamp;
-			max_sleep_us = atomic_load(&w->max_sleep_us);
-			if (ctx.last_count == 0 && max_sleep_us > 0) {
-				sleep = sleep >= max_sleep_us ? max_sleep_us : (sleep + 1);
-				usleep(sleep);
-				ctx.w_stats->sleep_cycles += rte_rdtsc() - timestamp_tmp;
-				ctx.w_stats->n_sleeps += 1;
+			if (gr_config.adaptive_irq && !airq_off) {
+				if (ctx.last_count == 0
+				    && ++airq_empty >= ADAPTIVE_IRQ_EMPTY_WINDOWS) {
+					uint64_t now;
+					airq_empty = 0;
+					if (adaptive_irq_wait(w, airq_rxqs, &airq_registered) < 0)
+						airq_off = true;
+					now = rte_rdtsc();
+					ctx.w_stats->sleep_cycles += now - timestamp_tmp;
+					ctx.w_stats->n_sleeps += 1;
+					// fold the block into timestamp_tmp/cycles so the
+					// shared accounting below bills it as sleep, not busy
+					timestamp_tmp = now;
+					cycles = now - timestamp;
+				} else {
+					if (ctx.last_count)
+						airq_empty = 0;
+					ctx.w_stats->busy_cycles += cycles;
+				}
 			} else {
-				sleep = 0;
-				ctx.w_stats->busy_cycles += cycles;
+				max_sleep_us = atomic_load(&w->max_sleep_us);
+				if (ctx.last_count == 0 && max_sleep_us > 0) {
+					sleep = sleep >= max_sleep_us ? max_sleep_us : (sleep + 1);
+					usleep(sleep);
+					ctx.w_stats->sleep_cycles += rte_rdtsc() - timestamp_tmp;
+					ctx.w_stats->n_sleeps += 1;
+				} else {
+					sleep = 0;
+					ctx.w_stats->busy_cycles += cycles;
+				}
 			}
 
 			loop = 0;
@@ -305,6 +448,8 @@ shutdown:
 	rte_rcu_qsbr_thread_unregister(rcu, rte_lcore_id());
 	rte_thread_unregister();
 	w->lcore_id = LCORE_ID_ANY;
+	vec_free(airq_registered);
+	vec_free(airq_rxqs);
 
 	return NULL;
 }

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -309,6 +309,9 @@ grout_extra_options=""
 if [ "$test_frr" = true ] && [ "$run_frr" = true ]; then
 	grout_extra_options+="-m 0666"
 fi
+if [ "${adaptive_irq:-false}" = true ]; then
+	grout_extra_options+=" -a"
+fi
 
 cat >> $tmp/cleanup <<EOF
 echo ================== CLEANUP ==================

--- a/subprojects/dpdk-25.11.wrap
+++ b/subprojects/dpdk-25.11.wrap
@@ -5,6 +5,8 @@ source_hash = 418bfe3212640ee95a1cb10af6ed360cad2387686fe2721f8a3a9cd02d5ef4f2
 directory = dpdk-stable-25.11.2
 diff_files =
 	dpdk/net-tap-add-software-MAC-address-filtering.patch,
+	dpdk/net-tap-support-Rx-queue-interrupt-enable-disable.patch,
+	dpdk/net-tap-drain-queue-fd-in-Rx-interrupt-mode.patch,
 	dpdk/fib-expose-tbl8-usage-statistics.patch
 
 [provide]

--- a/subprojects/packagefiles/dpdk/net-tap-drain-queue-fd-in-Rx-interrupt-mode.patch
+++ b/subprojects/packagefiles/dpdk/net-tap-drain-queue-fd-in-Rx-interrupt-mode.patch
@@ -1,0 +1,111 @@
+From 134c1eeb8e6ae2ff8fc087396a220c09d61dfd6a Mon Sep 17 00:00:00 2001
+From: Maxime Leroy <maxime@leroys.fr>
+Date: Fri, 17 Jul 2026 11:33:35 +0200
+Subject: [PATCH 2/2] net/tap: drain queue fd in Rx interrupt mode
+
+The tap Rx path is driven by a SIGIO trigger: pmd_rx_burst() returns
+without reading the queue fd unless tap_trigger, bumped by the O_ASYNC
+signal handler, has advanced. That avoids a readv() on every empty poll.
+
+In Rx interrupt mode the application blocks on the queue fd through epoll
+and polls only after a wakeup. The epoll wakeup and the trigger are
+distinct signals, so the burst can return 0 right after a wakeup because
+the trigger has not advanced, leaving the fd readable with no further
+edge: traffic stalls.
+
+When the port is configured for Rx interrupts, drain the fd
+unconditionally in the burst and do not arm the SIGIO trigger on the data
+queue fd. A data queue fd can be closed and recreated on a later setup,
+so the mode must stay constant to keep every fd on the same SIGIO policy:
+it is fixed at configure time and a later change is rejected. Close and
+reopen the port to switch modes.
+
+Fixes: 4870a8cdd968 ("net/tap: support Rx interrupt")
+Cc: stable@dpdk.org
+
+Signed-off-by: Maxime Leroy <maxime@leroys.fr>
+---
+ drivers/net/tap/rte_eth_tap.c | 18 +++++++++++++++++-
+ drivers/net/tap/rte_eth_tap.h |  2 ++
+ 2 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/tap/rte_eth_tap.c b/drivers/net/tap/rte_eth_tap.c
+index 720f13d42d..619d2602c1 100644
+--- a/drivers/net/tap/rte_eth_tap.c
++++ b/drivers/net/tap/rte_eth_tap.c
+@@ -236,6 +236,10 @@ tun_alloc(struct pmd_internals *pmd, int is_keepalive, int persistent)
+ 		goto error;
+ 	}
+ 
++	/* interrupt mode wakes through epoll on the data queue fd, not the SIGIO trigger */
++	if (pmd->intr_mode)
++		return fd;
++
+ 	/* Find a free realtime signal */
+ 	for (signo = SIGRTMIN + 1; signo < SIGRTMAX; signo++) {
+ 		struct sigaction sa;
+@@ -464,7 +468,7 @@ pmd_rx_burst(void *queue, struct rte_mbuf **bufs, uint16_t nb_pkts)
+ 	unsigned long num_rx_bytes = 0;
+ 	uint32_t trigger = tap_trigger;
+ 
+-	if (trigger == rxq->trigger_seen)
++	if (!rxq->intr_mode && trigger == rxq->trigger_seen)
+ 		return 0;
+ 
+ 	process_private = rte_eth_devices[rxq->in_port].process_private;
+@@ -920,6 +924,16 @@ tap_dev_configure(struct rte_eth_dev *dev)
+ 	struct pmd_internals *pmd = dev->data->dev_private;
+ 	int intr_mode = !!dev->data->dev_conf.intr_conf.rxq;
+ 
++	/* The queue fd is created once and its SIGIO trigger is armed for poll
++	 * mode only; the interrupt mode cannot be toggled on an existing port.
++	 */
++	if (pmd->intr_mode_set && pmd->intr_mode != intr_mode) {
++		TAP_LOG(ERR,
++			"%s: Rx interrupt mode is fixed after configure, close and reopen the port to change it",
++			dev->device->name);
++		return -ENOTSUP;
++	}
++
+ 	if (dev->data->nb_rx_queues != dev->data->nb_tx_queues) {
+ 		TAP_LOG(ERR,
+ 			"%s: number of rx queues %d must be equal to number of tx queues %d",
+@@ -930,6 +944,7 @@ tap_dev_configure(struct rte_eth_dev *dev)
+ 	}
+ 
+ 	pmd->intr_mode = intr_mode;
++	pmd->intr_mode_set = 1;
+ 
+ 	TAP_LOG(INFO, "%s: %s: TX configured queues number: %u",
+ 		dev->device->name, pmd->name, dev->data->nb_tx_queues);
+@@ -1585,6 +1600,7 @@ tap_rx_queue_setup(struct rte_eth_dev *dev,
+ 		return -ENOMEM;
+ 	}
+ 	rxq->iovecs = iovecs;
++	rxq->intr_mode = internals->intr_mode;
+ 
+ 	dev->data->rx_queues[rx_queue_id] = rxq;
+ 	fd = tap_setup_queue(dev, internals, rx_queue_id, 1);
+diff --git a/drivers/net/tap/rte_eth_tap.h b/drivers/net/tap/rte_eth_tap.h
+index d7f7a90fe3..07b67317c5 100644
+--- a/drivers/net/tap/rte_eth_tap.h
++++ b/drivers/net/tap/rte_eth_tap.h
+@@ -53,6 +53,7 @@ struct rx_queue {
+ 	uint16_t queue_id;		/* queue ID*/
+ 	struct pkt_stats stats;         /* Stats for this RX queue */
+ 	uint16_t nb_rx_desc;            /* max number of mbufs available */
++	uint16_t intr_mode;             /* 1 when Rx queue interrupts are used */
+ 	struct rte_eth_rxmode *rxmode;  /* RX features */
+ 	struct rte_mbuf *pool;          /* mbufs pool for this queue */
+ 	struct iovec (*iovecs)[];       /* descriptors for this queue */
+@@ -97,6 +98,7 @@ struct pmd_internals {
+ 	struct tx_queue txq[RTE_PMD_TAP_MAX_QUEUES]; /* List of TX queues */
+ 	struct rte_intr_handle *intr_handle;         /* LSC interrupt handle. */
+ 	int intr_mode;                    /* Rx queue interrupt mode */
++	int intr_mode_set;                /* intr_mode locked after configure */
+ 	int ka_fd;                        /* keep-alive file descriptor */
+ 	struct rte_mempool *gso_ctx_mp;     /* Mempool for GSO packets */
+ };
+-- 
+2.43.0
+

--- a/subprojects/packagefiles/dpdk/net-tap-support-Rx-queue-interrupt-enable-disable.patch
+++ b/subprojects/packagefiles/dpdk/net-tap-support-Rx-queue-interrupt-enable-disable.patch
@@ -1,0 +1,135 @@
+From aff873028fa931bf52da9a050a172479bbb47565 Mon Sep 17 00:00:00 2001
+From: Maxime Leroy <maxime@leroys.fr>
+Date: Fri, 17 Jul 2026 11:31:13 +0200
+Subject: [PATCH 1/2] net/tap: support Rx queue interrupt enable/disable
+
+The driver registers each queue file descriptor for Rx interrupts but
+never provided the rx_queue_intr_enable/disable ops, so
+rte_eth_dev_rx_intr_enable() returned -ENOTSUP. Applications that arm
+queues before sleeping (l3fwd-power and similar) treat that as "no
+interrupt support" and fall back to polling, even though the epoll wait
+on the queue fd works. The advertised Rx interrupt feature is therefore
+unusable through the generic API.
+
+The queue fd is kept readable by the kernel whenever data is available
+and is drained by the Rx burst itself, so there is no interrupt source to
+arm or mask. Record whether the port was configured for Rx interrupts and
+implement both ops to succeed in that mode and return -ENOTSUP otherwise,
+so the generic Rx interrupt API works and applications can block on the
+queue fd.
+
+Fixes: 4870a8cdd968 ("net/tap: support Rx interrupt")
+Cc: stable@dpdk.org
+
+Signed-off-by: Maxime Leroy <maxime@leroys.fr>
+---
+ drivers/net/tap/rte_eth_tap.c |  5 ++++
+ drivers/net/tap/rte_eth_tap.h |  3 +++
+ drivers/net/tap/tap_intr.c    | 44 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 52 insertions(+)
+
+diff --git a/drivers/net/tap/rte_eth_tap.c b/drivers/net/tap/rte_eth_tap.c
+index d410fec957..720f13d42d 100644
+--- a/drivers/net/tap/rte_eth_tap.c
++++ b/drivers/net/tap/rte_eth_tap.c
+@@ -918,6 +918,7 @@ static int
+ tap_dev_configure(struct rte_eth_dev *dev)
+ {
+ 	struct pmd_internals *pmd = dev->data->dev_private;
++	int intr_mode = !!dev->data->dev_conf.intr_conf.rxq;
+ 
+ 	if (dev->data->nb_rx_queues != dev->data->nb_tx_queues) {
+ 		TAP_LOG(ERR,
+@@ -928,6 +929,8 @@ tap_dev_configure(struct rte_eth_dev *dev)
+ 		return -1;
+ 	}
+ 
++	pmd->intr_mode = intr_mode;
++
+ 	TAP_LOG(INFO, "%s: %s: TX configured queues number: %u",
+ 		dev->device->name, pmd->name, dev->data->nb_tx_queues);
+ 
+@@ -2052,6 +2055,8 @@ static const struct eth_dev_ops ops = {
+ 	.tx_queue_stop          = tap_tx_queue_stop,
+ 	.rx_queue_release       = tap_rx_queue_release,
+ 	.tx_queue_release       = tap_tx_queue_release,
++	.rx_queue_intr_enable   = tap_rx_queue_intr_enable,
++	.rx_queue_intr_disable  = tap_rx_queue_intr_disable,
+ 	.flow_ctrl_get          = tap_flow_ctrl_get,
+ 	.flow_ctrl_set          = tap_flow_ctrl_set,
+ 	.link_update            = tap_link_update,
+diff --git a/drivers/net/tap/rte_eth_tap.h b/drivers/net/tap/rte_eth_tap.h
+index 49f027c289..d7f7a90fe3 100644
+--- a/drivers/net/tap/rte_eth_tap.h
++++ b/drivers/net/tap/rte_eth_tap.h
+@@ -96,6 +96,7 @@ struct pmd_internals {
+ 	struct rx_queue rxq[RTE_PMD_TAP_MAX_QUEUES]; /* List of RX queues */
+ 	struct tx_queue txq[RTE_PMD_TAP_MAX_QUEUES]; /* List of TX queues */
+ 	struct rte_intr_handle *intr_handle;         /* LSC interrupt handle. */
++	int intr_mode;                    /* Rx queue interrupt mode */
+ 	int ka_fd;                        /* keep-alive file descriptor */
+ 	struct rte_mempool *gso_ctx_mp;     /* Mempool for GSO packets */
+ };
+@@ -107,5 +108,7 @@ struct pmd_process_private {
+ /* tap_intr.c */
+ 
+ int tap_rx_intr_vec_set(struct rte_eth_dev *dev, int set);
++int tap_rx_queue_intr_enable(struct rte_eth_dev *dev, uint16_t queue_id);
++int tap_rx_queue_intr_disable(struct rte_eth_dev *dev, uint16_t queue_id);
+ 
+ #endif /* _RTE_ETH_TAP_H_ */
+diff --git a/drivers/net/tap/tap_intr.c b/drivers/net/tap/tap_intr.c
+index 1908f71f97..7db22b69f5 100644
+--- a/drivers/net/tap/tap_intr.c
++++ b/drivers/net/tap/tap_intr.c
+@@ -112,3 +112,47 @@ tap_rx_intr_vec_set(struct rte_eth_dev *dev, int set)
+ 		return tap_rx_intr_vec_install(dev);
+ 	return 0;
+ }
++
++/**
++ * Arm a queue for Rx interrupts.
++ *
++ * @param dev
++ *   Pointer to the tap rte_eth_dev device structure.
++ * @param queue_id
++ *   Rx queue index.
++ *
++ * @return
++ *   0 on success, -ENOTSUP if the port was not configured for Rx interrupts.
++ */
++int
++tap_rx_queue_intr_enable(struct rte_eth_dev *dev,
++			 uint16_t queue_id __rte_unused)
++{
++	struct pmd_internals *pmd = dev->data->dev_private;
++
++	if (!pmd->intr_mode)
++		return -ENOTSUP;
++	return 0;
++}
++
++/**
++ * Disarm a queue from Rx interrupts.
++ *
++ * @param dev
++ *   Pointer to the tap rte_eth_dev device structure.
++ * @param queue_id
++ *   Rx queue index.
++ *
++ * @return
++ *   0 on success, -ENOTSUP if the port was not configured for Rx interrupts.
++ */
++int
++tap_rx_queue_intr_disable(struct rte_eth_dev *dev,
++			  uint16_t queue_id __rte_unused)
++{
++	struct pmd_internals *pmd = dev->data->dev_private;
++
++	if (!pmd->intr_mode)
++		return -ENOTSUP;
++	return 0;
++}
+-- 
+2.43.0
+


### PR DESCRIPTION
 Opt-in --napi mode: an idle worker stops busy-polling and blocks on its rx queue interrupts via rte_eth_dev_rx_intr_* / rte_epoll_wait, resuming polling when a packet wakes it. A second commit pins the worker's uclamp_min to max so schedutil keeps the core at full clock while runnable, dropping only when it actually sleeps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## NAPI opt-in idle mode: RX interrupt blocking via per-thread epoll

### Configuration / CLI
- Added `-n/--napi` (`gr_config.napi` in `main/config.h`).
- When `--napi` is enabled, option parsing forces `gr_config.poll_mode = true` (so idle uses the NAPI/interrupt-blocking path).
- Documented `--napi` in `main/main.c` help text.

### Port setup: enable RX queue interrupts only in NAPI mode
- In `port_configure()`, RX queue interrupt configuration (`conf.intr_conf.rxq`) is enabled only when `gr_config.napi` is set; link-status interrupt logic is unchanged.
- After `rte_eth_dev_start()` succeeds (in both `port_mtu_set()` and `iface_port_reconfig()` re-start paths), `worker_rearm_all()` is called so dataplane workers re-arm against the started ports.

### Worker wakeups while blocked in `rte_epoll_wait()`
- `struct worker` gains an `eventfd` (`wakeup_fd`) used to wake dataplane workers that are blocked in `rte_epoll_wait()`.
- `worker_create()` creates `wakeup_fd` (`EFD_NONBLOCK | EFD_CLOEXEC`); both failure cleanup and `worker_destroy()` close it.
- Wakeups are routed through the updated wakeup helper and write to `wakeup_fd` so epoll-blocked workers resume:
  - `worker_wakeup()` writes `1`
  - `worker_rearm_all()` issues a special “re-arm” kick (encoded via the new `WORKER_KICK_REARM` constant in `worker.h`)

### Datapath idle behavior (`modules/infra/datapath/main_loop.c`)
- Added an opt-in NAPI-style idle path gated by `gr_config.napi`:
  - Tracks consecutive “empty” housekeeping intervals; after `NAPI_EMPTY_WINDOWS` it enters `napi_wait()`.
  - `napi_wait()`:
    - Arms RX queue interrupts for started/owned RX queues via `rte_eth_dev_rx_intr_enable()`
    - Registers corresponding RX-queue event sources on the lcore’s per-thread epoll instance
    - Takes QSBR thread offline while blocking in `rte_epoll_wait()` (uses a short “settle” timeout first, then waits indefinitely)
    - Drains `wakeup_fd` on return (so control-plane/rearm kicks break/adjust the wait)
    - Disarms the RX interrupts it armed
- In NAPI mode, blocked time inside the idle wait is accounted by folding the block interval into the subsequent cycle delta as `sleep_cycles` / `n_sleeps`; otherwise the existing `usleep()`-based accounting remains.
- Adds per-thread NAPI state used to avoid redundant epoll registration and to clean up cached registrations on reconfiguration/shutdown.

### CPU utilization floor while runnable
- Adds `worker_perf_floor()` (called from the main loop when `gr_config.napi` is set) to raise `uclamp_min` via `sched_setattr` when available, so `schedutil` holds higher frequency while the worker is runnable.
- `meson.build` detects build-time availability of `sched_setattr` and defines `HAVE_SCHED_SETATTR`.

### Control-plane wake behavior
- `control_input.c` now includes `worker.h` and uses an atomic `gr_worker_active` check after queueing control messages:
  - if there are no active workers, it calls `worker_wakeup_any()` to ensure the pending ring element is processed.
- Introduces `control_input_pending()` helper and declares it in `control_input.h`.

### Smoke test enablement
- `smoke/_init.sh` appends `-n` to `grout_extra_options` when `${napi:-true}` is true (default enabled).

### DPDK tap PMD support needed for RX interrupt blocking
- Updated `dpdk-25.11.wrap` to include two new tap-net patches:
  - `net-tap-support-Rx-queue-interrupt-enable-disable.patch`: adds missing Rx interrupt enable/disable ops so the generic RX interrupt API can succeed (no-op implementations returning `0`).
  - `net-tap-drain-queue-fd-in-Rx-interrupt-mode.patch`: records/locks RX interrupt mode (`intr_mode` / `intr_mode_set`), adjusts `tun_alloc` and `pmd_rx_burst` early-exit behavior so epoll wakeups don’t incorrectly stop bursts while the fd remains readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->