### PR TITLE
icmp,icmp6: fix ICMP error message handling

### DIFF
--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -51,12 +51,23 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 
 	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
 		struct rte_icmp_hdr *icmp = rte_pktmbuf_mtod(i->mbuf, struct rte_icmp_hdr *);
+		struct ip_local_mbuf_data *data = ip_local_mbuf_data(i->mbuf);
 
 		if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REPLY) {
 			// RFC 792: Destination Unreachable or Time Exceeded
 			// The icmp_seq_nb and icmp_ident fields are unused.
 			// Jump to the next header which contains the original IP header
-			struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
+			struct rte_ipv4_hdr *ip;
+			size_t inner_ip_len;
+
+			// RFC 792: ICMP error header (8) + original IP
+			// header (20 min) + 8 bytes of original data.
+			if (data->len < sizeof(*icmp) + sizeof(*ip) + sizeof(*icmp)) {
+				icmp_queue_pop(i, true);
+				continue;
+			}
+
+			ip = PAYLOAD(icmp);
 
 			if (ip->next_proto_id != IPPROTO_ICMP) {
 				// should not happen, but let's be safe.
@@ -64,9 +75,13 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 				continue;
 			}
 
-			// Skip the original IP header (may have options) to
-			// find the original ICMP payload.
-			icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
+			inner_ip_len = rte_ipv4_hdr_len(ip);
+			if (data->len < sizeof(*icmp) + inner_ip_len + sizeof(*icmp)) {
+				icmp_queue_pop(i, true);
+				continue;
+			}
+
+			icmp = RTE_PTR_ADD(ip, inner_ip_len);
 
 			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
 				// should not happen, but let's be safe.

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -104,9 +104,9 @@ out:
 
 static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_recv_req *icmp_req = request;
-	gr_clock_ns_t *pkt_timestamp, rcv_timestamp;
 	struct gr_ip4_icmp_recv_resp *resp = NULL;
 	struct ip_local_mbuf_data *ip_data;
+	gr_clock_ns_t rcv_timestamp;
 	struct rte_icmp_hdr *icmp;
 	struct rte_mbuf *m;
 	size_t len = 0;
@@ -141,8 +141,15 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	// icmp either points to an echo request or reply (checked in get_icmp_response())
 	resp->ident = rte_be_to_cpu_16(icmp->icmp_ident);
 	resp->seq_num = rte_be_to_cpu_16(icmp->icmp_seq_nb);
-	pkt_timestamp = PAYLOAD(icmp);
-	resp->response_time = rcv_timestamp - *pkt_timestamp;
+
+	if (resp->type == RTE_ICMP_TYPE_ECHO_REPLY) {
+		// The echo reply payload contains the timestamp from the
+		// original request. ICMP errors only carry 8 bytes of the
+		// original packet data (the ICMP header) so the timestamp
+		// is not available.
+		gr_clock_ns_t *pkt_timestamp = PAYLOAD(icmp);
+		resp->response_time = rcv_timestamp - *pkt_timestamp;
+	}
 
 	len = sizeof(*resp);
 out:

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -105,8 +105,8 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_recv_req *icmp_req = request;
 	gr_clock_ns_t *pkt_timestamp, rcv_timestamp;
 	struct gr_ip4_icmp_recv_resp *resp = NULL;
+	struct ip_local_mbuf_data *ip_data;
 	struct rte_icmp_hdr *icmp;
-	struct rte_ipv4_hdr *ip;
 	struct rte_mbuf *m;
 	size_t len = 0;
 	int ret = 0;
@@ -120,12 +120,10 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		goto out;
 	}
 
-	// Ugly, there is no guarantee that the outer packet is actually IPv4
-	ip = rte_pktmbuf_mtod_offset(m, struct rte_ipv4_hdr *, -sizeof(*ip));
-
+	ip_data = ip_local_mbuf_data(m);
 	icmp = rte_pktmbuf_mtod(m, struct rte_icmp_hdr *);
-	resp->src_addr = ip->src_addr;
-	resp->ttl = ip->time_to_live;
+	resp->src_addr = ip_data->src;
+	resp->ttl = ip_data->ttl;
 	resp->type = icmp->icmp_type;
 	resp->code = icmp->icmp_code;
 
@@ -133,7 +131,7 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		// RFC 792: Destination Unreachable or Time Exceeded
 		// The icmp_seq_nb and icmp_ident fields are unused.
 		// Jump to the next header which contains the original IP header
-		ip = PAYLOAD(icmp);
+		struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
 		// Skip the original IP header to find the original ICMP payload
 		icmp = PAYLOAD(ip);
 	}

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -20,10 +20,10 @@ struct icmp_queue_item {
 static STAILQ_HEAD(, icmp_queue_item) icmp_queue = STAILQ_HEAD_INITIALIZER(icmp_queue);
 static struct rte_mempool *pool;
 
-static void icmp_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
+static void icmp_queue_pop(struct icmp_queue_item *i) {
 	STAILQ_REMOVE(&icmp_queue, i, icmp_queue_item, next);
-	if (free_mbuf)
-		rte_pktmbuf_free(i->mbuf);
+	rte_pktmbuf_free(i->mbuf);
+	i->mbuf = NULL;
 	rte_mempool_put(pool, i);
 }
 
@@ -34,7 +34,7 @@ static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_que
 	void *data;
 
 	while (rte_mempool_get(pool, &data) < 0)
-		icmp_queue_pop(STAILQ_FIRST(&icmp_queue), true);
+		icmp_queue_pop(STAILQ_FIRST(&icmp_queue));
 
 	i = data;
 	i->mbuf = m;
@@ -63,7 +63,7 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 			// RFC 792: ICMP error header (8) + original IP
 			// header (20 min) + 8 bytes of original data.
 			if (data->len < sizeof(*icmp) + sizeof(*ip) + sizeof(*icmp)) {
-				icmp_queue_pop(i, true);
+				icmp_queue_pop(i);
 				continue;
 			}
 
@@ -71,13 +71,13 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 
 			if (ip->next_proto_id != IPPROTO_ICMP) {
 				// should not happen, but let's be safe.
-				icmp_queue_pop(i, true);
+				icmp_queue_pop(i);
 				continue;
 			}
 
 			inner_ip_len = rte_ipv4_hdr_len(ip);
 			if (data->len < sizeof(*icmp) + inner_ip_len + sizeof(*icmp)) {
-				icmp_queue_pop(i, true);
+				icmp_queue_pop(i);
 				continue;
 			}
 
@@ -85,7 +85,7 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 
 			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
 				// should not happen, but let's be safe.
-				icmp_queue_pop(i, true);
+				icmp_queue_pop(i);
 				continue;
 			}
 		}
@@ -93,8 +93,9 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 		if (rte_be_to_cpu_16(icmp->icmp_ident) == ident
 		    && rte_be_to_cpu_16(icmp->icmp_seq_nb) == seq_num) {
 			mbuf = i->mbuf;
+			i->mbuf = NULL;
 			*timestamp = i->timestamp;
-			icmp_queue_pop(i, false);
+			icmp_queue_pop(i);
 			return mbuf;
 		}
 	}
@@ -196,7 +197,7 @@ static void icmp_fini(struct event_base *) {
 	if (pool != NULL) {
 		struct icmp_queue_item *i, *tmp;
 		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)
-			icmp_queue_pop(i, true);
+			icmp_queue_pop(i);
 		rte_mempool_free(pool);
 		pool = NULL;
 	}

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -64,8 +64,9 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 				continue;
 			}
 
-			// Skip the original IP header to find the original ICMP payload
-			icmp = PAYLOAD(ip);
+			// Skip the original IP header (may have options) to
+			// find the original ICMP payload.
+			icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
 
 			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
 				// should not happen, but let's be safe.
@@ -132,8 +133,9 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		// The icmp_seq_nb and icmp_ident fields are unused.
 		// Jump to the next header which contains the original IP header
 		struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
-		// Skip the original IP header to find the original ICMP payload
-		icmp = PAYLOAD(ip);
+		// Skip the original IP header (may have options) to
+		// find the original ICMP payload.
+		icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
 	}
 
 	// icmp either points to an echo request or reply (checked in get_icmp_response())

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -87,6 +87,7 @@ static struct rte_mbuf *get_icmp6_echo_reply(
 			return mbuf;
 		}
 
+		continue;
 free_and_skip:
 		icmp6_queue_pop(i, true);
 	}

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -68,12 +68,14 @@ static struct rte_mbuf *get_icmp6_echo_reply(
 		// icmpv6 error packet: find embedded origin ipv6 packet, and use
 		// it if it's our original echo request
 		if (icmp6->type != ICMP6_TYPE_ECHO_REPLY) {
+			if (rte_pktmbuf_pkt_len(mbuf) < ICMP6_ERROR_PKT_LEN)
+				goto free_and_skip;
 			ip6 = PAYLOAD(icmp6_echo);
+			if (ip6->proto != IPPROTO_ICMPV6)
+				goto free_and_skip;
 			icmp6 = PAYLOAD(ip6);
 			icmp6_echo = PAYLOAD(icmp6);
-			if (rte_pktmbuf_pkt_len(mbuf) < ICMP6_ERROR_PKT_LEN
-			    || ip6->proto != IPPROTO_ICMPV6
-			    || icmp6->type != ICMP6_TYPE_ECHO_REQUEST)
+			if (icmp6->type != ICMP6_TYPE_ECHO_REQUEST)
 				goto free_and_skip;
 		}
 

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -20,10 +20,10 @@ struct icmp_queue_item {
 static STAILQ_HEAD(, icmp_queue_item) icmp_queue = STAILQ_HEAD_INITIALIZER(icmp_queue);
 static struct rte_mempool *pool;
 
-static void icmp6_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
+static void icmp6_queue_pop(struct icmp_queue_item *i) {
 	STAILQ_REMOVE(&icmp_queue, i, icmp_queue_item, next);
-	if (free_mbuf)
-		rte_pktmbuf_free(i->mbuf);
+	rte_pktmbuf_free(i->mbuf);
+	i->mbuf = NULL;
 	rte_mempool_put(pool, i);
 }
 
@@ -33,7 +33,7 @@ static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_qu
 	void *data;
 
 	while (rte_mempool_get(pool, &data) < 0)
-		icmp6_queue_pop(STAILQ_FIRST(&icmp_queue), true);
+		icmp6_queue_pop(STAILQ_FIRST(&icmp_queue));
 
 	i = data;
 	i->mbuf = m;
@@ -81,15 +81,16 @@ static struct rte_mbuf *get_icmp6_echo_reply(
 
 		if (rte_be_to_cpu_16(icmp6_echo->ident) == ident
 		    && rte_be_to_cpu_16(icmp6_echo->seqnum) == seq_num) {
-			icmp6_queue_pop(i, false);
+			i->mbuf = NULL;
 			*out_icmp6 = icmp6;
 			*timestamp = i->timestamp;
+			icmp6_queue_pop(i);
 			return mbuf;
 		}
 
 		continue;
 free_and_skip:
-		icmp6_queue_pop(i, true);
+		icmp6_queue_pop(i);
 	}
 
 	return errno_set_null(ENOENT);
@@ -165,7 +166,7 @@ static void icmp_fini(struct event_base *) {
 	if (pool != NULL) {
 		struct icmp_queue_item *i, *tmp;
 		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)
-			icmp6_queue_pop(i, true);
+			icmp6_queue_pop(i);
 		rte_mempool_free(pool);
 		pool = NULL;
 	}


### PR DESCRIPTION
The ICMP control plane code has several bugs when processing ICMP error messages (Destination Unreachable, TTL Exceeded). The icmp_recv handler reads the outer IP header at a wrong negative offset from the mbuf data pointer, which does not account for IP options. The embedded original IP header is also navigated with PAYLOAD(ip) assuming a fixed 20-byte size. Additionally, ICMP error messages only carry 8 bytes of the original payload (the ICMP header) so reading a timestamp past that is an out-of-bounds read. None of the embedded header accesses are validated against the actual packet length.

A similar lack of validation exists in the ICMPv6 path, along with a bug where non-matching packets are unconditionally freed from the queue, breaking concurrent pings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Validate embedded IPv4 and ICMP headers before access. Account for IPv4 options with `rte_ipv4_hdr_len()`.
- Read source and TTL from local mbuf metadata. Compute response time only for ICMP echo replies.
- Validate ICMPv6 error packets before parsing embedded headers. Keep valid non-matching packets queued for concurrent pings.
- Free queued mbufs consistently during queue removal, interface cleanup, and mempool release.
- Flush held nexthop mbufs before releasing their mempool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->