### PR TITLE
Frr version updates

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,9 @@ jobs:
             dpdk: '25.11'
             frr: '10.6'
           - compiler: gcc-14
+            dpdk: '25.11'
+            frr: '10.7'
+          - compiler: gcc-14
             dpdk: '25.11-head'
             frr: '10.5'
           - compiler: gcc-14

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,7 +17,7 @@ option(
 )
 
 option(
-  'frr_version', type: 'combo', choices: ['10.5', '10.6', 'master'], value: '10.5',
+  'frr_version', type: 'combo', choices: ['10.5', '10.6', '10.7', 'master'], value: '10.5',
   description: 'FRR version, defaults to 10.5.',
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,7 +17,7 @@ option(
 )
 
 option(
-  'frr_version', type: 'combo', choices: ['10.5', '10.6', '10.7', 'master'], value: '10.5',
+  'frr_version', type: 'combo', choices: ['10.5', '10.6', '10.7', 'master'], value: '10.6',
   description: 'FRR version, defaults to 10.5.',
 )
 

--- a/subprojects/frr-10.5.wrap
+++ b/subprojects/frr-10.5.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.5.3.tar.gz
-source_filename = frr-10.5.3.tar.gz
-source_hash = ecc95009b88e66df2c91be02fbf0a3eb8e1de434fd652e0cbf46f19126f708ec
-directory = frr-frr-10.5.3
+source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.5.4.tar.gz
+source_filename = frr-10.5.4.tar.gz
+source_hash = 1e8401e1bfcbb9b0dfefc9b335013733a3c77cdf85c79ff66d9e65167d9cfb1e
+directory = frr-frr-10.5.4
 patch_directory = frr
 
 [provide]

--- a/subprojects/frr-10.7.wrap
+++ b/subprojects/frr-10.7.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+source_url = https://github.com/FRRouting/frr/archive/refs/tags/frr-10.7.0.tar.gz
+source_filename = frr-10.7.0.tar.gz
+source_hash = 5c56b27756854b8d0a62b3e152d3f9ea08091851b2d686e140fdfb95cd88f612
+directory = frr-frr-10.7.0
+patch_directory = frr
+
+[provide]
+dependency_names = frr-10.7


### PR DESCRIPTION
Split from #642 to make reviewing easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Updates `subprojects/frr-10.5.wrap` FRRouting source metadata from `frr-10.5.3` to `frr-10.5.4` (source URL/filename, SHA-256, and extracted directory name).
- Extends CI `build-and-tests` matrix in `.github/workflows/check.yml` with a new entry: `compiler: gcc-14`, `dpdk: 25.11`, `frr: 10.7`.
- Updates `meson_options.txt` `frr_version` Meson option to add `10.7` to the version choices and change the default from `10.5` to `10.6` (while the option description text still references `10.5` as the default).
- Adds `subprojects/frr-10.7.wrap` with wrap/build metadata for FRRouting `10.7.0` (including `source_url`/hash, extracted directory, and `dependency_names = frr-10.7`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->