### PR TITLE
l2: program all fdb entries in bridge ports

### DIFF
--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -364,8 +364,6 @@ static void fdb_event_cb(uint32_t event, const void *obj) {
 		return;
 	}
 
-	if ((fdb->flags & GR_FDB_F_EXTERN) == 0)
-		return;
 	if (add && (fdb->flags & GR_FDB_F_HW))
 		return;
 	if (!add && !(fdb->flags & GR_FDB_F_HW))
@@ -393,10 +391,11 @@ void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool ad
 	void *data;
 
 	while (rte_hash_iterate(fdb_hash, &key, &data, &next) >= 0) {
-		if (!fdb_match(data, GR_FDB_F_EXTERN, bridge->id, GR_IFACE_ID_UNDEF, NULL))
+		fdb = data;
+
+		if (fdb->bridge_id != bridge->id)
 			continue;
 
-		fdb = data;
 		// we have no clear idea what to do with a vlan_id if one got pushed by FRR
 		assert(fdb->vlan_id == 0);
 		push_mac_to_hw(member, &fdb->mac, add);


### PR DESCRIPTION
When a bridge member port is attached, it is set to promiscuous mode so that it can accept frames destined to any MAC behind the bridge. Some SR-IOV VF hardware only partially supports promiscuous mode: frames ingressing from the outside world (the physical network) are delivered to a promiscuous VF, but frames originating from another VF on the same physical function are only delivered if the destination MAC is explicitly present in the receiving VF's unicast MAC filter. In that case, MAC addresses must be explicitly added to the hardware filter list for inter-VF traffic to work.

fdb_event_cb and fdb_sync_hardware only push MAC addresses for entries carrying the GR_FDB_F_EXTERN flag. This was written with BGP EVPN in mind, where remote MACs are installed as EXTERN entries via type-2 routes from zebra. However, VXLAN L2VPN can also operate without BGP using static flood lists: remote VTEPs are configured manually and MAC learning happens entirely on the wire via flood-and-learn. In that mode, there is no external control plane and all FDB entries only carry GR_FDB_F_LEARN. None of these learned MACs ever get pushed to member port hardware filters.

Consider two hosts connected by a VXLAN tunnel with static flood lists, each running a bridge with a local VM behind a VF on the same physical function. When the remote VM sends a frame, grout decapsulates it and learns the source MAC in the bridge FDB. The local VM replies, and the bridge correctly forwards via FDB lookup to the VXLAN port. But when the next inbound frame arrives from the tunnel and needs to be delivered to the local VM's VF, the hardware silently drops it because the remote VM's MAC is not in the VF filter list and the frame originates from the VXLAN decap path on a sibling VF. Connectivity breaks silently.

Remove the GR_FDB_F_EXTERN restriction in fdb_event_cb so that all FDB entries (learned or extern) get programmed into bridge member port MAC filters. Also fix fdb_sync_hardware which has the same restriction and only syncs extern entries when a new member joins the bridge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Program L2 bridge hardware filters for all matching FDB entries, including learned MACs, instead of only `GR_FDB_F_EXTERN` entries.
- Update FDB event handling and bridge hardware synchronization to remove the external-entry restriction while retaining existing hardware add/remove flag gating.
- Ensure newly joined bridge members receive learned and externally installed MAC entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->