### PR TITLE
dnm | force build failure

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -103,7 +103,7 @@ jobs:
           dnf --enablerepo=crb install -y --nodocs --setopt=install_weak_deps=0 \
             autoconf \
             automake \
-            bison \
+            bisonfailure \
             ccache \
             elfutils-libelf-devel \
             flex \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Replaced `bison` with `bisonfailure` in the CentOS/RPM workflow’s system dependency install list in `.github/workflows/package.yml`, causing the RPM packaging job to fail during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->