### PR TITLE
arp: only reply for IPs owned by the receiving iface

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,7 +83,7 @@ jobs:
             make gcc gdb ccache ninja-build meson git scdoc inotify-tools \
             libibverbs-dev libasan8 libcmocka-dev libedit-dev libarchive-dev \
             libevent-dev libmnl-dev libnuma-dev python3-pyelftools \
-            socat tcpdump traceroute graphviz iproute2 iputils-ping ndisc6 jq \
+            socat tcpdump traceroute graphviz iproute2 iputils-ping iputils-arping ndisc6 jq \
             dnsmasq systemd-coredump abigail-tools \
             "linux-modules-extra-$(uname -r)"
           # FRR dependencies

--- a/README.md
+++ b/README.md
@@ -287,13 +287,13 @@ In order to run the `smoke-tests`, `lint`, `check-patches` and `update-graph`
 targets, you'll need additional packages:
 
 ```sh
-dnf install gawk gdb clang-tools-extra jq codespell curl traceroute graphviz ndisc6 abidiff inotify-tools
+dnf install gawk gdb clang-tools-extra jq codespell curl traceroute graphviz ndisc6 iputils abidiff inotify-tools
 ```
 
 or
 
 ```sh
-apt install gawk gdb clang-format jq codespell curl traceroute graphviz ndisc6 abigail-tools inotify-tools
+apt install gawk gdb clang-format jq codespell curl traceroute graphviz ndisc6 iputils-arping abigail-tools inotify-tools
 ```
 
 ### Build

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -195,17 +195,25 @@ void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	}
 
 	if (arp->arp_opcode == RTE_BE16(RTE_ARP_OP_REQUEST)) {
-		// send a reply for our local ip
+		// Reply only if the target is a local address on this iface.
+		// Sender learning above still applies when we skip the reply.
 		struct nexthop *local = nh4_lookup(iface->vrf_id, arp->arp_data.arp_tip);
-		struct arp_reply_mbuf_data *d = arp_reply_mbuf_data(m);
-		d->local = local;
-		d->iface = iface;
-		if (post_to_stack(arp_output_reply_node, m) < 0) {
-			LOG(ERR, "post_to_stack: %s", strerror(errno));
-			goto free;
+		const struct nexthop_info_l3 *local_l3;
+
+		if (local != NULL) {
+			local_l3 = nexthop_info_l3(local);
+			if ((local_l3->flags & GR_NH_F_LOCAL) && local->iface_id == iface->id) {
+				struct arp_reply_mbuf_data *d = arp_reply_mbuf_data(m);
+				d->local = local;
+				d->iface = iface;
+				if (post_to_stack(arp_output_reply_node, m) < 0) {
+					LOG(ERR, "post_to_stack: %s", strerror(errno));
+					goto free;
+				}
+				// prevent double free, mbuf has been re-consumed by datapath
+				m = NULL;
+			}
 		}
-		// prevent double free, mbuf has been re-consumed by datapath
-		m = NULL;
 	}
 
 	// Flush all held packets.

--- a/modules/ip/datapath/arp_input_request.c
+++ b/modules/ip/datapath/arp_input_request.c
@@ -45,8 +45,12 @@ static uint16_t arp_input_request_process(
 			goto next;
 		}
 		l3 = nexthop_info_l3(local);
-		if (!(l3->flags & GR_NH_F_LOCAL)) {
-			// ARP request not for us
+		// Only reply for addresses configured on the receiving interface.
+		// nh4_lookup is VRF-wide, so without this check a dual-homed
+		// router with several ports on the same L2 would answer ARP for
+		// one interface's IP using another interface's MAC.
+		if (!(l3->flags & GR_NH_F_LOCAL) || local->iface_id != iface->id) {
+			// ARP request not for an address on this interface
 			edge = DROP;
 			goto next;
 		}

--- a/smoke/arp_iface_scope_test.sh
+++ b/smoke/arp_iface_scope_test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Two grout ports share one L2 domain (Linux bridge) with distinct IPs.
+# ARP replies must use the MAC of the interface that owns the target IP.
+# Regression for dual-VF / same-VLAN topologies where a VRF-wide local-IP
+# lookup would otherwise answer with the wrong interface MAC.
+
+. $(dirname $0)/_init.sh
+
+command -v arping || fail "arping (from iputils-arping / iputils) is not installed"
+
+port_add p0
+port_add p1
+
+ip link add name br-arp type bridge
+ip link set br-arp up
+ip link set x-p0 master br-arp
+ip link set x-p1 master br-arp
+ip link set x-p0 up
+ip link set x-p1 up
+
+grcli address add 172.16.21.1/28 iface p0
+grcli address add 172.16.21.19/28 iface p1
+
+mac0=$(grcli -j mac show iface p0 | jq -r '.[] | select(.primary == true) | .mac')
+mac1=$(grcli -j mac show iface p1 | jq -r '.[] | select(.primary == true) | .mac')
+[ -n "$mac0" ] && [ -n "$mac1" ] || fail "failed to read primary MACs"
+[ "$mac0" != "$mac1" ] || fail "expected distinct MACs on p0 and p1"
+
+netns_add peer
+ip link add veth-peer type veth peer name veth-br
+ip link set veth-br master br-arp
+ip link set veth-br up
+ip link set veth-peer netns peer
+ip -n peer link set lo up
+ip -n peer link set veth-peer up
+ip -n peer addr add 172.16.21.10/28 dev veth-peer
+
+# Happy path: each IP resolves to the owning interface MAC.
+reply=$(ip netns exec peer arping -c1 -w2 -I veth-peer 172.16.21.1) \
+	|| fail "ARP for p0 address failed"
+echo "$reply" | grep -qi "$mac0" || fail "ARP for .1 did not return p0 MAC $mac0"
+echo "$reply" | grep -qi "$mac1" && fail "ARP for .1 incorrectly returned p1 MAC $mac1"
+
+reply=$(ip netns exec peer arping -c1 -w2 -I veth-peer 172.16.21.19) \
+	|| fail "ARP for p1 address failed"
+echo "$reply" | grep -qi "$mac1" || fail "ARP for .19 did not return p1 MAC $mac1"
+echo "$reply" | grep -qi "$mac0" && fail "ARP for .19 incorrectly returned p0 MAC $mac0"
+
+# With p0 down, p1 must not answer ARP for p0's address.
+grcli interface set port p0 down
+if ip netns exec peer arping -c3 -w1 -I veth-peer 172.16.21.1; then
+	fail "got ARP reply for p0 address while p0 was down (p1 must not reply)"
+fi
+
+grcli interface set port p0 up
+# Allow the port to come back before retrying.
+sleep 0.5
+ip netns exec peer arping -c1 -w2 -I veth-peer 172.16.21.1 \
+	|| fail "ARP for p0 address failed after p0 up"
+
+# Symmetrically: with p1 down, p0 must not answer for p1's address.
+grcli interface set port p1 down
+if ip netns exec peer arping -c3 -w1 -I veth-peer 172.16.21.19; then
+	fail "got ARP reply for p1 address while p1 was down (p0 must not reply)"
+fi
+
+grcli interface set port p1 up
+sleep 0.5
+ip netns exec peer arping -c1 -w2 -I veth-peer 172.16.21.19 \
+	|| fail "ARP for p1 address failed after p1 up"


### PR DESCRIPTION
We have the following test scenario where, because of resource limitations, we have to split a network (/24) in two subnets (/28), representing two different networks but in the same VLAN.

Here's a diagram of the scenario:


```
                       VLAN 3801 (grout-test-net1)          VLAN 3802 (grout-test-net2)
                       172.16.16.0/24                       SAME L2 — two /28s carved on it
                       ============================         =====================================
                                                            172.16.21.0/28   |  172.16.21.16/28
                                                            (east LAN)       |  (interconnect)
                                                            -----------------+------------------
grout-west-endpoint                    grout-west-router                 grout-east-router                grout-east-endpoint
-------------------                    -----------------                 -----------------                -------------------
net1 VF                                net1 VF          net2 VF          net1 VF          net2 VF         net1 VF
172.16.16.10/24                        172.16.16.1/24   172.16.21.18/28  172.16.21.1/28   172.16.21.19/28 172.16.21.10/28
MAC :16:10                             MAC :16:01       MAC :21:18       MAC :21:01       MAC :21:19      MAC :21:10
     |                                      |                |                |                |               |
     +--------------------------------------+                |                |                |               |
            west LAN (VLAN 3801)                             |                |                |               |
                                                             +----------------+----------------+---------------+
                                                                        east LAN + interconnect
                                                                        (VLAN 3802 — one broadcast domain)
                                                                        PF ens7f0, VFs 8-15
IP routes:
  west-endpoint:  0.0.0.0/0          via 172.16.16.1
  east-endpoint:  0.0.0.0/0          via 172.16.21.1
  west-router:    172.16.21.0/28     via 172.16.21.19   (east-router.net2)
  east-router:    172.16.16.0/24     via 172.16.21.18   (west-router.net2)
```

Based on this, we're finding a problem. When several grout ports share one L2 domain (e.g. two SR-IOV VFs on the same VLAN), an ARP request for a local IP can be received on any of those ports:

```
Bug on VLAN 3802:
  ARP who-has 172.16.21.1  ----flooded to BOTH east-router VFs---->
       p0 (:21:01) owns .1  -> reply  .1 is-at :21:01   (correct)
       p1 (:21:19) sees .1  -> reply  .1 is-at :21:19   (wrong, before fix)
East-router is the problem node: two VFs, one VLAN, two IPv4 subnets.
```

Lookup was VRF-wide and only checked `GR_NH_F_LOCAL`, so a port that does not own the target IP could still reply using its own MAC. That produced wrong neighbor bindings and intermittent one-way ping failures.

This change scopes ARP replies to addresses configured on the receiving interface (`local->iface_id == iface->id`), in both `arp_input_request` and `arp_probe_input_cb`, matching the existing IPv6 NDP behavior. A smoke test covers two ports on a shared Linux bridge, and CI/docs gain the `arping` dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restrict ARP replies to local nexthops configured on the receiving interface in both request and probe handling.
- Add a regression smoke test for two ports sharing an L2 bridge, including interface-down scenarios.
- Add `arping` dependencies to CI and development setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->