### PR TITLE
bond: send GARP when active-backup member changes

### DIFF
--- a/modules/infra/control/bond.c
+++ b/modules/infra/control/bond.c
@@ -239,6 +239,7 @@ static int bond_detach_member(struct iface *iface, struct iface *member) {
 
 void bond_update_active_members(struct iface *iface) {
 	struct iface_info_bond *bond = iface_info_bond(iface);
+	uint8_t prev_active = bond->active_member;
 	const struct iface *member;
 	uint8_t *active_ids = NULL;
 	uint32_t speed = 0;
@@ -323,6 +324,11 @@ void bond_update_active_members(struct iface *iface) {
 			if (iface->flags & GR_IFACE_F_UP) {
 				event_push(GR_EVENT_IFACE_STATUS_UP, iface);
 			}
+		} else if (bond->active_member != prev_active) {
+			// Active member changed while already running.
+			// Re-announce addresses so that upstream L2 tables
+			// (bridges, switches) learn the new forwarding port.
+			event_push(GR_EVENT_IFACE_STATUS_UP, iface);
 		}
 	} else {
 		memset(bond->redirection_table, UINT8_MAX, sizeof(bond->redirection_table));


### PR DESCRIPTION
When the active member changes in active-backup mode while the bond is already in RUNNING state (e.g. primary member coming back up after a failover), no GR_EVENT_IFACE_STATUS_UP event was pushed. This event triggers gratuitous ARP announcements for all addresses on the bond interface.

Without the GARP, upstream bridges and switches keep forwarding unicast traffic to the old active member port. Since active-backup mode drops all incoming packets on non-active members, this creates a deadlock: traffic never reaches the new active member, so the upstream L2 forwarding table never gets updated.

Push GR_EVENT_IFACE_STATUS_UP when the active member index changes while the bond is already running, so that the GARP goes out through the new active member and upstream L2 tables are refreshed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Emit `GR_EVENT_IFACE_STATUS_UP` when an active-backup bond’s active member changes while already running.
- Trigger gratuitous ARP announcements through the new active member to refresh upstream forwarding tables after failover or recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->