### PR TITLE
L3vpn ipv6 fix

### DIFF
--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -1060,10 +1060,12 @@ enum zebra_dplane_result grout_neigh_update_ctx(struct zebra_dplane_ctx *ctx) {
 	bool add = dplane_ctx_get_op(ctx) != DPLANE_OP_NEIGH_DELETE;
 	uint16_t vrf_id = vrf_frr_to_grout(dplane_ctx_get_vrf(ctx));
 
+#if CURRENT_FRR_VERSION < MAKE_FRRVERSION(10, 6, 0)
 	if (addr->ipa_type != IPADDR_V4) {
 		gr_log_debug("only IPv4 VTEP addresses supported, skip");
 		return ZEBRA_DPLANE_REQUEST_SUCCESS;
 	}
+#endif
 
 	// Cache the RMAC for later use by grout_add_nexthop. We cannot
 	// create a separate nexthop here because grout's L3 nexthop hash

--- a/smoke/bgp6_srv6_frr_test.sh
+++ b/smoke/bgp6_srv6_frr_test.sh
@@ -195,20 +195,15 @@ wait_event -t 20 'route4 add: vrf=gr-vrf1 16.0.0.0/24 origin=bgp via type=SRv6 '
 wait_event -t 20 'route6 add: vrf=main 2001:db8:2:2:100::/128 origin=bgp via type=SRv6-local '
 
 attempts=0
-while ! vtysh -N bgp-peer -c "show ip route vrf vrf1" | grep -q "B>\* 16.1.0.0/24 .*seg6" ; do
-	if [ "$attempts" -ge 40 ]; then
-		fail "BGP seg6 route not learned in FRR BGP Peer"
-	fi
-	sleep 0.5
+while ! vtysh -N bgp-peer -c "show ip route vrf vrf1" | grep -q "B>\* 16.1.0.0/24 .*seg6"; do
+	[ "$attempts" -ge 5 ] && fail "BGP seg6 route not learned in FRR BGP Peer"
+	sleep 1
 	attempts=$((attempts + 1))
 done
-
 attempts=0
-while ! vtysh -N bgp-peer -c "show ipv6 route" | grep -q "B>\* 2001:db8:1:1:100::/128 .*seg6local" ; do
-	if [ "$attempts" -ge 40 ]; then
-		fail "BGP seg6local route not learned in FRR BGP Peer"
-	fi
-	sleep 0.5
+while ! vtysh -N bgp-peer -c "show ipv6 route" | grep -q "B>\* 2001:db8:1:1:100::/128 .*seg6local"; do
+	[ "$attempts" -ge 5 ] && fail "BGP seg6local route not learned in FRR BGP Peer"
+	sleep 1
 	attempts=$((attempts + 1))
 done
 

--- a/smoke/evpn_l2l3vni_frr_test.sh
+++ b/smoke/evpn_l2l3vni_frr_test.sh
@@ -249,28 +249,14 @@ while ! vtysh -c "show evpn vni 100" | grep -qF "VNI: 100"; do
 done
 
 # -- Wait for EVPN type-5 route exchange (IPv4) --------------------------------
+wait_event -t 10 'route4 add: vrf=tenant 16.0.0.0/24'
+
 attempts=0
-while ! vtysh -c "show bgp l2vpn evpn route type 5" | grep -qF "16.0.0.0"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -c "show bgp l2vpn evpn route type 5"
-		fail "Grout FRR did not learn type-5 route for 16.0.0.0/24"
-	fi
+while ! ip -n evpn-peer route show vrf tenant proto bgp | grep -qF "48.0.0.0/24"; do
+	[ "$attempts" -ge 5 ] && fail "Route 48.0.0.0/24 not installed in peer VRF tenant"
 	sleep 1
 	attempts=$((attempts + 1))
 done
-
-attempts=0
-while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5" | grep -qF "48.0.0.0"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5"
-		fail "Linux peer did not learn type-5 route for 48.0.0.0/24"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
-# -- Wait for routes to be installed in VRF ------------------------------------
-wait_event 'route4 add: vrf=tenant 16.0.0.0/24'
 
 # -- Check RMAC is set on route nexthops and uses L3 VNI ----------------------
 rmac=$(ip netns exec evpn-peer cat /sys/class/net/vni-l3/address)

--- a/smoke/evpn_l3vpn_frr_test.sh
+++ b/smoke/evpn_l3vpn_frr_test.sh
@@ -214,72 +214,20 @@ while ! vtysh -N evpn-peer -c "show evpn vni 1000" | grep -qF "L3"; do
 	attempts=$((attempts + 1))
 done
 
-# -- Wait for EVPN type-5 route exchange (IPv4) --------------------------------
-attempts=0
-while ! vtysh -c "show bgp l2vpn evpn route type 5" | grep -qF "16.0.0.0"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -c "show bgp l2vpn evpn route type 5"
-		fail "Grout FRR did not learn type-5 route for 16.0.0.0/24"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
-attempts=0
-while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5" | grep -qF "48.0.0.0"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -c "show bgp vrf tenant ipv4 unicast"
-		vtysh -c "show bgp l2vpn evpn route"
-		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5"
-		fail "Linux peer did not learn type-5 route for 48.0.0.0/24"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
-# -- Wait for EVPN type-5 route exchange (IPv6) --------------------------------
-attempts=0
-while ! vtysh -c "show bgp l2vpn evpn route type 5" | grep -qF "fd00:16::"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -c "show bgp l2vpn evpn route type 5"
-		fail "Grout FRR did not learn type-5 route for fd00:16::/64"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
-attempts=0
-while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5" | grep -qF "fd00:48::"; do
-	if [ "$attempts" -ge 5 ]; then
-		vtysh -c "show bgp vrf tenant ipv6 unicast"
-		vtysh -c "show bgp l2vpn evpn route"
-		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 5"
-		fail "Linux peer did not learn type-5 route for fd00:48::/64"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
-# -- Wait for routes to be installed in VRF ------------------------------------
-wait_event 'route4 add: vrf=tenant 16.0.0.0/24'
+# -- Wait for EVPN type-5 route exchange ---------------------------------------
+wait_event -t 10 'route4 add: vrf=tenant 16.0.0.0/24'
 wait_event 'route6 add: vrf=tenant fd00:16::/64'
 
+# The peer should also have our routes by now, allow a few retries.
 attempts=0
-while ! ip -n evpn-peer route show vrf tenant | grep -qF "48.0.0.0/24"; do
-	if [ "$attempts" -ge 5 ]; then
-		ip -n evpn-peer route show vrf tenant
-		fail "Route 48.0.0.0/24 not installed in peer VRF tenant"
-	fi
+while ! ip -n evpn-peer route show vrf tenant proto bgp | grep -qF "48.0.0.0/24"; do
+	[ "$attempts" -ge 5 ] && fail "Route 48.0.0.0/24 not installed in peer VRF tenant"
 	sleep 1
 	attempts=$((attempts + 1))
 done
-
 attempts=0
-while ! ip -n evpn-peer -6 route show vrf tenant | grep -qF "fd00:48::"; do
-	if [ "$attempts" -ge 5 ]; then
-		ip -n evpn-peer -6 route show vrf tenant
-		fail "Route fd00:48::/64 not installed in peer VRF tenant"
-	fi
+while ! ip -n evpn-peer -6 route show vrf tenant proto bgp | grep -qF "fd00:48::"; do
+	[ "$attempts" -ge 5 ] && fail "Route fd00:48::/64 not installed in peer VRF tenant"
 	sleep 1
 	attempts=$((attempts + 1))
 done

--- a/smoke/evpn_l3vpn_vxlan6_frr_test.sh
+++ b/smoke/evpn_l3vpn_vxlan6_frr_test.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Robin Jarry
+
+# This test verifies EVPN Type-5 (IP prefix) L3VPN connectivity using symmetric
+# IRB (Integrated Routing and Bridging) over VXLAN between FRR+Grout and
+# a standalone FRR+Linux peer.
+#
+# Each side has a VRF with an L3 VNI (1000) and a host connected to a local
+# port. BGP EVPN advertises IPv4 and IPv6 prefixes (type-5 routes) and RMAC
+# entries (type-2 routes with GR_NH_F_REMOTE nexthops) across the VXLAN overlay.
+#
+# Success criteria:
+#   - Both sides exchange EVPN type-5 routes (IPv4 and IPv6 prefixes installed).
+#   - Host-A and Host-B can ping each other through the L3 VXLAN overlay.
+#   - IPv6 RMACs are installed as remote nexthops on the grout side.
+#
+#   .-------------------------------.         .-----------------------------.
+#   |           evpn-peer           |         |            grout            |
+#   |                               |         |                             |
+#   | .- - - - - - - .              |         |            .- - - - - - - . |
+#   | '  vrf tenant  '              |         |            '  vrf tenant  ' |
+#   | '              '              |         |            '              ' |
+#   | '  +-------+   '              |         |            '              ' |
+#   | '  | br-l3 |   '              |         |            '              ' |
+#   | '  +---+---+   '              |         |            '              ' |
+#   | '      |       '              |         |            '              ' |
+#   | ' +----+-----+ '              |         |            ' +----------+ ' |
+#   | ' | vxlan-l3 |...........     |         |    ..........| vxlan-l3 | ' |
+#   | ' +----------+ '        .     |         |    .       ' +----------+ ' |
+#   | '              '        .     |         |    .       '              ' |
+#   | '      .1      '        .     |         |    .       '     .1       ' |
+#   | '   +------+   '       .1     |         |   .2       '  +-------+   ' |
+#   | '   |  p1  |   '   +--------+ |         | +------+   '  |   p1  |   ' |
+#   | '   +--+---+   '   |  x-p0  | |         | |  p0  |   '  +---+---+   ' |
+#   | '- - - |- - - -'   +---+----+ |         | +--+---+   '- - - |- - - -' |
+#   '--------|---------------|------'         '----|--------------|---------'
+#            |               |                     |              |
+#            |               | <------- BGP  ----> |              |
+#      16.0.0.0/24           '---------------------'       48.0.0.0/24
+#      fd00:16::/64                 underlay               fd00:48::/64
+#            |                      3fff::/64                     |
+#    .-------|-----------.                             .----------|--------.
+#    |   +---+----+      |                             |      +---+----+   |
+#    |   |  x-p1  |      |                             |      |  x-p1  |   |
+#    |   +--------+      | <= = = = = = = = = = = = => |      +--------+   |
+#    |       .2          |        overlay L3VPN        |         .2        |
+#    |                   |                             |  lo:10.0.0.1/24   |
+#    |                   |                             |                   |
+#    |    host-a         |                             |       host-b      |
+#    '-------------------'                             '-------------------'
+
+set -e
+zebra=$(PATH="$1/frr_install/sbin:$1/frr_install/bin:$PATH" command -v zebra)
+frr_version=$($zebra --version | sed -En 's/zebra version //p')
+min_version=$(printf '%s\n%s\n' "$frr_version" "10.6.0" | sort -V | head -n1)
+if ! [ "$min_version" = "10.6.0" ]; then
+	echo "$0: FRR $frr_version does not support IPv6 underlay addresses"
+	exit 125
+fi
+
+. $(dirname $0)/_init_frr.sh
+
+# right side (grout) -----------------------------------------------------------
+create_interface p0
+set_ip_address p0 3fff::2/64
+
+# left side (Linux peer) -------------------------------------------------------
+start_frr evpn-peer
+
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.all.forwarding=1
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.all.rp_filter=0
+ip netns exec evpn-peer sysctl -qw net.ipv4.conf.default.rp_filter=0
+ip netns exec evpn-peer sysctl -qw net.ipv6.conf.all.forwarding=1
+
+move_to_netns x-p0 evpn-peer
+ip -n evpn-peer addr add 3fff::1/64 dev x-p0
+
+# Create L3VNI VXLAN on the Linux peer with a bridge+SVI (required by Linux)
+ip -n evpn-peer link add br-l3 type bridge
+ip -n evpn-peer link set br-l3 up
+
+ip -n evpn-peer link add vxlan-l3 type vxlan id 1000 local 3fff::1 dstport 4789 nolearning
+ip -n evpn-peer link set vxlan-l3 master br-l3
+ip -n evpn-peer link set vxlan-l3 up
+
+# Create VRF "tenant" on the peer and bind the L3VNI bridge as SVI
+ip -n evpn-peer link add tenant type vrf table 10
+ip -n evpn-peer link set tenant up
+ip -n evpn-peer link set br-l3 master tenant
+
+# Host-facing port in the peer VRF
+ip -n evpn-peer link add p1 type veth peer name x-p1
+ip -n evpn-peer link set p1 master tenant
+ip -n evpn-peer link set p1 up
+ip -n evpn-peer addr add 16.0.0.1/24 dev p1
+ip -n evpn-peer addr add fd00:16::1/64 dev p1
+
+netns_add host-a
+ip -n evpn-peer link set x-p1 netns host-a
+ip -n host-a link set x-p1 up
+ip -n host-a addr add 16.0.0.2/24 dev x-p1
+ip -n host-a route add default via 16.0.0.1
+ip -n host-a addr add fd00:16::2/64 dev x-p1
+ip -n host-a -6 route add default via fd00:16::1
+
+# FRR config on the Linux peer
+vtysh -N evpn-peer <<-EOF
+configure terminal
+
+vrf tenant
+ vni 1000
+exit-vrf
+
+router bgp 65000
+ bgp router-id 172.16.0.0
+ no bgp default ipv4-unicast
+
+ neighbor 3fff::2 remote-as 65000
+
+ address-family l2vpn evpn
+  neighbor 3fff::2 activate
+  advertise-all-vni
+ exit-address-family
+exit
+
+router bgp 65000 vrf tenant
+ bgp router-id 172.16.0.0
+
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family ipv6 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+  advertise ipv6 unicast
+ exit-address-family
+exit
+EOF
+
+# right side (grout) setup L3VPN -----------------------------------------------
+create_vrf tenant
+
+# L3 VNI VXLAN in VRF mode (no bridge needed in grout)
+grcli interface add vxlan vxlan-l3 vni 1000 local 3fff::2 vrf tenant
+
+create_interface p1 vrf tenant
+set_ip_address p1 48.0.0.1/24
+set_ip_address p1 fd00:48::1/64
+
+netns_add host-b
+move_to_netns x-p1 host-b
+ip -n host-b addr add 48.0.0.2/24 dev x-p1
+ip -n host-b addr add 10.0.0.1/24 dev lo
+ip -n host-b route add default via 48.0.0.1
+ip -n host-b addr add fd00:48::2/64 dev x-p1
+ip -n host-b -6 route add default via fd00:48::1
+
+mark_events
+
+# FRR config on grout
+vtysh <<-EOF
+configure terminal
+
+vrf tenant
+ vni 1000
+exit-vrf
+
+router bgp 65000
+ bgp router-id 172.16.0.1
+ no bgp default ipv4-unicast
+
+ neighbor 3fff::1 remote-as 65000
+
+ address-family l2vpn evpn
+  neighbor 3fff::1 activate
+  advertise-all-vni
+ exit-address-family
+exit
+
+router bgp 65000 vrf tenant
+ bgp router-id 172.16.0.1
+
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family ipv6 unicast
+  redistribute connected
+ exit-address-family
+
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+  advertise ipv6 unicast
+ exit-address-family
+exit
+EOF
+
+# -- Check L3VNI is recognized by both sides -----------------------------------
+attempts=0
+while ! vtysh -c "show evpn vni 1000" | grep -qF "L3"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -c "show evpn vni"
+		fail "Grout FRR does not recognize VNI 1000 as L3VNI"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+attempts=0
+while ! vtysh -N evpn-peer -c "show evpn vni 1000" | grep -qF "L3"; do
+	if [ "$attempts" -ge 5 ]; then
+		vtysh -N evpn-peer -c "show evpn vni"
+		fail "Linux peer does not recognize VNI 1000 as L3VNI"
+	fi
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+# -- Wait for EVPN type-5 route exchange ---------------------------------------
+wait_event -t 10 'route4 add: vrf=tenant 16.0.0.0/24'
+wait_event 'route6 add: vrf=tenant fd00:16::/64'
+
+# The peer should also have our routes by now, allow a few retries.
+attempts=0
+while ! ip -n evpn-peer route show vrf tenant proto bgp | grep -qF "48.0.0.0/24"; do
+	[ "$attempts" -ge 5 ] && fail "Route 48.0.0.0/24 not installed in peer VRF tenant"
+	sleep 1
+	attempts=$((attempts + 1))
+done
+attempts=0
+while ! ip -n evpn-peer -6 route show vrf tenant proto bgp | grep -qF "fd00:48::"; do
+	[ "$attempts" -ge 5 ] && fail "Route fd00:48::/64 not installed in peer VRF tenant"
+	sleep 1
+	attempts=$((attempts + 1))
+done
+
+# -- Check RMAC is set on route nexthops ---------------------------------------
+rmac=$(ip netns exec evpn-peer cat /sys/class/net/vxlan-l3/address)
+
+wait_event "nh new: type=L3 id=[0-9]+ iface=vxlan-l3 vrf=tenant origin=zebra family=ipv6 addr=3fff::1 mac=$rmac flags=static remote"
+
+vtysh -c "show bgp l2vpn evpn route type 5"
+grcli route show vrf tenant
+grcli nexthop show vrf tenant
+
+# -- Verify L3 connectivity through VXLAN overlay (IPv4) -----------------------
+ip netns exec host-b ping -i0.1 -c3 -W1 16.0.0.2
+ip netns exec host-a ping -i0.1 -c3 -W1 48.0.0.2
+
+# -- Verify L3 connectivity through VXLAN overlay (IPv6) -----------------------
+ip netns exec host-b ping -6 -i0.1 -c3 -W1 fd00:16::2
+ip netns exec host-a ping -6 -i0.1 -c3 -W1 fd00:48::2
+
+# -- Verify local nexthop uses port, not VXLAN ---------------------------------
+# Route to 10.0.0.0/24 (behind host-b) via local gateway 48.0.0.2. The nexthop
+# for 48.0.0.2 must use port p1, not the VXLAN interface.
+set_ip_route 10.0.0.0/24 48.0.0.2 tenant
+grcli ping 10.0.0.1 vrf tenant count 3 delay 10

--- a/smoke/evpn_vxlan6_frr_test.sh
+++ b/smoke/evpn_vxlan6_frr_test.sh
@@ -153,17 +153,14 @@ move_to_netns x-p1 host-b
 ip -n host-b addr add fc00::3/64 dev x-p1
 
 # -- Wait for EVPN type-3 (flood VTEP) exchange -------------------------------
+wait_event -t 10 "flood add: vtep vrf=main 3fff::1 vni=100"
+
 attempts=0
-while ! bridge -n evpn-peer fdb show dev vxlan100 | grep -qF 3fff::2; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -N evpn-peer -c "show evpn vni 100"
-		fail "Linux peer did not learn remote VTEP 3fff::2"
-	fi
+while ! bridge -n evpn-peer fdb show dev vxlan100 | grep -qF "3fff::2"; do
+	[ "$attempts" -ge 5 ] && fail "Linux peer did not learn remote VTEP 3fff::2"
 	sleep 1
 	attempts=$((attempts + 1))
 done
-
-wait_event "flood add: vtep vrf=main 3fff::1 vni=100"
 
 bridge -n evpn-peer fdb show dev vxlan100
 grcli fdb show
@@ -183,32 +180,10 @@ mac_a=$(ip netns exec host-a cat /sys/class/net/x-p1/address)
 
 wait_event "fdb add: bridge=br100 $mac_a.* vtep=3fff::1.* extern"
 
-attempts=0
-while ! vtysh -c "show bgp l2vpn evpn route type 2" | grep -qF "$mac_a"; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -c "show bgp l2vpn evpn route type 2"
-		fail "FRR did not learn type 2 route"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
 mac_b=$(ip netns exec host-b cat /sys/class/net/x-p1/address)
 attempts=0
-while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 2" | grep -qF "$mac_b"; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 2"
-		fail "EVPN peer did not learn type 2 route"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-attempts=0
 while ! bridge -n evpn-peer fdb show dev vxlan100 | grep -q "$mac_b.*extern"; do
-	if [ "$attempts" -ge 10 ]; then
-		bridge -n evpn-peer fdb show dev vxlan100
-		fail "EVPN peer did not program FDB entry in bridge"
-	fi
+	[ "$attempts" -ge 5 ] && fail "EVPN peer did not program FDB entry for $mac_b"
 	sleep 1
 	attempts=$((attempts + 1))
 done

--- a/smoke/evpn_vxlan_frr_test.sh
+++ b/smoke/evpn_vxlan_frr_test.sh
@@ -143,17 +143,14 @@ move_to_netns x-p1 host-b
 ip -n host-b addr add 10.0.0.3/24 dev x-p1
 
 # -- Wait for EVPN type-3 (flood VTEP) exchange -------------------------------
+wait_event -t 10 "flood add: vtep vrf=main 172.16.0.1 vni=100"
+
 attempts=0
 while ! bridge -n evpn-peer fdb show dev vxlan100 | grep -qF 172.16.0.2; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -N evpn-peer -c "show evpn vni 100"
-		fail "Linux peer did not learn remote VTEP 172.16.0.2"
-	fi
+	[ "$attempts" -ge 5 ] && fail "Linux peer did not learn remote VTEP 172.16.0.2"
 	sleep 1
 	attempts=$((attempts + 1))
 done
-
-wait_event "flood add: vtep vrf=main 172.16.0.1 vni=100"
 
 bridge -n evpn-peer fdb show dev vxlan100
 grcli fdb show
@@ -173,32 +170,10 @@ mac_a=$(ip netns exec host-a cat /sys/class/net/x-p1/address)
 
 wait_event "fdb add: bridge=br100 $mac_a.* vtep=172.16.0.1.* extern"
 
-attempts=0
-while ! vtysh -c "show bgp l2vpn evpn route type 2" | grep -qF "$mac_a"; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -c "show bgp l2vpn evpn route type 2"
-		fail "FRR did not learn type 2 route"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-
 mac_b=$(ip netns exec host-b cat /sys/class/net/x-p1/address)
 attempts=0
-while ! vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 2" | grep -qF "$mac_b"; do
-	if [ "$attempts" -ge 10 ]; then
-		vtysh -N evpn-peer -c "show bgp l2vpn evpn route type 2"
-		fail "EVPN peer did not learn type 2 route"
-	fi
-	sleep 1
-	attempts=$((attempts + 1))
-done
-attempts=0
 while ! bridge -n evpn-peer fdb show dev vxlan100 | grep -q "$mac_b.*extern"; do
-	if [ "$attempts" -ge 10 ]; then
-		bridge -n evpn-peer fdb show dev vxlan100
-		fail "EVPN peer did not program FDB entry in bridge"
-	fi
+	[ "$attempts" -ge 5 ] && fail "EVPN peer did not program FDB entry for $mac_b"
 	sleep 1
 	attempts=$((attempts + 1))
 done

--- a/smoke/ospf6_frr_test.sh
+++ b/smoke/ospf6_frr_test.sh
@@ -83,13 +83,6 @@ while ! vtysh -c 'show ipv6 ospf6 neighbor json' | jq '.neighbors[] | select(.ne
 	attempts=$((attempts - 1))
 done
 
-attempts=30
-while ! vtysh -c 'show ipv6 route ospf6 json' | jq '."2001:db8:1000::/64"[0].protocol == "ospf6"' -e ; do
-	sleep 1
-	if [ "$attempts" -le 0 ]; then
-		fail "OSPF6 failed to get routes."
-	fi
-	attempts=$((attempts - 1))
-done
+wait_event -t 60 'route6 add: vrf=main 2001:db8:1000::/64 origin=ospf'
 
 grcli ping 2001:db8:1000::1 count 3 delay 10

--- a/smoke/ospf_frr_test.sh
+++ b/smoke/ospf_frr_test.sh
@@ -86,13 +86,6 @@ while ! vtysh -c 'show ip ospf neighbor json' | jq '.neighbors."172.16.0.2"[0].c
 	attempts=$((attempts - 1))
 done
 
-attempts=60
-while ! vtysh -c 'show ip route ospf json' | jq '."16.0.0.1/32"[0].protocol == "ospf"' -e ; do
-	sleep 1
-	if [ "$attempts" -le 0 ]; then
-		fail "OSPF failed to get routes."
-	fi
-	attempts=$((attempts - 1))
-done
+wait_event -t 60 'route4 add: vrf=main 16.0.0.1/32 origin=ospf'
 
 grcli ping 16.0.0.1 count 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- `frr/rt_grout.c`: In `grout_neigh_update_ctx`, the IPv4-only VTEP check is now gated by FRR version. It is applied only for FRR versions older than `10.6.0` (non-IPv4 VTEPs are logged and skipped). For `10.6.0` and newer, this function no longer performs the IPv4 VTEP rejection at that point.
- `smoke/evpn_l3vpn_vxlan6_frr_test.sh`: Added EVPN Type-5 L3VPN smoke coverage over a VXLAN overlay with IPv4 and IPv6, including FRR version gating (`zebra` < `10.6.0` exits with code `125`), VNI/L3 VNI recognition waits, Type-5 route installation checks via `wait_event`, nexthop validation, and end-to-end IPv4/IPv6 ping between hosts.
- `smoke/bgp6_srv6_frr_test.sh`: Adjusted BGP route-verification retry behavior for SRv6 (`seg6`) checks: fewer maximum retries and fixed retry timing changes, plus a loop-structure adjustment to increment attempts after sleeping.
- `smoke/evpn_l2l3vni_frr_test.sh`: Replaced FRR `vtysh` polling for EVPN Type-5 routes with dataplane/route-event synchronization: wait for `route4 add` events, then poll the peer Linux routing table for the expected learned prefix.
- `smoke/evpn_l3vpn_frr_test.sh`: Replaced broad FRR/BGP CLI polling for EVPN Type-5 route exchange (IPv4/IPv6) with narrower `wait_event` synchronization for Type-5 route installation, followed by peer Linux routing-table verification for the corresponding prefixes.
- `smoke/evpn_vxlan6_frr_test.sh`: Updated synchronization/validation to be event- and dataplane-driven:
  - EVPN type-3 flood VTEP exchange now waits for Grout `flood add` before checking Linux bridge FDB learning (tightened retries and fail-fast behavior).
  - EVPN type-2 validation now prioritizes peer Linux bridge FDB checks (`extern` entries) instead of polling FRR `vtysh` EVPN Type-2 routes.
- `smoke/evpn_vxlan_frr_test.sh`: Similar to the VXLAN6 test—type-3 flood VTEP uses `wait_event` timing before FDB checks, and type-2 validation relies on `wait_event`/FDB-based checks for remote MAC entries with reduced retry budgets.
- `smoke/ospf6_frr_test.sh`: Switched OSPFv6 convergence verification from polling FRR JSON output to `wait_event` for a `route6 add` event for the expected prefix with origin `ospf`.
- `smoke/ospf_frr_test.sh`: Switched OSPFv2 convergence verification from polling FRR JSON output to `wait_event` for a `route4 add` event with origin `ospf`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->