### PR TITLE
cli: fix ping response time display

### DIFF
--- a/modules/ip/cli/icmp.c
+++ b/modules/ip/cli/icmp.c
@@ -85,13 +85,14 @@ static cmd_status_t icmp_send(
 			else
 				printf("timeout: icmp_seq=%d\n", i);
 		} else {
+			double roundtrip_ms = (reply_resp->response_time * 1000.) / GR_NS_PER_S;
 			switch (reply_resp->type) {
 			case RTE_ICMP_TYPE_ECHO_REPLY:
 				if (mode_traceroute) {
 					printf("%2d  " IP4_F " time=%.3f ms\n",
 					       i,
 					       &reply_resp->src_addr,
-					       reply_resp->response_time / 1000.);
+					       roundtrip_ms);
 					stop = true;
 					errors = 0;
 					errno = 0;
@@ -101,7 +102,7 @@ static cmd_status_t icmp_send(
 					       &reply_resp->src_addr,
 					       reply_resp->seq_num,
 					       reply_resp->ttl,
-					       reply_resp->response_time / 1000.);
+					       roundtrip_ms);
 				}
 				break;
 			case RTE_ICMP_TYPE_DEST_UNREACHABLE:
@@ -119,7 +120,7 @@ static cmd_status_t icmp_send(
 				printf("%2d  " IP4_F " time=%.3f ms\n",
 				       i,
 				       &reply_resp->src_addr,
-				       reply_resp->response_time / 1000.);
+				       roundtrip_ms);
 				break;
 			}
 			free(resp_ptr);

--- a/modules/ip6/cli/icmp6.c
+++ b/modules/ip6/cli/icmp6.c
@@ -77,6 +77,7 @@ static cmd_status_t icmp_send(
 			else
 				printf("timeout: icmp_seq=%d\n", i);
 		} else {
+			double roundtrip_ms = (reply_resp->response_time * 1000.) / GR_NS_PER_S;
 			switch (reply_resp->type) {
 			case ICMP6_TYPE_ECHO_REPLY:
 				if (!mode_traceroute) {
@@ -85,12 +86,12 @@ static cmd_status_t icmp_send(
 					       &reply_resp->src_addr,
 					       reply_resp->seq_num,
 					       reply_resp->ttl,
-					       reply_resp->response_time / 1000.);
+					       roundtrip_ms);
 				} else {
 					printf("%2d  " IP6_F " time=%.3f ms\n",
 					       i,
 					       &reply_resp->src_addr,
-					       reply_resp->response_time / 1000.);
+					       roundtrip_ms);
 					stop = true;
 					errors = 0;
 				}
@@ -128,7 +129,7 @@ static cmd_status_t icmp_send(
 				printf("%2d  " IP6_F " time=%.3f ms%s\n",
 				       i,
 				       &reply_resp->src_addr,
-				       reply_resp->response_time / 1000.,
+				       roundtrip_ms,
 				       errdesc);
 			}
 			free(resp_ptr);


### PR DESCRIPTION
The response_time value is now in nanoseconds.

Fixes: fe0c7f9a3654 ("api: replace clock_t with high-res type")

@MortenBroerup fyi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Update ICMP (modules/ip/cli/icmp.c) round-trip time formatting to treat `reply_resp->response_time` as nanoseconds by computing a `double roundtrip_ms` using `GR_NS_PER_S`, then use `roundtrip_ms` in the `RTE_ICMP_TYPE_ECHO_REPLY` (traceroute and non-traceroute) and `RTE_ICMP_TYPE_TTL_EXCEEDED` output paths instead of printing `response_time / 1000.` inline.
- Update ICMPv6 (modules/ip6/cli/icmp6.c) traceroute timing to precompute a `roundtrip_ms` from nanosecond `reply_resp->response_time` using `GR_NS_PER_S`, and pass `roundtrip_ms` into the traceroute echo-reply and traceroute error/timeout `printf` formatting rather than recomputing the ms conversion inline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->