### PR TITLE
fdb: also program mac in hw when an entry is updated

### DIFF
--- a/modules/l2/api/gr_l2.h
+++ b/modules/l2/api/gr_l2.h
@@ -65,6 +65,7 @@ typedef enum : uint8_t {
 	GR_FDB_F_STATIC = GR_BIT8(0), // User-configured, never aged out.
 	GR_FDB_F_LEARN = GR_BIT8(1), // Learned via local bridge.
 	GR_FDB_F_EXTERN = GR_BIT8(2), // Programmed by external control plane.
+	GR_FDB_F_HW = GR_BIT8(3), // Mac address programmed in hardware filter.
 } gr_fdb_flags_t;
 
 // Forwarding database entry associating a MAC+VLAN to a bridge member interface.

--- a/modules/l2/cli/fdb.c
+++ b/modules/l2/cli/fdb.c
@@ -85,6 +85,8 @@ static size_t fdb_format_flags(char *buf, size_t len, gr_fdb_flags_t flags) {
 		SAFE_BUF(snprintf, len, "%sstatic", n ? " " : "");
 	if (flags & GR_FDB_F_EXTERN)
 		SAFE_BUF(snprintf, len, "%sextern", n ? " " : "");
+	if (flags & GR_FDB_F_HW)
+		SAFE_BUF(snprintf, len, "%shw", n ? " " : "");
 err:
 	return n;
 }
@@ -113,6 +115,8 @@ static cmd_status_t fdb_show(struct gr_api_client *c, const struct ec_pnode *p) 
 		req.flags |= GR_FDB_F_LEARN;
 	if (arg_str(p, "extern") != NULL)
 		req.flags |= GR_FDB_F_EXTERN;
+	if (arg_str(p, "hw") != NULL)
+		req.flags |= GR_FDB_F_HW;
 
 	struct gr_table *table = gr_table_new();
 	gr_table_column(table, "BRIDGE", GR_DISP_LEFT); // 0

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -256,6 +256,8 @@ static inline bool fdb_match(
 		return false;
 	if ((flags & GR_FDB_F_EXTERN) && !(e->flags & GR_FDB_F_EXTERN))
 		return false;
+	if ((flags & GR_FDB_F_HW) && !(e->flags & GR_FDB_F_HW))
+		return false;
 	if (bridge_id != GR_IFACE_ID_UNDEF && e->bridge_id != bridge_id)
 		return false;
 	if (iface_id != GR_IFACE_ID_UNDEF && e->iface_id != iface_id)
@@ -352,7 +354,8 @@ static void push_mac_to_hw(struct iface *iface, const struct rte_ether_addr *mac
 
 static void fdb_event_cb(uint32_t event, const void *obj) {
 	const struct iface_info_bridge *bridge_info;
-	const struct gr_fdb_entry *fdb = obj;
+	struct gr_fdb_entry *fdb = (void *)obj;
+	bool add = event != GR_EVENT_FDB_DEL;
 	const struct iface *bridge;
 
 	bridge = iface_from_id(fdb->bridge_id);
@@ -363,6 +366,10 @@ static void fdb_event_cb(uint32_t event, const void *obj) {
 
 	if ((fdb->flags & GR_FDB_F_EXTERN) == 0)
 		return;
+	if (add && (fdb->flags & GR_FDB_F_HW))
+		return;
+	if (!add && !(fdb->flags & GR_FDB_F_HW))
+		return;
 
 	bridge_info = iface_info_bridge(bridge);
 	for (unsigned i = 0; i < bridge_info->n_members; i++) {
@@ -370,11 +377,13 @@ static void fdb_event_cb(uint32_t event, const void *obj) {
 
 		// we have no clear idea what to do with a vlan_id if one got pushed by FRR
 		assert(fdb->vlan_id == 0);
-		// FIXME: ideally, we should ask for adding the mac in hw only when getting the
-		// *first* transition from !EXTERN to EXTERN to handle both learning mac on the
-		// wire and from FRR.
-		push_mac_to_hw(member, &fdb->mac, event != GR_EVENT_FDB_DEL);
+		push_mac_to_hw(member, &fdb->mac, add);
 	}
+
+	if (add)
+		fdb->flags |= GR_FDB_F_HW;
+	else
+		fdb->flags &= ~GR_FDB_F_HW;
 }
 
 void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool add) {
@@ -472,6 +481,7 @@ RTE_INIT(init) {
 	api_handler(GR_FDB_CONFIG_GET, fdb_config_get);
 	api_handler(GR_FDB_CONFIG_SET, fdb_config_set);
 	event_subscribe(GR_EVENT_FDB_ADD, fdb_event_cb);
+	event_subscribe(GR_EVENT_FDB_UPDATE, fdb_event_cb);
 	event_subscribe(GR_EVENT_FDB_DEL, fdb_event_cb);
 	event_serializer(GR_EVENT_FDB_ADD, NULL);
 	event_serializer(GR_EVENT_FDB_DEL, NULL);


### PR DESCRIPTION
When an FDB entry is create via regular local mac learning in a VXLAN port (via flood vteps), the associated address is *not* installed in the hardware filters because the entry does not have GR_FDB_F_EXTERN.

Later, when an EVPN type 2 route is exchanged via BGP, the FDB entry is *updated* (not created) and the GR_FDB_F_EXTERN flag is added.

But since fdb_event_cb only fires on creation and deletion, the hardware filter is never updated. Subscribe to GR_EVENT_FDB_UPDATE to fix this.

Fixes: 10be5b5883ce ("l2: push external mac addresses in hardware")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds `GR_FDB_F_HW` to `gr_fdb_flags_t` to mark MAC entries programmed into hardware. Extends `fdb_match` so flush/list requests can filter on `GR_FDB_F_HW`, and updates `fdb_event_cb` to subscribe to `GR_EVENT_FDB_UPDATE` and apply the same add/delete hardware programming path as existing events: it derives whether the update is an add or delete, early-returns when the entry’s current `GR_FDB_F_HW` already matches the requested transition, programs the MAC to bridge members when needed, and sets/clears `GR_FDB_F_HW` after the corresponding hardware add/delete. Also updates `modules/l2/cli/fdb.c` to render the `hw` flag and accept `fdb show hw` filtering based on `GR_FDB_F_HW`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->