### PR TITLE
mempool: defer free until all mbufs are returned

### DIFF
--- a/modules/dhcp/control/client.c
+++ b/modules/dhcp/control/client.c
@@ -527,7 +527,7 @@ static void dhcp_fini(struct event_base *) {
 
 static struct module dhcp_module = {
 	.name = "dhcp",
-	.depends_on = "graph,ip_address,iface",
+	.depends_on = "graph,ip_address,iface,mempool",
 	.init = dhcp_init,
 	.fini = dhcp_fini,
 };

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -519,7 +519,7 @@ static void cp_module_fini(struct event_base *) {
 
 static struct module cp_module = {
 	.name = "controlplane",
-	.depends_on = "graph",
+	.depends_on = "graph,mempool",
 	.init = cp_module_init,
 	.fini = cp_module_fini,
 };

--- a/modules/infra/control/graph.c
+++ b/modules/infra/control/graph.c
@@ -703,6 +703,7 @@ static void graph_fini(struct event_base *) {
 
 static struct module graph_module = {
 	.name = "graph",
+	.depends_on = "mempool",
 	.init = graph_init,
 	.fini = graph_fini,
 };

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -767,7 +767,7 @@ static void iface_fini(struct event_base *) {
 
 static struct module iface_module = {
 	.name = "iface",
-	.depends_on = "*_route,control_queue",
+	.depends_on = "*_route,control_queue,mempool",
 	.init = iface_init,
 	.fini = iface_fini,
 };

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -300,6 +300,7 @@ static void loopback_module_fini(struct event_base *) {
 
 static struct module loopback_module = {
 	.name = "iface_loopback",
+	.depends_on = "mempool",
 	.init = loopback_module_init,
 	.fini = loopback_module_fini,
 };

--- a/modules/infra/control/mempool.c
+++ b/modules/infra/control/mempool.c
@@ -5,10 +5,26 @@
 #include "log.h"
 #include "mbuf.h"
 #include "mempool.h"
+#include "module.h"
+#include "sys_queue.h"
+
+#include <gr_clock.h>
+
+#include <event2/event.h>
 
 #include <stdlib.h>
 
 LOG_TYPE("mempool");
+
+struct pending_free {
+	STAILQ_ENTRY(pending_free) next;
+	struct rte_mempool *mp;
+	gr_clock_ns_t timestamp;
+	gr_clock_ns_t last_warn;
+};
+
+static STAILQ_HEAD(, pending_free) pending_list = STAILQ_HEAD_INITIALIZER(pending_list);
+static struct event *pending_timer;
 
 struct mempool_tracker {
 	struct rte_mempool *mp;
@@ -37,6 +53,7 @@ static int mt_sort(const void *p1, const void *p2) {
 #define MT_COUNT RTE_MAX_NUMA_NODES + 1
 static struct mempool_tracker trackers[MT_COUNT][MAX_MEMPOOL_PER_NUMA];
 static uint32_t mempool_default_size = MEMPOOL_DEFAULT_SIZE;
+static bool pending_has_name(const char *name);
 
 struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 	char mp_name[RTE_MEMPOOL_NAMESIZE];
@@ -55,6 +72,9 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 		unsigned mt_index = socket_id == SOCKET_ID_ANY ? 0 : socket_id + 1;
 		struct mempool_tracker *mt = &trackers[mt_index][i];
 		if (mt->mp == NULL) {
+			sprintf(mp_name, "mbuf_%d:%d", socket_id, i);
+			if (pending_has_name(mp_name))
+				continue;
 			alloc_size = mempool_default_size;
 			if (count > mempool_default_size / 4) {
 				alloc_size = count * 2;
@@ -62,7 +82,6 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 				// For future mempools, increase default size;
 				mempool_default_size = alloc_size;
 			}
-			sprintf(mp_name, "mbuf_%d:%d", socket_id, i);
 			LOG(DEBUG,
 			    "allocate mempool %s reserved %u (size %u, mbuf_size %u)",
 			    mp_name,
@@ -104,6 +123,42 @@ struct rte_mempool *gr_pktmbuf_pool_get(int8_t socket_id, uint32_t count) {
 	return mp;
 }
 
+#define PENDING_WARN_INTERVAL (5 * 60 * GR_NS_PER_S)
+
+static bool pending_has_name(const char *name) {
+	struct pending_free *pf;
+
+	STAILQ_FOREACH (pf, &pending_list, next) {
+		if (strcmp(pf->mp->name, name) == 0)
+			return true;
+	}
+	return false;
+}
+
+static void pending_free_cb(evutil_socket_t, short, void *) {
+	struct pending_free *pf, *tmp;
+	gr_clock_ns_t now = gr_clock_ns();
+
+	STAILQ_FOREACH_SAFE (pf, &pending_list, next, tmp) {
+		gr_clock_ns_t elapsed = now - pf->timestamp;
+		if (rte_mempool_full(pf->mp)) {
+			LOG(DEBUG,
+			    "deferred free mempool %s after %lu ms",
+			    pf->mp->name,
+			    elapsed / 1000000);
+			rte_mempool_free(pf->mp);
+			STAILQ_REMOVE(&pending_list, pf, pending_free, next);
+			free(pf);
+		} else if (elapsed > pf->last_warn + PENDING_WARN_INTERVAL) {
+			pf->last_warn = elapsed;
+			LOG(WARNING,
+			    "mempool %s still not empty after %lu min",
+			    pf->mp->name,
+			    elapsed / 1000000 / 1000 / 60);
+		}
+	}
+}
+
 void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 	if (mp == NULL)
 		return;
@@ -121,8 +176,16 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 				    mt->mp->size);
 				mt->reserved -= count;
 				if (mt->reserved == 0) {
-					LOG(DEBUG, "free mempool %s", mt->mp->name);
-					rte_mempool_free(mp);
+					struct pending_free *pf = malloc(sizeof(*pf));
+					if (pf == NULL)
+						ABORT("malloc(pending_free) failed");
+					pf->mp = mp;
+					pf->timestamp = gr_clock_ns();
+					pf->last_warn = 0;
+					STAILQ_INSERT_TAIL(&pending_list, pf, next);
+					LOG(DEBUG,
+					    "schedule mempool %s for deferred free",
+					    mp->name);
 					mt->mp = NULL;
 					mt->reserved = 0;
 				}
@@ -134,4 +197,36 @@ void gr_pktmbuf_pool_release(struct rte_mempool *mp, uint32_t count) {
 		struct mempool_tracker *mt = trackers[s];
 		qsort(mt, MAX_MEMPOOL_PER_NUMA, sizeof(*mt), mt_sort);
 	}
+}
+
+static void mempool_init(struct event_base *ev_base) {
+	pending_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, pending_free_cb, NULL);
+	if (pending_timer == NULL)
+		ABORT("event_new() failed");
+	if (event_add(pending_timer, &(struct timeval) {.tv_sec = 1}) < 0)
+		ABORT("event_add() failed");
+}
+
+static void mempool_fini(struct event_base *) {
+	struct pending_free *pf;
+
+	if (pending_timer)
+		event_free(pending_timer);
+
+	while ((pf = STAILQ_FIRST(&pending_list)) != NULL) {
+		LOG(DEBUG, "free pending mempool %s", pf->mp->name);
+		rte_mempool_free(pf->mp);
+		STAILQ_REMOVE_HEAD(&pending_list, next);
+		free(pf);
+	}
+}
+
+static struct module mempool_module = {
+	.name = "mempool",
+	.init = mempool_init,
+	.fini = mempool_fini,
+};
+
+RTE_INIT(mempool_module_init) {
+	module_register(&mempool_module);
 }

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -205,7 +205,7 @@ static void ra_fini(struct event_base * /*ev_base*/) {
 
 static struct module ra_module = {
 	.name = "ip6_router_advert",
-	.depends_on = "graph",
+	.depends_on = "graph,mempool",
 	.init = ra_init,
 	.fini = ra_fini,
 };


### PR DESCRIPTION
Here is a draft, untested.

Such a check should help catch any leak / remaining reference of mbufs in grout, rather than blindly shooting the mempools like we do atm.

Now that I think about it, we could probably add a rte_mempool_full() check and log an ERR in mempool_fini, though I did not do it in this PR.