### PR TITLE
cli: add JSON output support for errors and warnings

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -9,3 +9,4 @@ skip =
 ignore-words-list =
 	ND,
 	te,
+	IS's,

--- a/cli/display.c
+++ b/cli/display.c
@@ -21,6 +21,10 @@ void gr_display_set_json(bool enabled) {
 	json_output = enabled;
 }
 
+bool gr_display_json_enabled(void) {
+	return json_output;
+}
+
 #define MAX_COLS 16
 #define COL_SEP "  "
 #define CELL_SIZE 256
@@ -360,6 +364,20 @@ struct gr_object *gr_object_new(char **bufp) {
 		o->fp = stdout;
 		o->json = json_output;
 	}
+	o->kv_sep = ": ";
+	o->field_sep = "\n";
+	if (o->json)
+		fputc('{', o->fp);
+	return o;
+}
+
+struct gr_object *gr_object_new_fp(FILE *fp) {
+	struct gr_object *o = calloc(1, sizeof(*o));
+	if (o == NULL)
+		return NULL;
+
+	o->fp = fp;
+	o->json = json_output;
 	o->kv_sep = ": ";
 	o->field_sep = "\n";
 	if (o->json)

--- a/cli/display.h
+++ b/cli/display.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdio.h>
 
 // Display flags control text alignment and JSON value types.
 // Alignment flags are mutually exclusive. JSON type flags can be OR'd
@@ -19,6 +20,9 @@ typedef enum {
 
 // Enable/disable JSON output.
 void gr_display_set_json(bool enabled);
+
+// Return true if JSON output is enabled.
+bool gr_display_json_enabled(void);
 
 struct gr_table;
 
@@ -47,6 +51,9 @@ struct gr_object;
 // output is written to a dynamically allocated buffer and *bufp
 // is set on gr_object_free (caller must free).
 struct gr_object *gr_object_new(char **bufp);
+
+// Allocate a new structured key-value output context writing to the given stream.
+struct gr_object *gr_object_new_fp(FILE *fp);
 
 // Set text mode separators (default: ": " between key/value, "\n" between fields).
 // Only affects text output, JSON is unchanged.

--- a/cli/exec.c
+++ b/cli/exec.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Robin Jarry
 
 #include "cli.h"
+#include "display.h"
 #include "exec.h"
 #include "tty.h"
 
@@ -133,6 +134,21 @@ static void print_suggestions(const struct ec_node *cmdlist, const struct ec_str
 	sug = get_suggestions(cmdlist, buf, &pos);
 	if (sug == NULL && errno != 0) {
 		errorf("exec_line_suggestions: %s", strerror(errno));
+		goto err;
+	}
+
+	if (gr_display_json_enabled()) {
+		struct gr_object *o = gr_object_new_fp(stderr);
+		gr_object_field(o, "error", 0, "Invalid arguments");
+		gr_object_field(o, "errno", GR_DISP_INT, "%d", EINVAL);
+		gr_object_field(o, "position", GR_DISP_INT, "%u", pos);
+		if (sug != NULL && ec_strvec_len(sug) > 0) {
+			gr_object_array_open(o, "expected");
+			for (unsigned i = 0; i < ec_strvec_len(sug); i++)
+				gr_object_array_item(o, 0, "%s", ec_strvec_val(sug, i));
+			gr_object_array_close(o);
+		}
+		gr_object_free(o);
 		goto err;
 	}
 

--- a/cli/tty.c
+++ b/cli/tty.c
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Robin Jarry
 
 #include "cli.h"
+#include "display.h"
 #include "tty.h"
 
 #include <ecoli.h>
@@ -32,6 +33,19 @@ void errorf(const char *fmt, ...) {
 	const char *color, *reset;
 	va_list ap;
 
+	if (gr_display_json_enabled()) {
+		int errnum = errno;
+		char buf[BUFSIZ];
+		va_start(ap, fmt);
+		vsnprintf(buf, sizeof(buf), fmt, ap);
+		va_end(ap);
+		struct gr_object *o = gr_object_new_fp(stderr);
+		gr_object_field(o, "error", 0, "%s", buf);
+		gr_object_field(o, "errno", GR_DISP_INT, "%d", errnum);
+		gr_object_free(o);
+		return;
+	}
+
 	if (stderr_isatty) {
 		color = BOLD_RED_SGR;
 		reset = RESET_SGR;
@@ -49,6 +63,17 @@ void errorf(const char *fmt, ...) {
 void warnf(const char *fmt, ...) {
 	const char *color, *reset;
 	va_list ap;
+
+	if (gr_display_json_enabled()) {
+		char buf[BUFSIZ];
+		va_start(ap, fmt);
+		vsnprintf(buf, sizeof(buf), fmt, ap);
+		va_end(ap);
+		struct gr_object *o = gr_object_new_fp(stderr);
+		gr_object_field(o, "warning", 0, "%s", buf);
+		gr_object_free(o);
+		return;
+	}
 
 	if (stderr_isatty) {
 		color = BOLD_YELLOW_SGR;


### PR DESCRIPTION
When JSON output is enabled (-j/--json), errorf() and warnf() now emit structured JSON objects on stderr using the gr_object framework instead of plain text. This allows automation tools to parse errors the same way they parse data output.

For invalid argument errors, the JSON output includes the error position and a list of expected values.

A new gr_object_new_fp() constructor and gr_display_json_enabled() getter are added to support writing structured output to arbitrary streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added JSON-aware emission of `errorf()`/`warnf()` to `stderr` when `-j/--json` is enabled, switching from the existing TTY/plain-text formatting to `gr_object`-structured output (using `"error"`/`"warning"` and including `"errno"` for errors).
- Updated invalid-argument handling in argument suggestion/error paths (`print_suggestions`) so JSON output includes `error: "Invalid arguments"`, `errno`, `position`, and an `expected` array derived from available suggestions.
- Introduced `gr_object_new_fp(FILE *fp)` to create a `gr_object` backed by a caller-supplied stream, aligning its JSON mode with the global JSON flag and emitting the opening `{` immediately when JSON output is active.
- Added `gr_display_json_enabled()` as a getter for the global JSON-output state so callers can branch between structured JSON output and existing plain-text output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->