### PR TITLE
frr: sync nexthop groups from grout on startup

### DIFF
--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -905,6 +905,32 @@ enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx) {
 	return grout_add_nexthop(nh_id, origin, dplane_ctx_get_nhe_ng(ctx)->nexthop);
 }
 
+void grout_nexthop_group_add(struct gr_nexthop *gr_nh, bool startup) {
+	const struct gr_nexthop_info_group *g = (const struct gr_nexthop_info_group *)gr_nh->info;
+	struct nh_grp grp[g->n_members];
+	int type;
+
+	gr_log_debug("add group nh_id %u n_members %u", gr_nh->nh_id, g->n_members);
+
+	for (uint32_t i = 0; i < g->n_members; i++) {
+		grp[i].id = g->members[i].nh_id;
+		grp[i].weight = g->members[i].weight;
+	}
+
+	type = origin2zebra(gr_nh->origin, AF_UNSPEC, true);
+	zebra_nhg_kernel_find(
+		gr_nh->nh_id,
+		NULL,
+		grp,
+		g->n_members,
+		vrf_grout_to_frr(gr_nh->vrf_id),
+		AFI_UNSPEC,
+		type,
+		startup,
+		NULL
+	);
+}
+
 void grout_nexthop_change(bool new, struct gr_nexthop *gr_nh, bool startup) {
 	struct nexthop *nh = NULL;
 	afi_t afi = AFI_UNSPEC;

--- a/frr/rt_grout.h
+++ b/frr/rt_grout.h
@@ -14,6 +14,7 @@ void grout_route6_change(bool new, struct gr_ip6_route *gr_r6, bool startup);
 enum zebra_dplane_result grout_add_del_route(struct zebra_dplane_ctx *ctx);
 enum zebra_dplane_result grout_add_del_nexthop(struct zebra_dplane_ctx *ctx);
 void grout_nexthop_change(bool new, struct gr_nexthop *gr_nh, bool startup);
+void grout_nexthop_group_add(struct gr_nexthop *gr_nh, bool startup);
 
 void grout_macfdb_change(const struct gr_fdb_entry *fdb, bool new);
 enum zebra_dplane_result grout_macfdb_update_ctx(struct zebra_dplane_ctx *ctx);

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -455,44 +455,28 @@ err:
 	event_add_timer(zrouter.master, grout_reconnect, NULL, 1, &grout_ctx.dg_t_zebra_sync);
 }
 
-static void grout_sync_nhs(struct event *e) {
+static void grout_sync_nh_groups(struct event *) {
 	struct gr_nh_list_req nh_req = {
-		.vrf_id = EVENT_VAL(e), .type = GR_NH_T_ALL, .include_internal = false
+		.vrf_id = GR_VRF_ID_UNDEF, .type = GR_NH_T_GROUP, .include_internal = false
 	};
 	struct gr_nexthop *nh;
 	int ret;
 
-	gr_log_info("vrf %u", EVENT_VAL(e));
-
+	// Groups have vrf_id=GR_VRF_ID_UNDEF in grout, query once for all.
 	gr_api_client_stream_foreach (
 		nh, ret, grout_ctx.sync_client, GR_NH_LIST, sizeof(nh_req), &nh_req
 	) {
-		grout_nexthop_change(true, nh, true);
+		grout_nexthop_group_add(nh, true);
 	}
 	if (ret < 0) {
-		gr_log_err("GR_NH_LIST: %s", strerror(errno));
+		gr_log_err("GR_NH_LIST (groups): %s", strerror(errno));
 		event_add_timer(
 			zrouter.master, grout_reconnect, NULL, 1, &grout_ctx.dg_t_zebra_sync
 		);
 		return;
 	}
 
-	// Pass 2 (this VRF done): chain to nhs of next VRF.
-	// All NHs across all VRFs are registered before any route is
-	// injected so cross-VRF NH references (e.g. SR6_LOCAL with
-	// out_vrf in a different VRF than the prefix being matched)
-	// resolve at route inject time.
-	for (unsigned int i = EVENT_VAL(e) + 1; i < GR_MAX_IFACES; i++) {
-		if (bf_test_index(grout_ctx.sync_vrf, i)) {
-			event_add_event(
-				zrouter.master, grout_sync_nhs, NULL, i, &grout_ctx.dg_t_zebra_sync
-			);
-			return;
-		}
-	}
-
-	// Pass 2 done across all VRFs. Kick off Pass 3 (routes) starting
-	// from the first VRF.
+	// Kick off routes starting from the first VRF.
 	for (unsigned int i = 0; i < GR_MAX_IFACES; i++) {
 		if (bf_test_index(grout_ctx.sync_vrf, i)) {
 			event_add_event(
@@ -505,6 +489,46 @@ static void grout_sync_nhs(struct event *e) {
 			return;
 		}
 	}
+}
+
+static void grout_sync_nhs(struct event *e) {
+	struct gr_nh_list_req nh_req = {
+		.vrf_id = EVENT_VAL(e), .type = GR_NH_T_ALL, .include_internal = false
+	};
+	struct gr_nexthop *nh;
+	int ret;
+
+	gr_log_info("vrf %u", EVENT_VAL(e));
+
+	gr_api_client_stream_foreach (
+		nh, ret, grout_ctx.sync_client, GR_NH_LIST, sizeof(nh_req), &nh_req
+	) {
+		if (nh->type != GR_NH_T_GROUP)
+			grout_nexthop_change(true, nh, true);
+	}
+	if (ret < 0) {
+		gr_log_err("GR_NH_LIST: %s", strerror(errno));
+		event_add_timer(
+			zrouter.master, grout_reconnect, NULL, 1, &grout_ctx.dg_t_zebra_sync
+		);
+		return;
+	}
+
+	// Chain to individual NHs of next VRF. All individual NHs across
+	// all VRFs must be registered before groups, so that group member
+	// references resolve.
+	for (unsigned int i = EVENT_VAL(e) + 1; i < GR_MAX_IFACES; i++) {
+		if (bf_test_index(grout_ctx.sync_vrf, i)) {
+			event_add_event(
+				zrouter.master, grout_sync_nhs, NULL, i, &grout_ctx.dg_t_zebra_sync
+			);
+			return;
+		}
+	}
+
+	// Individual NHs done across all VRFs. Sync NH groups (global, not
+	// per-VRF) so that group member references resolve before routes.
+	event_add_event(zrouter.master, grout_sync_nh_groups, NULL, 0, &grout_ctx.dg_t_zebra_sync);
 }
 
 static void grout_sync_addrs(struct event *e) {


### PR DESCRIPTION
Recent FRR versions wrap every singleton nexthop in a nexthop group. Routes reference the group nh_id rather than the underlying L3 nexthop directly. When zebra restarts and the plugin re-reads routes from grout, those routes carry the group nh_id. If the group is not registered in zebra's NHG hash table, rib_sweep_route fails to resolve it and the orphan route is never purged.

The startup sync was not registering group nexthops at all. Individual NHs were synced per-VRF via grout_sync_nhs/grout_nexthop_change, but groups were silently skipped because grout_gr_nexthop_to_frr_nexthop only produced a dummy entry for them.

Split the NH sync into two passes: first individual nexthops (per-VRF, as before), then a single global pass for groups via the new grout_nexthop_group_add function which builds a proper struct nh_grp array and calls zebra_nhg_kernel_find. Groups must come second because they reference member nh_ids that must already exist in zebra's hash table. Groups are not per-VRF in grout (they have vrf_id=UNDEF), so the group pass queries once with GR_VRF_ID_UNDEF.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added startup nexthop-group registration via `grout_nexthop_group_add(struct gr_nexthop *gr_nh, bool startup)` (declared in `frr/rt_grout.h`, implemented in `frr/rt_grout.c`).
  - Interprets `gr_nh->info` as a group nexthop payload (`gr_nexthop_info_group`) and builds a local `struct nh_grp grp[g->n_members]` from member nexthop IDs plus weights.
  - Derives the Zebra NHG `type` using `origin2zebra(gr_nh->origin, AF_UNSPEC, true)` (address-family handling kept as `UNSPEC` rather than reduced to IP).
  - Converts the grout VRF to FRR VRF (`vrf_grout_to_frr()`) and installs/registers the group with `zebra_nhg_kernel_find(..., startup, ...)` using the assembled member list.

- Split startup synchronization into two phases in `frr/zebra_dplane_grout.c`:
  1. Per-VRF pass registers individual nexthops only by skipping entries with type `GR_NH_T_GROUP` in `grout_sync_nhs`.
  2. Global pass (`grout_sync_nh_groups`) streams group nexthops once using `.vrf_id = GR_VRF_ID_UNDEF` (group entries referencing member IDs) and registers each group, then starts route synchronization after the group pass.

- Routes referencing group IDs are resolved correctly by ensuring group NHGs are registered only after their member nexthop IDs already exist in Zebra’s nexthop hash table; route sync starts after the group pass to avoid orphan routes across Zebra restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->