### PR TITLE
ctlplane: set loose reverse path filtering on TAP representors

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,5 +23,6 @@ FROM scratch
 COPY --from=builder /tmp/null/ /
 STOPSIGNAL SIGRTMIN+3
 ENV GROUT_OVERRIDE_DEFAULT_ROUTE=true
+ENV GROUT_OVERRIDE_RP_FILTER=true
 ENTRYPOINT ["/usr/libexec/catatonit/catatonit", "--"]
 CMD ["/usr/bin/grout"]

--- a/docs/grout.8.scdoc
+++ b/docs/grout.8.scdoc
@@ -88,6 +88,14 @@ Grout is a software router based on DPDK _rte_graph_.
 	another default route (e.g. from Kubernetes) takes priority over grout's
 	own default route.
 
+*GROUT_OVERRIDE_RP_FILTER*
+	When set to _1_, _true_, _on_, or _yes_ (case insensitive), set loose
+	reverse path filtering (_rp_filter=2_) on control plane TAP interfaces.
+	This prevents the kernel from dropping packets delivered by grout when
+	strict reverse path filtering (_rp_filter=1_) is enabled globally. This
+	is required when _net.ipv4.conf.all.rp_filter_ is set to _1_ (strict) in
+	the network namespace where grout is running.
+
 # EXTRA EAL ARGUMENTS
 
 Any DPDK EAL argument can be specified after an optional *--*. This is an

--- a/main/config.h
+++ b/main/config.h
@@ -22,6 +22,7 @@ struct gr_config {
 	bool log_syslog;
 	bool log_packets;
 	bool override_default_route;
+	bool override_rp_filter;
 	vec char **eal_extra_args;
 	cpu_set_t control_cpus; // control plane threads allowed CPUs
 	cpu_set_t datapath_cpus; // datapath threads allowed CPUs

--- a/main/grout.default
+++ b/main/grout.default
@@ -10,3 +10,8 @@ GROUT_OPTS='--syslog'
 # be set to false if removing PrivateNetwork=true from the systemd service and
 # running grout in the main network namespace.
 GROUT_OVERRIDE_DEFAULT_ROUTE=true
+
+# Set loose reverse path filtering on control plane TAP interfaces.
+# Required when net.ipv4.conf.all.rp_filter is set to 1 (strict) in the network
+# namespace where grout is running.
+GROUT_OVERRIDE_RP_FILTER=true

--- a/main/main.c
+++ b/main/main.c
@@ -299,6 +299,7 @@ int main(int argc, char **argv) {
 		goto end;
 
 	gr_config.override_default_route = parse_bool_env("GROUT_OVERRIDE_DEFAULT_ROUTE");
+	gr_config.override_rp_filter = parse_bool_env("GROUT_OVERRIDE_RP_FILTER");
 
 	if (dpdk_log_init() < 0)
 		goto end;
@@ -306,6 +307,8 @@ int main(int argc, char **argv) {
 	LOG(NOTICE, "starting grout version %s", GROUT_VERSION);
 	if (gr_config.override_default_route)
 		LOG(NOTICE, "GROUT_OVERRIDE_DEFAULT_ROUTE is set, overriding default route");
+	if (gr_config.override_rp_filter)
+		LOG(NOTICE, "GROUT_OVERRIDE_RP_FILTER is set, bypassing reverse path filtering");
 	LOG(NOTICE,
 	    "License available at https://git.dpdk.org/apps/grout/plain/licenses/BSD-3-clause.txt");
 

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -321,6 +321,21 @@ static void cp_create(struct iface *iface) {
 		LOG(WARNING, "fopen(%s): %s", path, strerror(errno));
 	}
 
+	if (gr_config.override_rp_filter) {
+		// Set loose reverse path filtering on the TAP so that packets
+		// delivered by grout are not dropped by rp_filter. The effective
+		// rp_filter mode is max(conf.all, conf.<iface>), so setting the
+		// per-interface value to 2 (loose) overrides a global strict setting.
+		snprintf(path, sizeof(path), "/proc/sys/net/ipv4/conf/%s/rp_filter", iface->name);
+		f = fopen(path, "w");
+		if (f != NULL) {
+			fputs("2", f);
+			fclose(f);
+		} else {
+			LOG(WARNING, "fopen(%s): %s", path, strerror(errno));
+		}
+	}
+
 	iface->cp_ev = event_new(
 		ev_base,
 		iface->cp_fd,

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -33,6 +33,8 @@ if [ "${INTERACTIVE:-false}" = true ] && [ -z "${SMOKE_TMUX_SOCK:-}" ]; then
 fi
 
 ip link set lo up
+sysctl -qw net.ipv4.conf.all.rp_filter=1
+sysctl -qw net.ipv4.conf.default.rp_filter=1
 
 : "${test_frr:=false}"
 
@@ -265,6 +267,7 @@ llocal_addr() {
 if [ "$run_grout" = true ]; then
 	smoke_setenv GROUT_SOCK_PATH "$tmp/grout.sock"
 	smoke_setenv GROUT_OVERRIDE_DEFAULT_ROUTE true
+	smoke_setenv GROUT_OVERRIDE_RP_FILTER true
 fi
 if [ -n "${builddir}" ]; then
 	smoke_setenv PATH "$builddir:$PATH"


### PR DESCRIPTION
When rp_filter=1 (strict mode) is enabled, the kernel does a reverse path FIB lookup on incoming packets to verify that the source address is reachable via the same interface. With only oif rules, this lookup falls through to the main/VRF table where the default route points to the TUN loopback, causing an interface mismatch and dropping the packet.

Add a matching iif rule for each TAP so that the rp_filter FIB lookup hits table 999 and finds the default route via the same TAP the packet arrived on. This does not affect actual routing of return packets which still go through the TUN loopback into the datapath as before.

Update the stale rule flush logic to also collect and clean up iif rules on restart.

Enable rp_filter in all smoke tests to exercise the added iif rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- `smoke/_init.sh`: after bringing up `lo`, sets IPv4 strict reverse path filtering for namespace defaults (`net.ipv4.conf.all.rp_filter=1` and `net.ipv4.conf.default.rp_filter=1`); when `run_grout` is enabled, exports `GROUT_OVERRIDE_RP_FILTER=true` into the grout environment.
- `Containerfile` + `main/grout.default`: set `GROUT_OVERRIDE_RP_FILTER=true` in the container/grout defaults (with comments that it’s required when `net.ipv4.conf.all.rp_filter` is `1`/strict where grout runs).
- `docs/grout.8.scdoc`: documents `GROUT_OVERRIDE_RP_FILTER` and that it configures `rp_filter=2` (loose) on control plane TAP interfaces when strict (`rp_filter=1`) is enabled globally.
- `main`: adds `gr_config.override_rp_filter`, parsed from `GROUT_OVERRIDE_RP_FILTER`; when set, emits a `NOTICE` that reverse path filtering will be bypassed.
- `modules/infra/control/ctlplane.c`: during control-plane TAP creation, when `gr_config.override_rp_filter` is enabled, writes `/proc/sys/net/ipv4/conf/<iface>/rp_filter=2` for the TAP (after the existing `/keep_addr_on_down` sysctl write) and logs `WARNING` if the `rp_filter` sysctl can’t be opened/written.
- `modules/infra/control/netlink.c`: configures control-plane policy routing using table `999` for both IPv4 and IPv6 by installing per-TAP policy rules that match `oif=<tap>` via `FRA_OIFNAME` and a `default dev <tap>` route in table `999`; on init, flushes stale state for table `999` by dumping `RTM_GETRULE`/`RTM_GETROUTE`, collecting entries where `table == 999`, and deleting the corresponding policy rules (by saved `FRA_OIFNAME`) and routes (in table `999`) to avoid orphan kernel entries across crash/restart cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->