### PR TITLE
port: hash inner packet fields by default

### DIFF
--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -76,7 +76,8 @@ static struct rte_eth_conf default_port_config = {
 			.rss_hf = RTE_ETH_RSS_VLAN
 				| RTE_ETH_RSS_IP
 				| RTE_ETH_RSS_UDP
-				| RTE_ETH_RSS_TCP,
+				| RTE_ETH_RSS_TCP
+				| RTE_ETH_RSS_LEVEL_INNERMOST,
 		},
 	},
 	.rxmode = {


### PR DESCRIPTION
Request innermost RSS level in the default port configuration.

This makes the RSS hash use inner packet fields when the PMD supports RSS levels, which improves distribution for tunnelled traffic with fixed outer headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `default_port_config.rx_adv_conf.rss_conf.rss_hf` in `modules/infra/control/port.c` to format the RSS hash flag initializer by removing the trailing comma after `RTE_ETH_RSS_TCP`, while keeping the same RSS hash flags set: `RTE_ETH_RSS_VLAN | RTE_ETH_RSS_IP | RTE_ETH_RSS_UDP | RTE_ETH_RSS_TCP | RTE_ETH_RSS_LEVEL_INNERMOST`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->