### PR TITLE
Fix spurious logs related to control plane representors

### DIFF
--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -409,7 +409,7 @@ err:
 static void cp_set_vrf_master(const struct iface *iface) {
 	uint32_t master = 0; // default VRF has no kernel master: leave TAP standalone
 
-	if (iface->vrf_id != GR_VRF_DEFAULT_ID) {
+	if (iface->mode == GR_IFACE_MODE_VRF && iface->vrf_id != GR_VRF_DEFAULT_ID) {
 		const struct iface *vrf = iface_from_id(iface->vrf_id);
 		if (vrf == NULL || vrf->type != GR_IFACE_TYPE_VRF) {
 			LOG(ERR, "no VRF iface for id %u on %s", iface->vrf_id, iface->name);

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -371,6 +371,9 @@ static void cp_set_speed(struct iface *iface) {
 	char buf[512] = {0};
 	int ioctl_sock;
 
+	if (iface->cp_id == 0)
+		return;
+
 	gr_strcpy(ifr.ifr_name, IFNAMSIZ, iface->name);
 	els = (struct ethtool_link_settings *)buf;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Returns early from `cp_set_speed()` when `cp_id` is zero.
- Assigns a VRF master only for VRF-mode interfaces with a non-default VRF ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->