### PR TITLE
Fix frr auto detect

### DIFF
--- a/frr/meson.build
+++ b/frr/meson.build
@@ -15,6 +15,10 @@ frr_dep = dependency(
   fallback: ['frr-' + frr_version, 'frr_dep'],
 )
 
+if not frr_dep.found()
+  subdir_done()
+endif
+
 install_build_flag = frr_dep.get_variable('install_on_build', default_value: 'false') == 'true'
 frr_moduledir = frr_dep.get_variable('moduledir')
 


### PR DESCRIPTION
Break compilation of grout in buildroot. Must be merged and a new release must be done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Restores FRR auto-detection compatibility with Buildroot by skipping FRR subdirectory configuration when neither system FRR headers nor the fallback subproject is available. This prevents Meson configuration failures in `--wrap-mode=nodownload` environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->