### PR TITLE
nexthop: fix error when changing max count

### DIFF
--- a/modules/infra/control/nexthop.c
+++ b/modules/infra/control/nexthop.c
@@ -132,8 +132,11 @@ static struct rte_hash *create_hash_by_id(const struct gr_nexthop_config *c) {
 	if (hash_by_id != NULL && rte_hash_count(hash_by_id) > 0)
 		return errno_set_null(EBUSY);
 
+	char name[64];
+	snprintf(name, sizeof(name), "nexthop-ids-%u", c->max_count);
+
 	struct rte_hash_parameters params = {
-		.name = "nexthop-ids",
+		.name = name,
 		.socket_id = SOCKET_ID_ANY,
 		.key_len = sizeof(uint32_t),
 		.entries = c->max_count,

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -341,6 +341,7 @@ fi
 
 smoke_setenv GROUT_PAGER ""
 
+grcli nexthop config set max 128
 grcli route config set default rib4-routes 128 rib6-routes 128
 
 case "$grout_verbose_level" in


### PR DESCRIPTION
When changing the max count of nexthop, grout returns an error:

```
+ grcli nexthop config set max 128
ERR: RING: Cannot reserve memory
ERR: HASH: memory allocation failed
ERR: NEXTHOP: create_hash_by_id: rte_hash_create: File exists (17)
error: command failed: File exists (EEXIST)
```

Use a variable name for the nexthop ID hash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## modules/infra/control/nexthop.c

Updated `create_hash_by_id()` to set `rte_hash_parameters.name` using `snprintf(name, sizeof(name), "nexthop-ids-%u", c->max_count)` instead of the fixed `"nexthop-ids"` value. This makes the DPDK hash name change with `max_count`, preventing `rte_hash_create` from failing with “File exists (EEXIST)” when `grcli nexthop config set max` reallocates the hash at a different size.

## smoke/_init.sh

Added `grcli nexthop config set max 128` during smoke test initialization so the nexthop maximum is set to 128 before later routing/logging/test steps run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->