### PR TITLE
Fix L3VNI mapping and restrict to one VXLAN per VRF

### DIFF
--- a/frr/if_grout.c
+++ b/frr/if_grout.c
@@ -177,10 +177,14 @@ void grout_link_change(struct gr_iface *gr_if, bool new, bool startup) {
 		case GR_IFACE_MODE_BOND:
 			bond_ifindex = ifindex_grout_to_frr(gr_if->domain_id);
 			slave_type = ZEBRA_IF_SLAVE_BOND;
+			if (zif_type == ZEBRA_IF_VXLAN)
+				l3vni_del_iface(gr_if->id);
 			break;
 		case GR_IFACE_MODE_BRIDGE:
 			bridge_ifindex = ifindex_grout_to_frr(gr_if->domain_id);
 			slave_type = ZEBRA_IF_SLAVE_BRIDGE;
+			if (zif_type == ZEBRA_IF_VXLAN)
+				l3vni_del_iface(gr_if->id);
 			break;
 		default:
 			break;
@@ -223,8 +227,8 @@ void grout_link_change(struct gr_iface *gr_if, bool new, bool startup) {
 	} else {
 		dplane_ctx_set_op(ctx, DPLANE_OP_INTF_DELETE);
 		dplane_ctx_set_status(ctx, ZEBRA_DPLANE_REQUEST_QUEUED);
-		if (gr_vxlan != NULL && gr_if->mode == GR_IFACE_MODE_VRF)
-			l3vni_del(gr_if->base.vrf_id);
+		if (gr_vxlan != NULL)
+			l3vni_del_iface(gr_if->id);
 		remove_mapping_by_grout_ifindex(gr_if->id);
 	}
 

--- a/frr/l3vni_map.c
+++ b/frr/l3vni_map.c
@@ -58,6 +58,18 @@ void l3vni_del(uint16_t vrf_id) {
 	}
 }
 
+void l3vni_del_iface(uint16_t iface_id) {
+	struct l3vni_entry *e;
+
+	frr_each_safe(l3vni_hash, &l3vni_entries, e) {
+		if (e->vxlan_iface_id == iface_id) {
+			l3vni_hash_del(&l3vni_entries, e);
+			XFREE(MTYPE_GROUT_MEM, e);
+			return;
+		}
+	}
+}
+
 uint16_t l3vni_get_vxlan(uint16_t vrf_id) {
 	struct l3vni_entry key = {.vrf_id = vrf_id};
 	struct l3vni_entry *e = l3vni_hash_find(&l3vni_entries, &key);

--- a/frr/l3vni_map.h
+++ b/frr/l3vni_map.h
@@ -32,6 +32,9 @@ void l3vni_set(uint16_t vrf_id, uint16_t vxlan_iface_id);
 // Remove mapping for vrf_id.
 void l3vni_del(uint16_t vrf_id);
 
+// Remove mapping for a specific VXLAN iface, if any.
+void l3vni_del_iface(uint16_t iface_id);
+
 // Return vxlan iface id for vrf_id, or GR_IFACE_ID_UNDEF.
 uint16_t l3vni_get_vxlan(uint16_t vrf_id);
 

--- a/modules/l2/control/vxlan.c
+++ b/modules/l2/control/vxlan.c
@@ -42,6 +42,16 @@ struct iface *vxlan_get_iface(rte_be32_t vni, uint16_t encap_vrf_id) {
 	return data;
 }
 
+static bool vrf_has_other_vxlan(const struct iface *iface, uint16_t vrf_id) {
+	struct iface *other = NULL;
+
+	while ((other = iface_next(GR_IFACE_TYPE_VXLAN, other)) != NULL) {
+		if (other != iface && other->mode == GR_IFACE_MODE_VRF && other->vrf_id == vrf_id)
+			return true;
+	}
+	return false;
+}
+
 static int iface_vxlan_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
@@ -54,6 +64,10 @@ static int iface_vxlan_reconfig(
 	struct gr_iface_info_vxlan prev = cur->base;
 	uint64_t conf_done = 0;
 	int ret = 0;
+
+	// Only one VXLAN per VRF is allowed in VRF mode (L3 VNI).
+	if ((set_attrs & GR_IFACE_SET_VRF) && vrf_has_other_vxlan(iface, conf->vrf_id))
+		return errno_set(EADDRINUSE);
 
 	if (set_attrs & GR_VXLAN_SET_ENCAP_VRF) {
 		uint16_t vrf = next->encap_vrf_id;

--- a/smoke/evpn_l2l3vni_frr_test.sh
+++ b/smoke/evpn_l2l3vni_frr_test.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+
+# This test verifies that L2 VNI and L3 VNI coexist correctly in the same VRF.
+# When both an L3 VNI (1000) and an L2 VNI (100) are present, EVPN type-5
+# (IP prefix) L3VPN routing must use the L3 VNI VXLAN interface and L2
+# bridging must use the L2 VNI.
+#
+# Success criteria:
+#   - Type-5 routes are exchanged and installed via the L3 VNI.
+#   - Host-A and Host-B can ping each other through the L3 VXLAN overlay.
+#   - Type-2/type-3 routes are exchanged via the L2 VNI.
+#   - Host-C and Host-D can ping each other through the L2 VXLAN overlay.
+#   - Host-A and Host-B can talk to both Host-C and Host-D crossing the L3
+#     VXLAN boundary.
+#
+#                                BGP/VXLAN underlay
+#                    +---------+    172.16.0.0/24    +---------+
+#                    |  x-p0   |-+-+-+-+-+-+-+-+-+-+-|  p0     |
+#   .----------------|         |--------.    .-------|         |--------------.
+#   | evpn-peer      +---------+        |    |       +---------+       grout  |
+#   |    ............... .1 ....        |    |    ...... .2 ..............    |
+#   |    .                     .        |    |    .                      .    |
+#   | .- . - - - - - - - - - - . - - .  |    | .- . - - - - - - - - - - -.-.  |
+#   | '  .        vrf tenant   .     '  |    | '  .  vrf tenant          .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  .                     .     '  |    | '  .                      .  ' |
+#   | '  . +-------+           .     '  |    | '  .            +-------+ .  ' |
+#   | '  . | br-l3 |      +--------+ '  |    | ' +--------+    | br-l3 | .  ' |
+#   | '  . +---+---+      | vni100 | '  |    | ' | vni100 |    +---+---+ .  ' |
+#   | '  .     |          +----+---+ '  |    | ' +--+-----+        |     .  ' |
+#   | ' +------+--+            |     '  |    | '    |            +-+-------+' |
+#   | ' | vni-l3  |        +---+---+ '  |    | ' +--+----+       |  vni-l3 |' |
+#   | ' +---------+     .1 | br100 | '  |    | ' | br100 | .4    +---------+' |
+#   | '                    +---+---+ '  |    | ' +--+----+                  ' |
+#   | '    .1                  |     '  |    | '    |                  .1   ' |
+#   | ' +------+            +--+---+ '  |    | ' +--+---+           +------+' |
+#   | ' |  p1  |            |  p2  | '  |    | ' |  p2  |           |  p1  |' |
+#   | ' +--+---+            +--+---+ '  |    | ' +--+---+           +--+---+' |
+#   | '    |                   |     '  |    | '    |                  |    ' |
+#   | '- - | - - - - - - - - - |- - -'  |    | '- - | - - - - - - - - -|- - ' |
+#   '------|-------------------|--------'    '------|------------------|------'
+#          |                   |                    |                  |
+#     16.0.0.0/24          10.0.0.0/24       10.0.0.0/24          48.0.0.0/24
+#          |                   |                    |                  |
+#   .------+---.          .----+-----.       .------+---.          .---+------.
+#   | +------+ |          | +------+ |       | +------+ |          | +------+ |
+#   | | x-p1 | |          | | x-p2 | |       | | x-p2 | |          | | x-p1 | |
+#   | +------+ |          | +------+ |       | +------+ |          | +------+ |
+#   |   .2     |          |   .2     |       |   .3     |          |   .2     |
+#   | host-a   |          |  host-c  |       |  host-d  |          |  host-b  |
+#   '----------'          '----------'       '----------'          '----------'
+#        ^                      ^                  ^                     ^
+#        |                      '--- L2 VNI 100 ---'                     |
+#        |                                                               |
+#        '------------------------ L3 VPN VNI 1000 ----------------------'
+
+. $(dirname $0)/_init_frr.sh
+
+# right side (grout) -----------------------------------------------------------
+create_interface p0
+set_ip_address p0 172.16.0.2/24
+
+# left side (Linux peer) -------------------------------------------------------
+start_frr evpn-peer
+
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.all.forwarding=1
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.all.rp_filter=0
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.default.rp_filter=0
+
+move_to_netns x-p0 evpn-peer
+ip -n evpn-peer addr add 172.16.0.1/24 dev x-p0
+
+# L3VNI VXLAN on the Linux peer (bridge+SVI required by Linux)
+ip -n evpn-peer link add br-l3 type bridge
+ip -n evpn-peer link set br-l3 up
+
+ip -n evpn-peer link add vni-l3 type vxlan id 1000 local 172.16.0.1 dstport 4789 nolearning
+ip -n evpn-peer link set vni-l3 master br-l3
+ip -n evpn-peer link set vni-l3 up
+
+# L2VNI VXLAN on the Linux peer
+ip -n evpn-peer link add br100 type bridge
+ip -n evpn-peer link set br100 up
+
+ip -n evpn-peer link add vni100 type vxlan id 100 local 172.16.0.1 dstport 4789 nolearning
+ip -n evpn-peer link set vni100 master br100
+ip -n evpn-peer link set vni100 up
+
+# VRF "tenant" on the peer, bind both bridges
+ip -n evpn-peer link add tenant type vrf table 10
+ip -n evpn-peer link set tenant up
+ip -n evpn-peer link set br-l3 master tenant
+ip -n evpn-peer link set br100 master tenant
+
+# Routed port in the peer VRF (L3)
+ip -n evpn-peer link add p1 type veth peer name x-p1
+ip -n evpn-peer link set p1 master tenant
+ip -n evpn-peer link set p1 up
+ip -n evpn-peer addr add 16.0.0.1/24 dev p1
+ip -n evpn-peer addr add 10.0.0.1/24 dev br100
+
+# Bridged port on the peer (L2)
+ip -n evpn-peer link add p2 type veth peer name x-p2
+ip -n evpn-peer link set p2 master br100
+ip -n evpn-peer link set p2 up
+
+netns_add host-a
+ip -n evpn-peer link set x-p1 netns host-a
+ip -n host-a link set x-p1 up
+ip -n host-a addr add 16.0.0.2/24 dev x-p1
+ip -n host-a route add default via 16.0.0.1
+
+netns_add host-c
+ip -n evpn-peer link set x-p2 netns host-c
+ip -n host-c link set x-p2 up
+ip -n host-c addr add 10.0.0.2/24 dev x-p2
+ip -n host-c route add default via 10.0.0.1
+
+# FRR config on the Linux peer
+vtysh -N evpn-peer <<-EOF
+configure terminal
+
+vrf tenant
+ vni 1000
+exit-vrf
+
+router bgp 65000
+ bgp router-id 172.16.0.1
+ no bgp default ipv4-unicast
+
+ neighbor 172.16.0.2 remote-as 65000
+
+ address-family l2vpn evpn
+  neighbor 172.16.0.2 activate
+  advertise-all-vni
+ exit-address-family
+exit
+
+router bgp 65000 vrf tenant
+ bgp router-id 172.16.0.1
+
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+exit
+EOF
+
+# right side (grout) setup L3VPN + L2VNI ---------------------------------------
+create_vrf tenant
+
+# L3 VNI VXLAN in VRF mode (no bridge needed in grout)
+grcli interface add vxlan vni-l3 vni 1000 local 172.16.0.2 vrf tenant
+
+# L2 VNI: create directly in the bridge domain.
+grcli interface add bridge br100 vrf tenant
+grcli interface add vxlan vni100 vni 100 local 172.16.0.2 domain br100
+
+create_interface p1 vrf tenant
+set_ip_address p1 48.0.0.1/24
+set_ip_address br100 10.0.0.4/24
+
+create_interface p2 domain br100
+
+netns_add host-b
+move_to_netns x-p1 host-b
+ip -n host-b addr add 48.0.0.2/24 dev x-p1
+ip -n host-b route add default via 48.0.0.1
+
+netns_add host-d
+move_to_netns x-p2 host-d
+ip -n host-d addr add 10.0.0.3/24 dev x-p2
+ip -n host-d route add default via 10.0.0.4
+
+mark_events
+
+# FRR config on grout
+vtysh <<-EOF
+configure terminal
+
+vrf tenant
+ vni 1000
+exit-vrf
+
+router bgp 65000
+ bgp router-id 172.16.0.2
+ no bgp default ipv4-unicast
+
+ neighbor 172.16.0.1 remote-as 65000
+
+ address-family l2vpn evpn
+  neighbor 172.16.0.1 activate
+  advertise-all-vni
+ exit-address-family
+exit
+
+router bgp 65000 vrf tenant
+ bgp router-id 172.16.0.2
+
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+exit
+EOF
+
+# -- Check L3VNI is recognized by both sides -----------------------------------
+attempts=0
+while ! vtysh -c "show evpn vni 1000" | grep -qF "L3"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -c "show evpn vni"
+		fail "Grout FRR does not recognize VNI 1000 as L3VNI"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+attempts=0
+while ! vtysh -N evpn-peer -c "show evpn vni 1000" | grep -qF "L3"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -N evpn-peer -c "show evpn vni"
+		fail "Linux peer does not recognize VNI 1000 as L3VNI"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+# -- Check L2VNI is recognized by both sides -----------------------------------
+attempts=0
+while ! vtysh -c "show evpn vni 100" | grep -qF "VNI: 100"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -c "show evpn vni"
+		fail "Grout FRR does not recognize VNI 100 as L2VNI"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+# -- Wait for EVPN type-5 route exchange (IPv4) --------------------------------
+attempts=0
+while ! vtysh -c "show bgp l2vpn evpn route type 5" | grep -qF "16.0.0.0"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -c "show bgp l2vpn evpn route type 5"
+		fail "Grout FRR did not learn type-5 route for 16.0.0.0/24"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+attempts=0
+while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5" | grep -qF "48.0.0.0"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5"
+		fail "Linux peer did not learn type-5 route for 48.0.0.0/24"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+# -- Wait for routes to be installed in VRF ------------------------------------
+wait_event 'route4 add: vrf=tenant 16.0.0.0/24'
+
+# -- Check RMAC is set on route nexthops and uses L3 VNI ----------------------
+rmac=$(ip netns exec evpn-peer cat /sys/class/net/vni-l3/address)
+wait_event "nh new: type=L3 id=[0-9]+ iface=vni-l3 vrf=tenant origin=zebra family=ipv4 addr=172.16.0.1 mac=$rmac flags=static remote"
+
+# -- Verify L3 connectivity through L3 VNI VXLAN overlay ----------------------
+ip netns exec host-b ping -i0.1 -c3 -W1 16.0.0.2
+ip netns exec host-a ping -i0.1 -c3 -W1 48.0.0.2
+
+# -- Verify L2 connectivity through L2 VNI VXLAN overlay ----------------------
+wait_event "flood add: vtep vrf=main 172.16.0.1 vni=100"
+
+ip netns exec host-c ping -i0.1 -c3 -W1 10.0.0.3
+ip netns exec host-d ping -i0.1 -c3 -W1 10.0.0.2
+
+# -- Verify L3 connectivity across L2 and L3 VXLAN overlays ------------------
+ip netns exec host-a ping -i0.1 -c3 -W1 10.0.0.2
+ip netns exec host-a ping -i0.1 -c3 -W1 10.0.0.3
+
+ip netns exec host-b ping -i0.1 -c3 -W1 10.0.0.2
+ip netns exec host-b ping -i0.1 -c3 -W1 10.0.0.3
+
+ip netns exec host-c ping -i0.1 -c3 -W1 16.0.0.2
+ip netns exec host-c ping -i0.1 -c3 -W1 48.0.0.2
+
+ip netns exec host-d ping -i0.1 -c3 -W1 16.0.0.2
+ip netns exec host-d ping -i0.1 -c3 -W1 48.0.0.2


### PR DESCRIPTION
The L3VNI forward table maps a VRF to a single VXLAN interface for EVPN type-5 nexthop redirection. Two issues exist with this mapping:

When a VXLAN interface leaves VRF mode (e.g. moved to a bridge as an L2 VNI) or is deleted while not in VRF mode, the mapping is never cleaned up or is cleaned up using the wrong key. This is fixed by adding l3vni_del_iface() which scans the forward table by interface ID and calling it on mode changes and deletion.

Additionally, nothing prevents creating multiple VXLAN interfaces in VRF mode in the same VRF. On Linux this situation does not arise because all VXLAN devices sit in bridges and the L2/L3 distinction comes from FRR configuration ("vrf / vni"), not from how the device is attached. In grout, VRF mode itself implies L3 VNI, so having two VXLANs in VRF mode in the same VRF silently overwrites the forward mapping and breaks L3 routing for the previous one. This is now rejected with EADDRINUSE at configuration time.

A smoke test exercises L2 VNI and L3 VNI coexistence in the same VRF, verifying both type-5 inter-subnet routing and type-2/type-3 intra-subnet bridging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added `l3vni_del_iface()` to remove L3VNI forward-table entries by VXLAN interface ID, and wired it into `grout_link_change()` to clear the mapping on VXLAN mode transitions to `GR_IFACE_MODE_BOND`/`GR_IFACE_MODE_BRIDGE`, and to broaden VXLAN deletion cleanup: when `gr_vxlan` exists on the delete path, it now unconditionally clears by interface ID via `l3vni_del_iface(gr_if->id)` (instead of only calling `l3vni_del(gr_if->base.vrf_id)` when the interface was in VRF mode).
- Rejected reconfiguring a VXLAN into VRF mode when another VXLAN is already in `GR_IFACE_MODE_VRF` for the same `vrf_id`; `iface_vxlan_reconfig` now returns `EADDRINUSE` to prevent silent overwrites of the L3VNI forward mapping.
- Added `smoke/evpn_l2l3vni_frr_test.sh` to verify L2 VNI + L3 VNI coexistence within the same tenant VRF, covering EVPN Type-5 inter-subnet routing and type-2/type-3 intra-subnet bridging, plus end-to-end reachability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->