### PR TITLE
l2: do not push locally learnt mac to hardware

### DIFF
--- a/api/gr_api.h
+++ b/api/gr_api.h
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 
 // Must be bumped when making non-backward compatible changes in API headers
-#define GR_API_VERSION 4
+#define GR_API_VERSION 5
 
 // API request header.
 struct gr_api_request {

--- a/modules/l2/api/gr_l2.h
+++ b/modules/l2/api/gr_l2.h
@@ -65,7 +65,6 @@ typedef enum : uint8_t {
 	GR_FDB_F_STATIC = GR_BIT8(0), // User-configured, never aged out.
 	GR_FDB_F_LEARN = GR_BIT8(1), // Learned via local bridge.
 	GR_FDB_F_EXTERN = GR_BIT8(2), // Programmed by external control plane.
-	GR_FDB_F_HW = GR_BIT8(3), // Mac address programmed in hardware filter.
 } gr_fdb_flags_t;
 
 // Forwarding database entry associating a MAC+VLAN to a bridge member interface.

--- a/modules/l2/cli/fdb.c
+++ b/modules/l2/cli/fdb.c
@@ -85,8 +85,6 @@ static size_t fdb_format_flags(char *buf, size_t len, gr_fdb_flags_t flags) {
 		SAFE_BUF(snprintf, len, "%sstatic", n ? " " : "");
 	if (flags & GR_FDB_F_EXTERN)
 		SAFE_BUF(snprintf, len, "%sextern", n ? " " : "");
-	if (flags & GR_FDB_F_HW)
-		SAFE_BUF(snprintf, len, "%shw", n ? " " : "");
 err:
 	return n;
 }
@@ -115,8 +113,6 @@ static cmd_status_t fdb_show(struct gr_api_client *c, const struct ec_pnode *p) 
 		req.flags |= GR_FDB_F_LEARN;
 	if (arg_str(p, "extern") != NULL)
 		req.flags |= GR_FDB_F_EXTERN;
-	if (arg_str(p, "hw") != NULL)
-		req.flags |= GR_FDB_F_HW;
 
 	struct gr_table *table = gr_table_new();
 	gr_table_column(table, "BRIDGE", GR_DISP_LEFT); // 0

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -21,6 +21,11 @@ struct fdb_key {
 	struct rte_ether_addr mac;
 };
 
+struct fdb_entry {
+	BASE(gr_fdb_entry);
+	uint16_t prev_iface_id;
+};
+
 static unsigned fdb_max_entries;
 static struct rte_hash *fdb_hash;
 static struct rte_mempool *fdb_pool;
@@ -50,7 +55,7 @@ static int fdb_reconfig(unsigned max_entries) {
 	struct rte_mempool *p = rte_mempool_create(
 		name,
 		rte_align32pow2(max_entries) - 1,
-		sizeof(struct gr_fdb_entry),
+		sizeof(struct fdb_entry),
 		0, // cache size
 		0, // priv size
 		NULL, // mp_init
@@ -112,7 +117,7 @@ void fdb_learn(
 	const struct l3_addr *vtep
 ) {
 	const struct fdb_key key = {bridge_id, vlan_id, *mac};
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	void *data;
 
 	if (rte_hash_lookup_data(fdb_hash, &key, &data) < 0) {
@@ -120,6 +125,7 @@ void fdb_learn(
 			return; // pool exhausted
 
 		fdb = data;
+		fdb->prev_iface_id = GR_IFACE_ID_UNDEF;
 		fdb->bridge_id = bridge_id;
 		fdb->vlan_id = vlan_id;
 		fdb->mac = *mac;
@@ -143,6 +149,7 @@ void fdb_learn(
 	if ((fdb->flags & GR_FDB_F_LEARN)
 	    && (fdb->iface_id != iface_id || !l3_addr_eq(&fdb->vtep, vtep))) {
 		// update in case the mac address has moved
+		fdb->prev_iface_id = fdb->iface_id;
 		fdb->iface_id = iface_id;
 		fdb->vtep = *vtep;
 		event_push(GR_EVENT_FDB_UPDATE, fdb);
@@ -150,7 +157,7 @@ void fdb_learn(
 }
 
 void fdb_purge_iface(uint16_t iface_id) {
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	uint32_t next = 0;
 	const void *key;
 	void *data;
@@ -160,11 +167,14 @@ void fdb_purge_iface(uint16_t iface_id) {
 		if (fdb->iface_id == iface_id) {
 			rte_hash_del_key(fdb_hash, key);
 		}
+		if (fdb->prev_iface_id == iface_id) {
+			fdb->prev_iface_id = GR_IFACE_ID_UNDEF;
+		}
 	}
 }
 
 void fdb_purge_bridge(uint16_t bridge_id) {
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	uint32_t next = 0;
 	const void *key;
 	void *data;
@@ -180,7 +190,7 @@ void fdb_purge_bridge(uint16_t bridge_id) {
 static struct api_out fdb_add(const void *request, struct api_ctx *) {
 	const struct gr_fdb_add_req *req = request;
 	const struct iface *iface;
-	struct gr_fdb_entry *e;
+	struct fdb_entry *e;
 	void *data;
 	int ret;
 
@@ -205,7 +215,8 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 			return api_out(-ret, 0, NULL);
 
 		e = data;
-		*e = req->fdb;
+		e->prev_iface_id = GR_IFACE_ID_UNDEF;
+		e->base = req->fdb;
 		e->bridge_id = iface->id;
 		e->last_seen = gr_clock_ns();
 
@@ -217,7 +228,8 @@ static struct api_out fdb_add(const void *request, struct api_ctx *) {
 		event_push(GR_EVENT_FDB_ADD, e);
 	} else if (req->exist_ok) {
 		e = data;
-		*e = req->fdb;
+		e->prev_iface_id = e->iface_id;
+		e->base = req->fdb;
 		e->bridge_id = iface->id;
 		e->last_seen = gr_clock_ns();
 
@@ -286,7 +298,7 @@ static struct api_out fdb_flush(const void *request, struct api_ctx *) {
 
 static struct api_out fdb_list(const void *request, struct api_ctx *ctx) {
 	const struct gr_fdb_list_req *req = request;
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	uint32_t next = 0;
 	const void *key;
 	void *data;
@@ -296,7 +308,7 @@ static struct api_out fdb_list(const void *request, struct api_ctx *ctx) {
 			continue;
 
 		fdb = data;
-		api_send(ctx, sizeof(*fdb), fdb);
+		api_send(ctx, sizeof(fdb->base), fdb);
 	}
 
 	return api_out(0, 0, NULL);
@@ -352,8 +364,9 @@ static void push_mac_to_hw(struct iface *iface, const struct rte_ether_addr *mac
 
 static void fdb_event_cb(uint32_t event, const void *obj) {
 	const struct iface_info_bridge *bridge_info;
-	const struct gr_fdb_entry *fdb = obj;
+	const struct fdb_entry *fdb = obj;
 	const struct iface *bridge;
+	struct iface *member;
 
 	bridge = iface_from_id(fdb->bridge_id);
 	if (bridge == NULL) {
@@ -361,22 +374,36 @@ static void fdb_event_cb(uint32_t event, const void *obj) {
 		return;
 	}
 
+	// we have no clear idea what to do with a vlan_id if one got pushed by FRR
+	assert(fdb->vlan_id == 0);
+
+	if (event == GR_EVENT_FDB_UPDATE) {
+		if (fdb->prev_iface_id == fdb->iface_id)
+			return;
+
+		member = iface_from_id(fdb->prev_iface_id);
+		if (member != NULL)
+			push_mac_to_hw(member, &fdb->mac, true);
+		member = iface_from_id(fdb->iface_id);
+		if (member != NULL)
+			push_mac_to_hw(member, &fdb->mac, false);
+		return;
+	}
+
 	bridge_info = iface_info_bridge(bridge);
 	for (unsigned i = 0; i < bridge_info->n_members; i++) {
-		struct iface *member = bridge_info->members[i];
+		member = bridge_info->members[i];
 
 		// skip the interface where the MAC was learned
 		if (member->id == fdb->iface_id)
 			continue;
 
-		// we have no clear idea what to do with a vlan_id if one got pushed by FRR
-		assert(fdb->vlan_id == 0);
 		push_mac_to_hw(member, &fdb->mac, event != GR_EVENT_FDB_DEL);
 	}
 }
 
 void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool add) {
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	uint32_t next = 0;
 	const void *key;
 	void *data;
@@ -398,7 +425,7 @@ void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool ad
 
 static void fdb_ageing_cb(evutil_socket_t, short /*what*/, void * /*priv*/) {
 	const struct iface *bridge;
-	struct gr_fdb_entry *fdb;
+	struct fdb_entry *fdb;
 	gr_clock_ns_t now;
 	uint32_t next = 0;
 	uint16_t max_age;
@@ -475,6 +502,7 @@ RTE_INIT(init) {
 	api_handler(GR_FDB_CONFIG_SET, fdb_config_set);
 	event_subscribe(GR_EVENT_FDB_ADD, fdb_event_cb);
 	event_subscribe(GR_EVENT_FDB_DEL, fdb_event_cb);
+	event_subscribe(GR_EVENT_FDB_UPDATE, fdb_event_cb);
 	event_serializer(GR_EVENT_FDB_ADD, NULL);
 	event_serializer(GR_EVENT_FDB_DEL, NULL);
 	event_serializer(GR_EVENT_FDB_UPDATE, NULL);

--- a/modules/l2/control/fdb.c
+++ b/modules/l2/control/fdb.c
@@ -256,8 +256,6 @@ static inline bool fdb_match(
 		return false;
 	if ((flags & GR_FDB_F_EXTERN) && !(e->flags & GR_FDB_F_EXTERN))
 		return false;
-	if ((flags & GR_FDB_F_HW) && !(e->flags & GR_FDB_F_HW))
-		return false;
 	if (bridge_id != GR_IFACE_ID_UNDEF && e->bridge_id != bridge_id)
 		return false;
 	if (iface_id != GR_IFACE_ID_UNDEF && e->iface_id != iface_id)
@@ -354,8 +352,7 @@ static void push_mac_to_hw(struct iface *iface, const struct rte_ether_addr *mac
 
 static void fdb_event_cb(uint32_t event, const void *obj) {
 	const struct iface_info_bridge *bridge_info;
-	struct gr_fdb_entry *fdb = (void *)obj;
-	bool add = event != GR_EVENT_FDB_DEL;
+	const struct gr_fdb_entry *fdb = obj;
 	const struct iface *bridge;
 
 	bridge = iface_from_id(fdb->bridge_id);
@@ -364,24 +361,18 @@ static void fdb_event_cb(uint32_t event, const void *obj) {
 		return;
 	}
 
-	if (add && (fdb->flags & GR_FDB_F_HW))
-		return;
-	if (!add && !(fdb->flags & GR_FDB_F_HW))
-		return;
-
 	bridge_info = iface_info_bridge(bridge);
 	for (unsigned i = 0; i < bridge_info->n_members; i++) {
 		struct iface *member = bridge_info->members[i];
 
+		// skip the interface where the MAC was learned
+		if (member->id == fdb->iface_id)
+			continue;
+
 		// we have no clear idea what to do with a vlan_id if one got pushed by FRR
 		assert(fdb->vlan_id == 0);
-		push_mac_to_hw(member, &fdb->mac, add);
+		push_mac_to_hw(member, &fdb->mac, event != GR_EVENT_FDB_DEL);
 	}
-
-	if (add)
-		fdb->flags |= GR_FDB_F_HW;
-	else
-		fdb->flags &= ~GR_FDB_F_HW;
 }
 
 void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool add) {
@@ -394,6 +385,9 @@ void fdb_sync_hardware(const struct iface *bridge, struct iface *member, bool ad
 		fdb = data;
 
 		if (fdb->bridge_id != bridge->id)
+			continue;
+		// skip the interface where the MAC was learned
+		if (member->id == fdb->iface_id)
 			continue;
 
 		// we have no clear idea what to do with a vlan_id if one got pushed by FRR
@@ -480,7 +474,6 @@ RTE_INIT(init) {
 	api_handler(GR_FDB_CONFIG_GET, fdb_config_get);
 	api_handler(GR_FDB_CONFIG_SET, fdb_config_set);
 	event_subscribe(GR_EVENT_FDB_ADD, fdb_event_cb);
-	event_subscribe(GR_EVENT_FDB_UPDATE, fdb_event_cb);
 	event_subscribe(GR_EVENT_FDB_DEL, fdb_event_cb);
 	event_serializer(GR_EVENT_FDB_ADD, NULL);
 	event_serializer(GR_EVENT_FDB_DEL, NULL);


### PR DESCRIPTION
Avoid pushing back mac addresses coming from the same iface. This is unneeded and may confuse some NICs.

With this approach, pushing mac to hardware becomes way simpler: a decapsulated packet mac address coming from a VXLAN iface simply has to be pushed to all members of the bridge, when it is first learnt.

Similarly, a mac address learnt by external means (FRR) can be pushed to all but the originating interface.

If we had a setup with a bridge with two member ifaces backed by two separate NICs, a mac address learnt from an interface belonging to the first NIC will be pushed to the interface backed by the second NIC.

As a consequence of this approach, we don't need to listen to FDB updates. The GR_FDB_F_HW flag becomes unneeded since only add/del ops matter.

Fixes: a4c609a5a5ac ("l2: program all fdb entries in bridge ports")
Fixes: 3f6447663762 ("fdb: fix missing mac in hw when an entry is updated")
Fixes: 10be5b5883ce ("l2: push external mac addresses in hardware")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Removed `GR_FDB_F_HW` from `gr_fdb_flags_t` (`modules/l2/api/gr_l2.h`) and updated CLI/view handling so `fdb_format_flags()` and `fdb show` no longer format or parse an `"hw"` flag (`modules/l2/cli/fdb.c`).
- Reworked L2 FDB control-plane state in `modules/l2/control/fdb.c` by wrapping `gr_fdb_entry` in an internal `struct fdb_entry` that tracks `prev_iface_id` for learned MACs whose learned interface (`iface_id`) changes.
- Updated `fdb_event_cb` to treat events as `const struct fdb_entry *`, remove all `GR_FDB_F_HW`-based gating, and program bridge members by skipping the learned/originating interface (`member->id == fdb->iface_id`).
  - For `GR_EVENT_FDB_ADD`/`GR_EVENT_FDB_DEL`: add/delete the MAC across all bridge members except the learned/originating interface.
  - For `GR_EVENT_FDB_UPDATE`: use `prev_iface_id` to delete from the newly learned interface and add to the previously learned interface, reflecting a MAC move between interfaces.
- Updated `fdb_match()` to no longer filter based on `GR_FDB_F_HW`, and updated `fdb_sync_hardware()` to no longer depend on `GR_FDB_F_HW` state and to also skip pushing updates to the learned/originating interface.
- Adjusted event subscription ordering at `RTE_INIT` so `GR_EVENT_FDB_DEL` is subscribed before `GR_EVENT_FDB_UPDATE`.
- Bumped `GR_API_VERSION` from `4` to `5` in `api/gr_api.h`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->