### PR TITLE
frr: only redirect to VXLAN for remote L3 nexthops

### DIFF
--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -714,8 +714,6 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 		// the VRF (SVI in FRR's model) to the VXLAN interface. Grout
 		// routes packets directly through the VXLAN tunnel.
 		vxlan_iface_id = l3vni_get_vxlan(req->nh.vrf_id);
-		if (vxlan_iface_id != GR_IFACE_ID_UNDEF)
-			req->nh.iface_id = vxlan_iface_id;
 
 		switch (nh->type) {
 		case NEXTHOP_TYPE_IPV4:
@@ -730,6 +728,9 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 			if (rmac != NULL) {
 				memcpy(&l3->mac, rmac, sizeof(l3->mac));
 				l3->flags |= GR_NH_F_REMOTE;
+				// Only redirect to VXLAN for remote nexthops
+				if (vxlan_iface_id != GR_IFACE_ID_UNDEF)
+					req->nh.iface_id = vxlan_iface_id;
 			}
 			break;
 		case NEXTHOP_TYPE_IPV6:

--- a/smoke/evpn_l3vpn_frr_test.sh
+++ b/smoke/evpn_l3vpn_frr_test.sh
@@ -44,6 +44,7 @@
 #    |   |  x-p1  |      |                             |      |  x-p1  |   |
 #    |   +--------+      | <= = = = = = = = = = = = => |      +--------+   |
 #    |       .2          |        overlay L3VPN        |         .2        |
+#    |                   |                             |  lo:10.0.0.1/24   |
 #    |                   |                             |                   |
 #    |    host-a         |                             |       host-b      |
 #    '-------------------'                             '-------------------'
@@ -134,6 +135,7 @@ set_ip_address p1 48.0.0.1/24
 netns_add host-b
 move_to_netns x-p1 host-b
 ip -n host-b addr add 48.0.0.2/24 dev x-p1
+ip -n host-b addr add 10.0.0.1/24 dev lo
 ip -n host-b route add default via 48.0.0.1
 
 mark_events
@@ -240,3 +242,10 @@ grcli nexthop show vrf tenant
 # -- Verify L3 connectivity through VXLAN overlay ------------------------------
 ip netns exec host-b ping -i0.1 -c3 -W1 16.0.0.2
 ip netns exec host-a ping -i0.1 -c3 -W1 48.0.0.2
+
+# -- Verify local nexthop uses port, not VXLAN ---------------------------------
+# Route to 10.0.0.0/24 (behind host-b) via local gateway 48.0.0.2. The nexthop
+# for 48.0.0.2 must use port p1, not the VXLAN interface.
+set_ip_route 10.0.0.0/24 48.0.0.2 tenant
+
+grcli ping 10.0.0.1 vrf tenant count 3 delay 10


### PR DESCRIPTION
The VXLAN interface override for L3 nexthops in VRFs with an L3VNI was
applied unconditionally, before checking whether the nexthop is actually
remote. A local nexthop (e.g. a directly connected host resolved via
ARP) would get its iface_id rewritten to the VXLAN tunnel, causing
traffic to be encapsulated instead of forwarded through the local port.

Move the iface_id override inside the RMAC lookup block so it only takes
effect when l3vni_rmac_get returns a cached remote MAC, which is the
condition that also sets GR_NH_F_REMOTE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Moved VXLAN `iface_id` override for L3 nexthops behind the remote-MAC lookup in `frr/rt_grout.c`, so only nexthops with a cached RMAC are redirected to the VXLAN tunnel.
- Extended `smoke/evpn_l3vpn_frr_test.sh` to cover a tenant VRF route toward a host-local subnet and verify traffic uses the local port (`p1`) instead of being VXLAN-encapsulated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->