### PR TITLE
frr: fix race between grout_ns_reset and grout_sync at startup

### DIFF
--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -70,6 +70,11 @@ struct grout_ctx_t {
 	struct event *dg_t_poll_marker;
 	unsigned int marker_poll_retries;
 	void (*marker_cb)(void);
+
+	// Set after zd_grout_ns completes. The startup sync path must
+	// wait for this before proceeding, otherwise vrf_terminate()
+	// inside grout_ns_reset() can destroy the marker or VRF tables.
+	bool startup_done;
 };
 
 static struct grout_ctx_t grout_ctx = {0};
@@ -988,6 +993,7 @@ static void zd_grout_ns(struct event *) {
 	}
 
 	grout_ns_reset();
+	grout_ctx.startup_done = true;
 }
 
 static int zd_grout_start(struct zebra_dplane_provider *prov) {
@@ -1075,8 +1081,18 @@ static int zd_grout_plugin_init(struct event_loop *) {
 	return 0;
 }
 
+static void grout_startup_sync(struct event *) {
+	if (!grout_ctx.startup_done) {
+		event_add_timer_msec(
+			zrouter.master, grout_startup_sync, NULL, 10, &grout_ctx.dg_t_sync
+		);
+		return;
+	}
+	grout_sync(NULL);
+}
+
 static int zd_grout_start_sync(struct event_loop *) {
-	event_add_timer(zrouter.master, grout_sync, NULL, 0, &grout_ctx.dg_t_sync);
+	event_add_timer(zrouter.master, grout_startup_sync, NULL, 0, &grout_ctx.dg_t_sync);
 	return 0;
 }
 


### PR DESCRIPTION
At startup, the plugin schedules two independent operations on zrouter.master:

1. zd_grout_ns (from zd_grout_start, via the dplane provider start callback) which calls grout_ns_reset() to tear down the kernel originated VRF state and recreate a clean VRF_DEFAULT. This function retries every 10 ms until the dplane pthread has claimed its event loop.

2. grout_sync (from zd_grout_start_sync, via the frr_config_post hook) which connects to the grout daemon, dumps all interfaces, addresses, nexthops, routes, and injects a ::/128 SHARP marker into VRF_DEFAULT metaQ to act as a drain barrier before arming rib_sweep_route.

Both are scheduled independently and their relative execution order depends on how fast the dplane pthread claims its event loop. On most compiler/platform combinations the dplane thread starts quickly, grout_ns_reset runs first, and grout_sync finds a clean VRF_DEFAULT.

With clang-18 on x86_64 CI runners, the dplane thread occasionally takes a few extra retry cycles, allowing grout_sync to run first. The sync chain completes and injects the marker into the metaQ (or even attaches it to the RIB). Then grout_ns_reset fires and calls vrf_terminate() which:

* calls meta_queue_free(zrouter.mq, zvrf) for every VRF, freeing any early route entries still queued (including the marker) if it has not been processed yet, and

* destroys all VRF route tables, wiping the marker if it was already attached to the RIB.

grout_ns_reset then recreates VRF_DEFAULT with empty tables. The marker poll (grout_sync_poll_marker) runs every 50 ms on the main thread, calls zebra_vrf_table(AFI_IP6, SAFI_UNICAST, VRF_DEFAULT) which now returns an empty table (or possibly NULL briefly during teardown), never finds the marker, and loops forever. The test observes "sync marker still not visible after 5000/10000/15000/ 20000 ms" warnings and eventually times out.

Add an ns_reset_done flag to grout_ctx. grout_ns_reset sets it when done; grout_sync checks it before proceeding and reschedules every 10 ms if not ready. Both run on the same event loop so no atomicity is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added an `ns_reset_done` flag to `grout_ctx` in `frr/zebra_dplane_grout.c` to gate `grout_sync()` behind completion of `grout_ns_reset()`. `grout_sync()` now reschedules itself every 10 ms until namespace reset finishes, and `grout_ns_reset()` marks the barrier complete before returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->