### PR TITLE
frr: fix compile error with frr master

### DIFF
--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -292,28 +292,33 @@ dispatch:
 // to call before injecting a new marker (covers an interrupted
 // previous reconnect) or after observation (cosmetic cleanup).
 static void grout_sync_cleanup_marker(void) {
-#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
 	rib_meta_queue_early_route_cleanup(
-		&grout_sync_marker_prefix, AFI_IP6, SAFI_UNICAST, VRF_DEFAULT, ZEBRA_ROUTE_SHARP
-	);
-#else
-	rib_meta_queue_early_route_cleanup(&grout_sync_marker_prefix, ZEBRA_ROUTE_SHARP);
+		&grout_sync_marker_prefix,
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 6, 0)
+		AFI_IP6,
+		SAFI_UNICAST,
+		VRF_DEFAULT,
 #endif
+#if CURRENT_FRR_VERSION >= MAKE_FRRVERSION(10, 8, 0)
+		RT_TABLE_MAIN,
+#endif
+		ZEBRA_ROUTE_SHARP
+	);
 	rib_delete(
 		AFI_IP6,
 		SAFI_UNICAST,
 		VRF_DEFAULT,
 		ZEBRA_ROUTE_SHARP,
-		0,
-		0,
+		0, // instance
+		0, // flags
 		&grout_sync_marker_prefix,
-		NULL,
-		NULL,
-		0,
-		0,
-		0,
-		0,
-		false
+		NULL, // src_p
+		NULL, // nh
+		0, // nhe_id
+		RT_TABLE_MAIN,
+		0, // metric
+		DISTANCE_INFINITY,
+		false // fromkernel
 	);
 }
 
@@ -343,12 +348,12 @@ static void grout_sync_inject_marker(void) {
 	re = zebra_rib_route_entry_new(
 		VRF_DEFAULT,
 		ZEBRA_ROUTE_SHARP,
-		0,
-		0,
-		0,
-		0,
-		0,
-		0,
+		0, // instance
+		0, // flags
+		0, // nhe_id
+		RT_TABLE_MAIN,
+		0, // metric
+		0, // mtu
 		DISTANCE_INFINITY,
 		GROUT_SYNC_MARKER_TAG
 	);


### PR DESCRIPTION
The rib_meta_queue_early_route_cleanup FRR function got a new table argument. Pass RT_TABLE_MAIN to fix the build error.

Link: https://github.com/FRRouting/frr/commit/50ed71b6d7dd1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updates `frr/zebra_dplane_grout.c` to match FRR master API changes and fix the resulting compilation error by adjusting `rib_meta_queue_early_route_cleanup()` call arguments in `grout_sync_cleanup_marker()` to be version-gated: include the AFI/SAFI/VRF tuple when `CURRENT_FRR_VERSION >= 10.6.0`, include `RT_TABLE_MAIN` when `CURRENT_FRR_VERSION >= 10.8.0`, and consistently pass the marker prefix and `ZEBRA_ROUTE_SHARP`. Also updates the same cleanup path’s `rib_delete()` call to pass explicit values for route-table and distance (e.g., `RT_TABLE_MAIN` and `DISTANCE_INFINITY`) instead of the prior placeholder argument sequence. Separately, updates `grout_sync_inject_marker()` so `zebra_rib_route_entry_new()` is called with an expanded, explicit `RT_TABLE_MAIN`/field argument sequence (and matching trailing parameters) to align with the newer FRR API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->