### PR TITLE
srv6: resolve nexthop groups in sr6_output

### DIFF
--- a/modules/srv6/datapath/srv6_output.c
+++ b/modules/srv6/datapath/srv6_output.c
@@ -6,6 +6,7 @@
 #include "ip6.h"
 #include "ip6_datapath.h"
 #include "l3.h"
+#include "nexthop.h"
 #include "srv6.h"
 
 #include <gr_srv6.h>
@@ -134,6 +135,13 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		if (nh == NULL) {
 			edge = NO_ROUTE;
 			goto next;
+		}
+		if (nh->type == GR_NH_T_GROUP) {
+			nh = nexthop_group_get_nh(nexthop_info_group(nh), m->hash.rss);
+			if (nh == NULL) {
+				edge = NO_ROUTE;
+				goto next;
+			}
 		}
 		l3_mbuf_data(m)->nh = nh;
 


### PR DESCRIPTION
When FRR wraps every nexthop in a group, fib6_lookup returns a group nexthop instead of the underlying L3 nexthop. In sr6_output, the secondary FIB lookup for the SID prefix is followed by a call to sr_tunsrc_get which reads nh->iface_id directly. Group nexthops have iface_id set to GR_IFACE_ID_UNDEF, causing sr_tunsrc_get to fail and dropping the packet at sr6_source_no_route.

Resolve the group to its member nexthop right after the fib6_lookup so that subsequent field accesses see the actual L3 nexthop.