### PR TITLE
rpm: fix build without systemd

### DIFF
--- a/rpm/grout.spec
+++ b/rpm/grout.spec
@@ -161,7 +161,9 @@ rm -rf %{buildroot}%{_sysconfdir} %{buildroot}%{_unitdir}
 %doc README.md
 %license licenses/GPL-2.0-or-later.txt
 %attr(755, root, root) %{_libdir}/frr/modules/dplane_grout.so
+%if %{with systemd}
 %attr(644, root, root) %{_unitdir}/frr.service.d/grout.conf
+%endif
 %if %{with docs}
 %attr(644, root, root) %{_mandir}/man7/grout-frr.7*
 %endif


### PR DESCRIPTION
Fix the following error when building `--without=systemd`:

```
Processing files: grout-frr-0.16.1-20260720120706.local.el10.x86_64
error: File not found: /BUILDROOT/.../usr/lib/systemd/system/frr.service.d/grout.conf
```

Fixes: a6643d4302f5 ("frr: add systemd dropin to rpm/deb installed files")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Conditionally includes `%{_unitdir}/frr.service.d/grout.conf` in the RPM `%files frr` section of `rpm/grout.spec` only when `%{with systemd}` is enabled, fixing RPM builds with `--without=systemd` by avoiding the missing drop-in file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->