### PR TITLE
Mbuf pool drain

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,11 +81,12 @@ ForEachMacros:
   - STAILQ_FOREACH_SAFE
   - TAILQ_FOREACH
   - TAILQ_FOREACH_SAFE
-  - rte_graph_foreach_node
   - gr_api_client_stream_foreach
+  - gr_nh_flags_foreach
+  - nexthop_l3_hold_queue_foreach
+  - rte_graph_foreach_node
   - vec_foreach
   - vec_foreach_ref
-  - gr_nh_flags_foreach
 IfMacros:
   - KJ_IF_MAYBE
 IncludeBlocks: Regroup

--- a/modules/dhcp/control/client.c
+++ b/modules/dhcp/control/client.c
@@ -527,7 +527,7 @@ static void dhcp_fini(struct event_base *) {
 
 static struct module dhcp_module = {
 	.name = "dhcp",
-	.depends_on = "graph,ip_address,iface",
+	.depends_on = "graph,ip_address,iface,mempool",
 	.init = dhcp_init,
 	.fini = dhcp_fini,
 };

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -524,7 +524,7 @@ static void cp_module_fini(struct event_base *) {
 
 static struct module cp_module = {
 	.name = "controlplane",
-	.depends_on = "graph",
+	.depends_on = "graph,mempool",
 	.init = cp_module_init,
 	.fini = cp_module_fini,
 };

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -703,6 +703,7 @@ static void graph_fini(struct event_base *) {
 
 static struct module graph_module = {
 	.name = "graph",
+	.depends_on = "mempool",
 	.init = graph_init,
 	.fini = graph_fini,
 };

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -767,7 +767,7 @@ static void iface_fini(struct event_base *) {
 
 static struct module iface_module = {
 	.name = "iface",
-	.depends_on = "*_route,control_queue",
+	.depends_on = "*_route,control_queue,mempool",
 	.init = iface_init,
 	.fini = iface_fini,
 };

--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -31,6 +31,9 @@ int netlink_set_ifalias(uint32_t, const char *) {
 }
 mock_func(struct rte_mempool *, gr_pktmbuf_pool_get(int8_t, uint32_t));
 void gr_pktmbuf_pool_release(struct rte_mempool *, uint32_t) { }
+struct rte_mempool *gr_pktmbuf_pool_resize(struct rte_mempool *mp, int8_t, uint32_t, uint32_t) {
+	return mp;
+}
 struct rte_rcu_qsbr *gr_datapath_rcu(void) {
 	static struct rte_rcu_qsbr rcu;
 	return &rcu;

--- a/modules/infra/control/l3_nexthop.c
+++ b/modules/infra/control/l3_nexthop.c
@@ -164,16 +164,34 @@ static void l3_remove_references(struct nexthop *nh) {
 	}
 }
 
-static void l3_free(struct nexthop *nh) {
+int nexthop_l3_hold_queue_add(struct nexthop *nh, struct rte_mbuf *m) {
 	struct nexthop_info_l3 *l3 = nexthop_info_l3(nh);
 
-	// Flush all held packets.
-	struct rte_mbuf *m = l3->held_pkts_head;
-	while (m != NULL) {
-		struct rte_mbuf *next = queue_mbuf_data(m)->next;
+	if (l3->held_pkts >= nh_conf.max_held_pkts)
+		return errno_set(ENOBUFS);
+
+	queue_mbuf_data(m)->next = NULL;
+	if (l3->held_pkts_head == NULL)
+		l3->held_pkts_head = m;
+	else
+		queue_mbuf_data(l3->held_pkts_tail)->next = m;
+	l3->held_pkts_tail = m;
+	l3->held_pkts++;
+
+	return 0;
+}
+
+void nexthop_l3_hold_queue_reset(struct nexthop *nh) {
+	struct nexthop_info_l3 *l3 = nexthop_info_l3(nh);
+	l3->held_pkts = 0;
+	l3->held_pkts_head = NULL;
+	l3->held_pkts_tail = NULL;
+}
+
+void nexthop_l3_hold_queue_flush(struct nexthop *nh) {
+	nexthop_l3_hold_queue_foreach (m, nh)
 		rte_pktmbuf_free(m);
-		m = next;
-	}
+	nexthop_l3_hold_queue_reset(nh);
 }
 
 static bool l3_equal(const struct nexthop *a, const struct nexthop *b) {
@@ -287,7 +305,7 @@ static struct nexthop_type_ops l3_nh_ops = {
 	.reconfig = l3_reconfig,
 	.lookup = l3_lookup,
 	.remove_references = l3_remove_references,
-	.free = l3_free,
+	.free = nexthop_l3_hold_queue_flush,
 	.equal = l3_equal,
 	.import_info = l3_import_info,
 	.to_api = l3_to_api,

--- a/modules/infra/control/l3_nexthop.c
+++ b/modules/infra/control/l3_nexthop.c
@@ -354,6 +354,7 @@ static void l3_age(struct nexthop *nh, struct nexthop_info_l3 *l3) {
 		}
 		break;
 	case GR_NH_S_FAILED:
+		nexthop_l3_hold_queue_flush(nh);
 		break;
 	}
 }

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -300,6 +300,7 @@ static void loopback_module_fini(struct event_base *) {
 
 static struct module loopback_module = {
 	.name = "iface_loopback",
+	.depends_on = "mempool",
 	.init = loopback_module_init,
 	.fini = loopback_module_fini,
 };

--- a/modules/infra/control/mempool.c
+++ b/modules/infra/control/mempool.c
@@ -5,10 +5,26 @@
 #include "log.h"
 #include "mbuf.h"
 #include "mempool.h"
+#include "module.h"
+#include "sys_queue.h"
+
+#include <gr_clock.h>
+
+#include <event2/event.h>
 
 #include <stdlib.h>
 
 LOG_TYPE("mempool");
+
+struct pending_free {
+	STAILQ_ENTRY(pending_free) next;
+	struct rte_mempool *mp;
+	gr_clock_ns_t timestamp;
+	gr_clock_ns_t last_warn;
+};
+
+static STAILQ_HEAD(, pending_free) pending_list = STAILQ_HEAD_INITIALIZER(pending_list);
+static struct event *pending_timer;
 
 struct mempool_tracker {
 	struct rte_mempool *mp;
@@ -37,6 +53,7 @@ static int mt_sort(const void *p1, const void *p2) {
 #define MT_COUNT RTE_MAX_NUMA_NODES + 1
 static struct mempool_tracker trackers[MT_COUNT][MAX_MEMPOOL_PER_NUMA];
 static uint32_t mempool_default_size = MEMPOOL_DEFAULT_SIZE;
+static bool pending_has_name(const char *name);
 
 struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 	char mp_name[RTE_MEMPOOL_NAMESIZE];
@@ -55,6 +72,9 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 		unsigned mt_index = socket_id == SOCKET_ID_ANY ? 0 : socket_id + 1;
 		struct mempool_tracker *mt = &trackers[mt_index][i];
 		if (mt->mp == NULL) {
+			sprintf(mp_name, "mbuf_%d:%d", socket_id, i);
+			if (pending_has_name(mp_name))
+				continue;
 			alloc_size = mempool_default_size;
 			if (count > mempool_default_size / 4) {
 				alloc_size = count * 2;
@@ -62,7 +82,6 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 				// For future mempools, increase default size;
 				mempool_default_size = alloc_size;
 			}
-			sprintf(mp_name, "mbuf_%d:%d", socket_id, i);
 			LOG(DEBUG,
 			    "allocate mempool %s reserved %u (size %u, mbuf_size %u)",
 			    mp_name,
@@ -104,6 +123,42 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 	return mp;
 }
 
+#define PENDING_WARN_INTERVAL (5 * 60 * GR_NS_PER_S)
+
+static bool pending_has_name(const char *name) {
+	struct pending_free *pf;
+
+	STAILQ_FOREACH (pf, &pending_list, next) {
+		if (strcmp(pf->mp->name, name) == 0)
+			return true;
+	}
+	return false;
+}
+
+static void pending_free_cb(evutil_socket_t, short, void *) {
+	struct pending_free *pf, *tmp;
+	gr_clock_ns_t now = gr_clock_ns();
+
+	STAILQ_FOREACH_SAFE (pf, &pending_list, next, tmp) {
+		gr_clock_ns_t elapsed = now - pf->timestamp;
+		if (rte_mempool_full(pf->mp)) {
+			LOG(DEBUG,
+			    "deferred free mempool %s after %lu ms",
+			    pf->mp->name,
+			    (elapsed * 1000) / GR_NS_PER_S);
+			rte_mempool_free(pf->mp);
+			STAILQ_REMOVE(&pending_list, pf, pending_free, next);
+			free(pf);
+		} else if (elapsed > pf->last_warn + PENDING_WARN_INTERVAL) {
+			pf->last_warn = elapsed;
+			LOG(WARNING,
+			    "mempool %s still not empty after %lu s",
+			    pf->mp->name,
+			    elapsed / GR_NS_PER_S);
+		}
+	}
+}
+
 void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 	if (mp == NULL)
 		return;
@@ -121,8 +176,16 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 				    mt->mp->size);
 				mt->reserved -= count;
 				if (mt->reserved == 0) {
-					LOG(DEBUG, "free mempool %s", mt->mp->name);
-					rte_mempool_free(mp);
+					struct pending_free *pf = malloc(sizeof(*pf));
+					if (pf == NULL)
+						ABORT("malloc(pending_free) failed");
+					pf->mp = mp;
+					pf->timestamp = gr_clock_ns();
+					pf->last_warn = 0;
+					STAILQ_INSERT_TAIL(&pending_list, pf, next);
+					LOG(DEBUG,
+					    "schedule mempool %s for deferred free",
+					    mp->name);
 					mt->mp = NULL;
 					mt->reserved = 0;
 				}
@@ -134,4 +197,42 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 		struct mempool_tracker *mt = trackers[s];
 		qsort(mt, MAX_MEMPOOL_PER_NUMA, sizeof(*mt), mt_sort);
 	}
+}
+
+static void mempool_init(struct event_base *ev_base) {
+	pending_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, pending_free_cb, NULL);
+	if (pending_timer == NULL)
+		ABORT("event_new() failed");
+	if (event_add(pending_timer, &(struct timeval) {.tv_sec = 1}) < 0)
+		ABORT("event_add() failed");
+}
+
+static void mempool_fini(struct event_base *) {
+	struct pending_free *pf;
+
+	if (pending_timer)
+		event_free(pending_timer);
+
+	while ((pf = STAILQ_FIRST(&pending_list)) != NULL) {
+		if (rte_mempool_full(pf->mp))
+			LOG(DEBUG, "freeing pending mempool %s", pf->mp->name);
+		else
+			LOG(ERR,
+			    "freeing mempool %s with mbufs still in-flight (released %lu s ago)",
+			    pf->mp->name,
+			    (gr_clock_ns() - pf->timestamp) / GR_NS_PER_S);
+		rte_mempool_free(pf->mp);
+		STAILQ_REMOVE_HEAD(&pending_list, next);
+		free(pf);
+	}
+}
+
+static struct module mempool_module = {
+	.name = "mempool",
+	.init = mempool_init,
+	.fini = mempool_fini,
+};
+
+RTE_INIT(mempool_module_init) {
+	module_register(&mempool_module);
 }

--- a/modules/infra/control/mempool.c
+++ b/modules/infra/control/mempool.c
@@ -199,6 +199,54 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 	}
 }
 
+struct rte_mempool *gr_pktmbuf_pool_resize(
+	struct rte_mempool *mp,
+	int8_t socket_id,
+	uint32_t old_count,
+	uint32_t new_count
+) {
+	assert(new_count > 0);
+
+	if (old_count == new_count)
+		return mp;
+
+	if (mp == NULL)
+		return gr_pktmbuf_pool_get(socket_id, new_count);
+
+	for (int s = 0; s < MT_COUNT; s++) {
+		for (int i = 0; i < MAX_MEMPOOL_PER_NUMA; i++) {
+			struct mempool_tracker *mt = &trackers[s][i];
+			if (mt->mp != mp)
+				continue;
+
+			assert(mt->reserved >= old_count);
+			if (mt->reserved - old_count + new_count <= mt->mp->size) {
+				// Pool has enough room, adjust reservation in place.
+				LOG(DEBUG,
+				    "resize mempool %s reserved %u -> %u (size %u)",
+				    mt->mp->name,
+				    mt->reserved,
+				    mt->reserved - old_count + new_count,
+				    mt->mp->size);
+				mt->reserved = mt->reserved - old_count + new_count;
+				goto sort;
+			}
+
+			// Not enough space, release and allocate a new pool.
+			gr_pktmbuf_pool_release(mp, old_count);
+			return gr_pktmbuf_pool_get(socket_id, new_count);
+		}
+	}
+
+	return errno_set_null(ENOENT);
+sort:
+	for (int s = 0; s < MT_COUNT; s++) {
+		struct mempool_tracker *mt = trackers[s];
+		qsort(mt, MAX_MEMPOOL_PER_NUMA, sizeof(*mt), mt_sort);
+	}
+	return mp;
+}
+
 static void mempool_init(struct event_base *ev_base) {
 	pending_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, pending_free_cb, NULL);
 	if (pending_timer == NULL)

--- a/modules/infra/control/mempool.h
+++ b/modules/infra/control/mempool.h
@@ -7,3 +7,9 @@
 
 struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count);
 void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count);
+struct rte_mempool *gr_pktmbuf_pool_resize(
+	struct rte_mempool *mp,
+	int8_t socket_id,
+	uint32_t old_count,
+	uint32_t new_count
+);

--- a/modules/infra/control/nexthop.h
+++ b/modules/infra/control/nexthop.h
@@ -53,6 +53,21 @@ GR_NH_TYPE_INFO(GR_NH_T_L3, nexthop_info_l3, {
 	struct rte_mbuf *held_pkts_tail;
 });
 
+// Append a packet to the hold queue. Returns -ENOBUFS if the queue is full.
+int nexthop_l3_hold_queue_add(struct nexthop *, struct rte_mbuf *);
+
+// Reset the hold queue without freeing the mbufs.
+void nexthop_l3_hold_queue_reset(struct nexthop *);
+
+// Empty the hold queue, freeing all mbufs.
+void nexthop_l3_hold_queue_flush(struct nexthop *);
+
+// Iterate over all held mbufs. It is safe to mutate/free the mbufs while iterating.
+#define nexthop_l3_hold_queue_foreach(m, nh)                                                       \
+	for (struct rte_mbuf *__next = NULL, *m = nexthop_info_l3(nh)->held_pkts_head;             \
+	     m != NULL && (__next = queue_mbuf_data(m)->next, true);                               \
+	     m = __next)
+
 struct hoplist {
 	vec struct nexthop **nh;
 };

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -133,9 +133,8 @@ int port_configure(struct iface_info_port *p, uint16_t n_txq_min) {
 	mbuf_count += RTE_GRAPH_BURST_SIZE;
 	mbuf_count = rte_align32pow2(mbuf_count) - 1;
 	if (mbuf_count != p->pool_size) {
-		gr_pktmbuf_pool_release(p->pool, p->pool_size);
-		p->pool = gr_pktmbuf_pool_get(socket_id, mbuf_count);
-		p->pool_size = mbuf_count;
+		p->pool = gr_pktmbuf_pool_resize(p->pool, socket_id, p->pool_size, mbuf_count);
+		p->pool_size = p->pool ? mbuf_count : 0;
 	}
 
 	if (p->pool == NULL)

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -52,6 +52,9 @@ int netlink_set_ifalias(uint32_t, const char *) {
 }
 mock_func(struct rte_mempool *, gr_pktmbuf_pool_get(int8_t, uint32_t));
 void gr_pktmbuf_pool_release(struct rte_mempool *, uint32_t) { }
+struct rte_mempool *gr_pktmbuf_pool_resize(struct rte_mempool *mp, int8_t, uint32_t, uint32_t) {
+	return mp;
+}
 struct rte_rcu_qsbr *gr_datapath_rcu(void) {
 	static struct rte_rcu_qsbr rcu;
 	return &rcu;

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -60,6 +60,18 @@ static void icmp_event_cb(uint32_t ev_type, const void *obj) {
 	}
 }
 
+#define ICMP_QUEUE_TIMEOUT (10 * GR_NS_PER_S)
+
+static void icmp_queue_gc(evutil_socket_t, short, void *) {
+	gr_clock_ns_t now = gr_clock_ns();
+	struct icmp_queue_item *i, *tmp;
+
+	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
+		if (now - i->timestamp >= ICMP_QUEUE_TIMEOUT)
+			icmp_queue_pop(i, true);
+	}
+}
+
 // Search for the oldest ICMP response matching the given identifier.
 // If found, the packet is removed from the queue.
 static struct rte_mbuf *
@@ -169,8 +181,9 @@ out:
 }
 
 #define ICMP_LOCAL_QUEUE_SIZE 1024
+static struct event *gc_timer;
 
-static void icmp_init(struct event_base *) {
+static void icmp_init(struct event_base *ev_base) {
 	pool = rte_mempool_create(
 		"icmp_queue", // name
 		ICMP_LOCAL_QUEUE_SIZE,
@@ -186,9 +199,18 @@ static void icmp_init(struct event_base *) {
 	);
 	if (pool == NULL)
 		ABORT("rte_mempool_create(icmp_queue) failed");
+
+	gc_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, icmp_queue_gc, NULL);
+	if (gc_timer == NULL)
+		ABORT("event_new() failed");
+	if (event_add(gc_timer, &(struct timeval) {.tv_sec = 1}) < 0)
+		ABORT("event_add() failed");
 }
 
 static void icmp_fini(struct event_base *) {
+	if (gc_timer)
+		event_free(gc_timer);
+
 	if (pool != NULL) {
 		struct icmp_queue_item *i, *tmp;
 		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Christophe Fontaine
 
+#include "event.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "log.h"
@@ -29,9 +30,15 @@ static void icmp_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
 
 // Callback invoked by control plane for each ICMP packet received for a local address.
 // The packet is added at the end of a linked list.
-static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *) {
+static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
 	struct icmp_queue_item *i;
 	void *data;
+
+	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE
+	    && mbuf_data(m)->iface == drain->obj) {
+		rte_pktmbuf_free(m);
+		return;
+	}
 
 	while (rte_mempool_get(pool, &data) < 0)
 		icmp_queue_pop(STAILQ_FIRST(&icmp_queue), true);
@@ -40,6 +47,17 @@ static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_que
 	i->mbuf = m;
 	i->timestamp = timestamp;
 	STAILQ_INSERT_TAIL(&icmp_queue, i, next);
+}
+
+static void icmp_event_cb(uint32_t ev_type, const void *obj) {
+	struct icmp_queue_item *i, *tmp;
+
+	if (ev_type == GR_EVENT_IFACE_REMOVE) {
+		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
+			if (mbuf_data(i->mbuf)->iface == obj)
+				icmp_queue_pop(i, true);
+		}
+	}
 }
 
 // Search for the oldest ICMP response matching the given identifier.
@@ -190,6 +208,7 @@ RTE_INIT(icmp_module_init) {
 	module_register(&icmp_module);
 	api_handler(GR_IP4_ICMP_SEND, icmp_send);
 	api_handler(GR_IP4_ICMP_RECV, icmp_recv);
+	event_subscribe(GR_EVENT_IFACE_REMOVE, icmp_event_cb);
 	icmp_input_register_callback(RTE_ICMP_TYPE_DEST_UNREACHABLE, icmp_input_cb);
 	icmp_input_register_callback(RTE_ICMP_TYPE_TTL_EXCEEDED, icmp_input_cb);
 	icmp_input_register_callback(RTE_ICMP_TYPE_ECHO_REPLY, icmp_input_cb);

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -113,21 +113,14 @@ hold:
 		return;
 	}
 
-	if (l3->held_pkts < nh_conf.max_held_pkts) {
-		queue_mbuf_data(m)->next = NULL;
-		if (l3->held_pkts_head == NULL)
-			l3->held_pkts_head = m;
-		else
-			queue_mbuf_data(l3->held_pkts_tail)->next = m;
-		l3->held_pkts_tail = m;
-		l3->held_pkts++;
+	if (nexthop_l3_hold_queue_add(nh, m) == 0) {
 		if (l3->state != GR_NH_S_PENDING) {
 			arp_output_request_solicit(nh);
 			l3->state = GR_NH_S_PENDING;
 		}
 		return;
 	} else {
-		LOG(DEBUG, IP4_F " hold queue full", &l3->ipv4);
+		LOG(DEBUG, IP4_F " hold queue: %s", &l3->ipv4, strerror(errno));
 	}
 free:
 	rte_pktmbuf_free(m);
@@ -140,7 +133,6 @@ void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	const struct iface *iface;
 	struct rte_mbuf *m = obj;
 	struct rte_arp_hdr *arp;
-	struct rte_mbuf *held;
 	struct nexthop *nh;
 	ip4_addr_t sip;
 
@@ -209,22 +201,15 @@ void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	}
 
 	// Flush all held packets.
-	held = l3->held_pkts_head;
-	while (held != NULL) {
+	nexthop_l3_hold_queue_foreach (held, nh) {
 		const struct nexthop_af_ops *ops;
-		struct rte_mbuf *next;
 
-		next = queue_mbuf_data(held)->next;
 		ops = nexthop_af_ops_from_mbuf(held);
 		assert(ops != NULL);
 		if (ops->resubmit(held, nh) < 0)
 			rte_pktmbuf_free(held);
-
-		held = next;
 	}
-	l3->held_pkts_head = NULL;
-	l3->held_pkts_tail = NULL;
-	l3->held_pkts = 0;
+	nexthop_l3_hold_queue_reset(nh);
 
 free:
 	rte_pktmbuf_free(m);

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -59,6 +59,18 @@ static void icmp6_event_cb(uint32_t ev_type, const void *obj) {
 	}
 }
 
+#define ICMP6_QUEUE_TIMEOUT (10 * GR_NS_PER_S)
+
+static void icmp6_queue_gc(evutil_socket_t, short, void *) {
+	gr_clock_ns_t now = gr_clock_ns();
+	struct icmp_queue_item *i, *tmp;
+
+	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
+		if (now - i->timestamp >= ICMP6_QUEUE_TIMEOUT)
+			icmp6_queue_pop(i, true);
+	}
+}
+
 #define ICMP6_ERROR_PKT_LEN                                                                        \
 	(GR_ICMP6_HDR_LEN + sizeof(struct rte_ipv6_hdr) + GR_ICMP6_HDR_LEN + sizeof(gr_clock_ns_t))
 
@@ -157,8 +169,9 @@ static struct api_out icmp6_recv(const void *request, struct api_ctx *) {
 }
 
 #define ICMP6_LOCAL_QUEUE_SIZE 1024
+static struct event *gc_timer;
 
-static void icmp_init(struct event_base *) {
+static void icmp_init(struct event_base *ev_base) {
 	pool = rte_mempool_create(
 		"icmp6_queue",
 		ICMP6_LOCAL_QUEUE_SIZE,
@@ -174,9 +187,18 @@ static void icmp_init(struct event_base *) {
 	);
 	if (pool == NULL)
 		ABORT("rte_mempool_create(icmp6_queue) failed");
+
+	gc_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, icmp6_queue_gc, NULL);
+	if (gc_timer == NULL)
+		ABORT("event_new() failed");
+	if (event_add(gc_timer, &(struct timeval) {.tv_sec = 1}) < 0)
+		ABORT("event_add() failed");
 }
 
 static void icmp_fini(struct event_base *) {
+	if (gc_timer)
+		event_free(gc_timer);
+
 	if (pool != NULL) {
 		struct icmp_queue_item *i, *tmp;
 		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Olivier Gournet
 
+#include "event.h"
 #include "icmp6.h"
 #include "ip6.h"
 #include "ip6_datapath.h"
@@ -28,9 +29,15 @@ static void icmp6_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
 }
 
 // called from dataplane context
-static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *) {
+static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
 	struct icmp_queue_item *i;
 	void *data;
+
+	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE
+	    && mbuf_data(m)->iface == drain->obj) {
+		rte_pktmbuf_free(m);
+		return;
+	}
 
 	while (rte_mempool_get(pool, &data) < 0)
 		icmp6_queue_pop(STAILQ_FIRST(&icmp_queue), true);
@@ -39,6 +46,17 @@ static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_qu
 	i->mbuf = m;
 	i->timestamp = timestamp;
 	STAILQ_INSERT_TAIL(&icmp_queue, i, next);
+}
+
+static void icmp6_event_cb(uint32_t ev_type, const void *obj) {
+	struct icmp_queue_item *i, *tmp;
+
+	if (ev_type == GR_EVENT_IFACE_REMOVE) {
+		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
+			if (mbuf_data(i->mbuf)->iface == obj)
+				icmp6_queue_pop(i, true);
+		}
+	}
 }
 
 #define ICMP6_ERROR_PKT_LEN                                                                        \
@@ -178,6 +196,7 @@ RTE_INIT(icmp_module_init) {
 	module_register(&icmp6_module);
 	api_handler(GR_IP6_ICMP6_SEND, icmp6_send);
 	api_handler(GR_IP6_ICMP6_RECV, icmp6_recv);
+	event_subscribe(GR_EVENT_IFACE_REMOVE, icmp6_event_cb);
 	icmp6_input_register_callback(ICMP6_TYPE_ECHO_REPLY, icmp6_input_cb);
 	icmp6_input_register_callback(ICMP6_ERR_DEST_UNREACH, icmp6_input_cb);
 	icmp6_input_register_callback(ICMP6_ERR_TTL_EXCEEDED, icmp6_input_cb);

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -125,21 +125,14 @@ hold:
 		return;
 	}
 
-	if (l3->held_pkts < nh_conf.max_held_pkts) {
-		queue_mbuf_data(m)->next = NULL;
-		if (l3->held_pkts_head == NULL)
-			l3->held_pkts_head = m;
-		else
-			queue_mbuf_data(l3->held_pkts_tail)->next = m;
-		l3->held_pkts_tail = m;
-		l3->held_pkts++;
+	if (nexthop_l3_hold_queue_add(nh, m) == 0) {
 		if (l3->state != GR_NH_S_PENDING) {
 			nh6_solicit(nh);
 			l3->state = GR_NH_S_PENDING;
 		}
 		return;
 	} else {
-		LOG(DEBUG, IP6_F " hold queue full", &l3->ipv6);
+		LOG(DEBUG, IP6_F " hold queue: %s", &l3->ipv6, strerror(errno));
 	}
 free:
 	rte_pktmbuf_free(m);
@@ -257,23 +250,16 @@ void ndp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 	}
 
 	// Flush all held packets.
-	struct rte_mbuf *held = l3->held_pkts_head;
-	while (held != NULL) {
+	nexthop_l3_hold_queue_foreach (held, nh) {
 		const struct nexthop_af_ops *ops;
-		struct rte_mbuf *next;
-
-		next = queue_mbuf_data(held)->next;
 
 		ops = nexthop_af_ops_from_mbuf(held);
 		assert(ops != NULL);
 		if (ops->resubmit(held, nh) < 0)
 			rte_pktmbuf_free(held);
-
-		held = next;
 	}
-	l3->held_pkts_head = NULL;
-	l3->held_pkts_tail = NULL;
-	l3->held_pkts = 0;
+	nexthop_l3_hold_queue_reset(nh);
+
 free:
 	rte_pktmbuf_free(m);
 }

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -205,7 +205,7 @@ static void ra_fini(struct event_base * /*ev_base*/) {
 
 static struct module ra_module = {
 	.name = "ip6_router_advert",
-	.depends_on = "graph",
+	.depends_on = "graph,mempool",
 	.init = ra_init,
 	.fini = ra_fini,
 };


### PR DESCRIPTION
This series fixes the following NULL pointer dereference when an ICMP message arrives while reconfiguring CPU affinity:

```
(gdb) bt -full
#0  get_icmp_response (ident=19013, seq_num=0, timestamp=<synthetic pointer>) at ../modules/ip/control/icmp.c:55
        icmp = 0x0
        i = 0x17ff88b80
        tmp = 0x17ff88c40
        mbuf = 0x0
        i = <optimized out>
        tmp = <optimized out>
        mbuf = <optimized out>
        icmp = <optimized out>
        ip = <optimized out>
#1  icmp_recv (request=<optimized out>) at ../modules/ip/control/icmp.c:114
        icmp_req = <optimized out>
        pkt_timestamp = <optimized out>
        rcv_timestamp = <optimized out>
        resp = 0x0
        icmp = <optimized out>
        ip = <optimized out>
--Type <RET> for more, q to quit, c to continue without paging--bt -full
        m = <optimized out>
        len = 0
        ret = 0
#2  0x000055fd55bb36df in read_cb (bev=0x55fd580b4570, priv=0x55fd580b48b0) at ../main/api.c:315
        input = 0x55fd580b4790
        ctx = 0x55fd580b48b0
        req_payload = 0x55fd58330740
        __PRETTY_FUNCTION__ = "read_cb"
        __func__ = "read_cb"
        out = <optimized out>
        handler = 0x7f0b260bc100
        send = <optimized out>
        resp = {for_id = 0, status = 0, payload_len = 1}
#3  0x00007f0b271c7f2c in bufferevent_run_readcb_ () from /lib64/libevent_core-2.1.so.7
No symbol table info available.
#4  0x00007f0b271cac18 in bufferevent_readcb.lto_priv () from /lib64/libevent_core-2.1.so.7
No symbol table info available.
#5  0x00007f0b271d4847 in event_process_active_single_queue () from /lib64/libevent_core-2.1.so.7
No symbol table info available.
#6  0x00007f0b271d662f in event_base_loop () from /lib64/libevent_core-2.1.so.7
No symbol table info available.
#7  0x000055fd55ab61ff in main (argc=8, argv=<optimized out>) at ../main/main.c:349
        ev_base = 0x55fd57fbec40
        ret = 1
        err = 0
        __func__ = "main"
        shutdown = <optimized out>
```

The timeline of the crash:

1. An ICMP echo reply arrives, mbuf is allocated from the port's mempool
2. Mbuf goes through the graph -> control_output -> control queue ring -> icmp_input_cb -> stored in icmp_queue
3. An API request to change CPU affinity arrives -- we're now inside read_cb in the libevent loop
4. worker_queue_distribute stops all workers, then calls port_configure for each port
5. port_configure calls gr_pktmbuf_pool_release(p->pool, ...) -- if the ref count drops to zero, the pool backing the ICMP mbuf is freed
6. read_cb returns, libevent loop resumes
7. Later, icmp_recv -> get_icmp_response accesses i->mbuf -- the mbuf's memory has been freed/unmapped -> buf_addr is 0 -> rte_pktmbuf_mtod returns 0 -> segfault

The icmp_queue (and potentially any pending items in the control queue ring) holds mbufs from the old pool that nobody drains before the pool is freed. The RCU mechanism doesn't help here because these mbufs are held by the control plane itself, not the datapath.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Resize existing packet-buffer mempools instead of releasing and recreating them during port reconfiguration.
- Defer mempool destruction until all outstanding mbufs are released. Track pending pools and report pools that remain busy.
- Add shared APIs for adding, resetting, flushing, and iterating L3 nexthop hold queues.
- Remove queued ICMP and ICMPv6 packets when their interface is removed.
- Expire stale ICMP queues with garbage-collection timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->