### PR TITLE
smoke: replace sleep-based waits with readiness checks

### DIFF
--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -296,6 +296,50 @@ llocal_addr() {
 		sed -En 's#(fe80:.*)/.*#\1#p'
 }
 
+# Wait until a given IP(v6) address is assigned on a kernel interface.
+wait_kernel_addr() {
+	set +x
+	trap 'set -x' RETURN
+
+	local addr="$1"
+	local dev="$2"
+
+	SECONDS=0
+	while ! ip addr show dev "$dev" to "$addr" | grep .; do
+		if [ "$SECONDS" -gt 10 ]; then
+			grcli address show iface "$dev"
+			ip addr show dev "$dev"
+			fail "address $addr not available on $dev after 10 seconds"
+		fi
+		sleep 0.1
+	done
+}
+
+# Wait until TCP and/or UDP listeners are ready on the given ports.
+# Usage: wait_listeners [--netns NS] PORT [PORT...]
+wait_listeners() {
+	set +x
+	trap 'set -x' RETURN
+
+	local ns_cmd=""
+	if [ "$1" = "--netns" ]; then
+		ns_cmd="ip netns exec $2"
+		shift 2
+	fi
+	local port
+
+	SECONDS=0
+	for port in "$@"; do
+		while ! $ns_cmd ss -tulnH sport = :"$port" | grep .; do
+			if [ "$SECONDS" -gt 10 ]; then
+				$ns_cmd ss -tuln
+				fail "listener on port $port not ready after 10 seconds"
+			fi
+			sleep 0.1
+		done
+	done
+}
+
 if [ "$run_grout" = true ]; then
 	smoke_setenv GROUT_SOCK_PATH "$tmp/grout.sock"
 	smoke_setenv GROUT_OVERRIDE_DEFAULT_ROUTE true

--- a/smoke/so_bindtodevice_test.sh
+++ b/smoke/so_bindtodevice_test.sh
@@ -63,7 +63,9 @@ for ns in peer0 peer1; do
 	ip netns exec $ns socat TCP4-LISTEN:9003,fork EXEC:'/bin/cat' &
 	ip netns exec $ns socat TCP6-LISTEN:9002,fork EXEC:'/bin/cat' &
 done
-sleep 1
+for ns in peer0 peer1; do
+	wait_listeners --netns $ns 9000 9001 9002 9003
+done
 
 run_scenario() {
 	local label="$1"
@@ -135,6 +137,7 @@ peer0_ll=$(ip -n peer0 -6 addr show dev x-p0 | sed -nE 's#.*inet6 (fe80:[^/]+).*
 grout0_ll=$(llocal_addr p0)
 [ -z "$peer0_ll" ] && fail "peer0 link-local not found on x-p0"
 [ -z "$grout0_ll" ] && fail "grout link-local not found on p0"
+wait_kernel_addr "$grout0_ll" p0
 for proto_port in "UDP6:9000" "TCP6:9002"; do
 	proto=${proto_port%:*}
 	port=${proto_port#*:}

--- a/smoke/so_listen_test.sh
+++ b/smoke/so_listen_test.sh
@@ -121,7 +121,7 @@ run_listen() {
 	t4=$!
 	socat "TCP6-LISTEN:9503${listen_opt},fork,reuseaddr"    EXEC:'/bin/cat' &
 	t6=$!
-	sleep 0.5
+	wait_listeners 9500 9501 9502 9503
 
 	if [ "$tcp_only" != "tcp-only" ]; then
 		probe "$label" "$ns" UDP4 "$dst4" "$dst6" 9500 "$expect"
@@ -181,11 +181,12 @@ run_listen "nobind/l3mdev=1/vrf" "" \
 # via x-p0 in its own netns. Mirrors so_bindtodevice_test scenario 8.
 grout0_ll=$(llocal_addr p0)
 [ -z "$grout0_ll" ] && fail "grout link-local not found on p0"
+wait_kernel_addr "$grout0_ll" p0
 socat "UDP6-LISTEN:9501,so-bindtodevice=p0,bind=[${grout0_ll}],fork"           EXEC:'/bin/cat' &
 ll_u6=$!
 socat "TCP6-LISTEN:9503,so-bindtodevice=p0,bind=[${grout0_ll}],fork,reuseaddr" EXEC:'/bin/cat' &
 ll_t6=$!
-sleep 0.5
+wait_listeners 9501 9503
 for proto_port in "UDP6:9501" "TCP6:9503"; do
 	proto=${proto_port%:*}
 	port=${proto_port#*:}


### PR DESCRIPTION
The SO_BINDTODEVICE and SO_LISTEN tests use fixed sleeps to wait for socat listeners and kernel address assignment. On slow CI runners, these sleeps are too short and cause random failures (e.g. socat failing to bind a link-local address not yet assigned to the TAP device).

Add wait_kernel_addr and wait_listeners helpers that poll for actual readiness instead of hoping a fixed delay is enough. Both suppress xtrace output to keep logs readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added `wait_kernel_addr` and `wait_listeners` readiness helpers with timeout diagnostics and suppressed xtrace output.
- Replaced fixed sleeps in SO_BINDTODEVICE and SO_LISTEN smoke tests with namespace-aware listener polling and kernel-address readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->