### PR TITLE
Control input cleanup

### DIFF
--- a/modules/dhcp/control/client.c
+++ b/modules/dhcp/control/client.c
@@ -7,6 +7,7 @@
 #include "iface.h"
 #include "ip4.h"
 #include "log.h"
+#include "mbuf.h"
 #include "module.h"
 #include "nexthop.h"
 
@@ -26,7 +27,7 @@ LOG_TYPE("dhcp");
 
 static struct event_base *dhcp_ev_base;
 static struct dhcp_client *dhcp_clients[GR_MAX_IFACES];
-static control_input_t dhcp_output;
+static rte_edge_t dhcp_output;
 
 bool dhcp_enabled(uint16_t iface_id) {
 	if (iface_id < GR_MAX_IFACES)
@@ -399,7 +400,7 @@ free:
 static void dhcp_init(struct event_base *ev_base) {
 	dhcp_ev_base = ev_base;
 
-	dhcp_output = gr_control_input_register_handler("eth_output", true);
+	dhcp_output = gr_control_input_register_handler("eth_output");
 }
 
 static int dhcp_start(uint16_t iface_id) {

--- a/modules/dhcp/control/client.c
+++ b/modules/dhcp/control/client.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Anthony Harivel
 
-#include "control_input.h"
 #include "control_queue.h"
 #include "dhcp.h"
+#include "eth.h"
 #include "iface.h"
 #include "ip4.h"
 #include "log.h"
@@ -27,7 +27,6 @@ LOG_TYPE("dhcp");
 
 static struct event_base *dhcp_ev_base;
 static struct dhcp_client *dhcp_clients[GR_MAX_IFACES];
-static rte_edge_t dhcp_output;
 
 bool dhcp_enabled(uint16_t iface_id) {
 	if (iface_id < GR_MAX_IFACES)
@@ -109,7 +108,7 @@ static int dhcp_send_request(struct dhcp_client *client) {
 	if (m == NULL)
 		return -errno;
 
-	if (post_to_stack(dhcp_output, m) < 0) {
+	if (eth_output_send(m) < 0) {
 		rte_pktmbuf_free(m);
 		return -errno;
 	}
@@ -126,7 +125,7 @@ static int dhcp_send_discover(struct dhcp_client *client) {
 	if (m == NULL)
 		return -errno;
 
-	if (post_to_stack(dhcp_output, m) < 0) {
+	if (eth_output_send(m) < 0) {
 		rte_pktmbuf_free(m);
 		return -errno;
 	}
@@ -399,8 +398,6 @@ free:
 
 static void dhcp_init(struct event_base *ev_base) {
 	dhcp_ev_base = ev_base;
-
-	dhcp_output = gr_control_input_register_handler("eth_output");
 }
 
 static int dhcp_start(uint16_t iface_id) {

--- a/modules/dhcp/control/client.c
+++ b/modules/dhcp/control/client.c
@@ -7,7 +7,6 @@
 #include "iface.h"
 #include "ip4.h"
 #include "log.h"
-#include "mempool.h"
 #include "module.h"
 #include "nexthop.h"
 
@@ -28,7 +27,6 @@ LOG_TYPE("dhcp");
 static struct event_base *dhcp_ev_base;
 static struct dhcp_client *dhcp_clients[GR_MAX_IFACES];
 static control_input_t dhcp_output;
-static struct rte_mempool *dhcp_mp;
 
 bool dhcp_enabled(uint16_t iface_id) {
 	if (iface_id < GR_MAX_IFACES)
@@ -402,10 +400,6 @@ static void dhcp_init(struct event_base *ev_base) {
 	dhcp_ev_base = ev_base;
 
 	dhcp_output = gr_control_input_register_handler("eth_output", true);
-
-	dhcp_mp = gr_pktmbuf_pool_get(SOCKET_ID_ANY, 512);
-	if (dhcp_mp == NULL)
-		ABORT("failed to get mempool");
 }
 
 static int dhcp_start(uint16_t iface_id) {
@@ -470,10 +464,6 @@ static int dhcp_stop(uint16_t iface_id) {
 	return 0;
 }
 
-struct rte_mempool *dhcp_get_mempool(void) {
-	return dhcp_mp;
-}
-
 static struct api_out dhcp_list_handler(const void *, struct api_ctx *ctx) {
 	struct dhcp_client *client;
 	uint16_t iface_id;
@@ -522,12 +512,11 @@ static void dhcp_fini(struct event_base *) {
 		if (dhcp_clients[iface_id] != NULL)
 			dhcp_stop(iface_id);
 	}
-	gr_pktmbuf_pool_release(dhcp_mp, 512);
 }
 
 static struct module dhcp_module = {
 	.name = "dhcp",
-	.depends_on = "graph,ip_address,iface,mempool",
+	.depends_on = "graph,ip_address,iface",
 	.init = dhcp_init,
 	.fini = dhcp_fini,
 };

--- a/modules/dhcp/control/dhcp.h
+++ b/modules/dhcp/control/dhcp.h
@@ -112,8 +112,6 @@ bool dhcp_enabled(uint16_t iface_id);
 
 void dhcp_input_cb(void *obj, uintptr_t priv, const struct control_queue_drain *);
 
-struct rte_mempool *dhcp_get_mempool(void);
-
 int dhcp_parse_packet(struct rte_mbuf *, struct dhcp_client *, dhcp_message_type_t *);
 struct rte_mbuf *dhcp_build_discover(uint16_t iface_id, uint32_t xid);
 struct rte_mbuf *

--- a/modules/dhcp/control/packet.c
+++ b/modules/dhcp/control/packet.c
@@ -85,7 +85,7 @@ static struct rte_mbuf *dhcp_build_packet(
 	if (iface_get_eth_addr(iface, &mac) < 0)
 		return errno_set_null(EMEDIUMTYPE);
 
-	m = rte_pktmbuf_alloc(dhcp_get_mempool());
+	m = rte_pktmbuf_alloc(iface->pool);
 	if (m == NULL)
 		return errno_set_null(ENOMEM);
 

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -2,7 +2,6 @@
 // Copyright (c) 2025 Christophe Fontaine
 
 #include "config.h"
-#include "control_input.h"
 #include "control_queue.h"
 #include "eth.h"
 #include "event.h"
@@ -38,8 +37,6 @@ LOG_TYPE("ctlplane");
 #define TUN_TAP_DEV_PATH "/dev/net/tun"
 
 static struct event_base *ev_base;
-
-static rte_edge_t iface_output;
 
 static void finalize_fd(struct event *ev, void * /*priv*/) {
 	int fd = event_get_fd(ev);
@@ -176,8 +173,8 @@ static void iface_cp_poll(evutil_socket_t, short reason, void *ev_iface) {
 		e->iface = iface;
 		e->domain = ETH_DOMAIN_LOOPBACK;
 
-		if (post_to_stack(loopback_get_control_id(), mbuf) < 0) {
-			LOG(ERR, "post_to_stack loopback: %s", strerror(errno));
+		if (loopback_input_send(mbuf) < 0) {
+			LOG(ERR, "loopback_input_send: %s", strerror(errno));
 			goto err;
 		}
 
@@ -228,8 +225,8 @@ static void iface_cp_poll(evutil_socket_t, short reason, void *ev_iface) {
 	iface_mbuf_data(mbuf)->iface = iface;
 	iface_mbuf_data(mbuf)->vlan_id = 0;
 
-	if (post_to_stack(iface_output, mbuf) < 0) {
-		LOG(ERR, "post_to_stack: %s", strerror(errno));
+	if (iface_output_send(mbuf) < 0) {
+		LOG(ERR, "iface_output_send: %s", strerror(errno));
 		goto err;
 	}
 
@@ -526,7 +523,6 @@ static void cp_module_init(struct event_base *base) {
 		LOG(WARNING, "netlink_flush_cp_route_table: %s", strerror(errno));
 
 	ev_base = base;
-	iface_output = gr_control_input_register_handler("iface_output");
 }
 
 static struct module cp_module = {

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -37,7 +37,6 @@ LOG_TYPE("ctlplane");
 
 #define TUN_TAP_DEV_PATH "/dev/net/tun"
 
-static struct rte_mempool *cp_pool;
 static struct event_base *ev_base;
 
 static control_input_t iface_output;
@@ -120,7 +119,7 @@ static void iface_cp_poll(evutil_socket_t, short reason, void *ev_iface) {
 		return;
 	}
 
-	mbuf = rte_pktmbuf_alloc(cp_pool);
+	mbuf = rte_pktmbuf_alloc(iface->pool);
 	if (!mbuf) {
 		LOG(ERR, "rte_pktmbuf_alloc %s", rte_strerror(rte_errno));
 		goto err;
@@ -341,6 +340,13 @@ static void cp_create(struct iface *iface) {
 		sysctl_write("net/ipv4/conf", iface, "rp_filter", "2");
 	}
 
+	iface->pool = gr_pktmbuf_pool_get(SOCKET_ID_ANY, RTE_GRAPH_BURST_SIZE);
+	if (iface->pool == NULL) {
+		LOG(ERR, "gr_pktmbuf_pool_get: %s", strerror(errno));
+		goto err;
+	}
+	iface->pool_size = RTE_GRAPH_BURST_SIZE;
+
 	iface->cp_ev = event_new(
 		ev_base,
 		iface->cp_fd,
@@ -359,6 +365,10 @@ static void cp_create(struct iface *iface) {
 	return;
 
 err:
+	if (iface->pool != NULL) {
+		gr_pktmbuf_pool_release(iface->pool, iface->pool_size);
+		iface->pool = NULL;
+	}
 	if (iface->cp_fd > 0)
 		close(iface->cp_fd);
 	if (ioctl_sock > 0)
@@ -368,6 +378,10 @@ err:
 static void cp_delete(struct iface *iface) {
 	if (iface->cp_ev)
 		event_free_finalize(0, iface->cp_ev, finalize_fd);
+	if (iface->pool != NULL) {
+		gr_pktmbuf_pool_release(iface->pool, iface->pool_size);
+		iface->pool = NULL;
+	}
 }
 
 static void cp_set_speed(struct iface *iface) {
@@ -511,22 +525,14 @@ static void cp_module_init(struct event_base *base) {
 	if (netlink_flush_cp_route_table() < 0)
 		LOG(WARNING, "netlink_flush_cp_route_table: %s", strerror(errno));
 
-	cp_pool = gr_pktmbuf_pool_get(SOCKET_ID_ANY, RTE_GRAPH_BURST_SIZE);
-	if (!cp_pool)
-		ABORT("pktmbuf_pool returned NULL");
 	ev_base = base;
 	iface_output = gr_control_input_register_handler("iface_output", true);
-}
-
-static void cp_module_fini(struct event_base *) {
-	gr_pktmbuf_pool_release(cp_pool, RTE_GRAPH_BURST_SIZE);
 }
 
 static struct module cp_module = {
 	.name = "controlplane",
 	.depends_on = "graph,mempool",
 	.init = cp_module_init,
-	.fini = cp_module_fini,
 };
 
 RTE_INIT(cp_constructor) {

--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -39,7 +39,7 @@ LOG_TYPE("ctlplane");
 
 static struct event_base *ev_base;
 
-static control_input_t iface_output;
+static rte_edge_t iface_output;
 
 static void finalize_fd(struct event *ev, void * /*priv*/) {
 	int fd = event_get_fd(ev);
@@ -526,7 +526,7 @@ static void cp_module_init(struct event_base *base) {
 		LOG(WARNING, "netlink_flush_cp_route_table: %s", strerror(errno));
 
 	ev_base = base;
-	iface_output = gr_control_input_register_handler("iface_output", true);
+	iface_output = gr_control_input_register_handler("iface_output");
 }
 
 static struct module cp_module = {

--- a/modules/infra/control/iface.h
+++ b/modules/infra/control/iface.h
@@ -26,6 +26,8 @@ struct __rte_cache_aligned iface {
 	int cp_id; // Control plane (Linux) port ID
 	int cp_fd; // control plane fd
 	struct event *cp_ev; // libevent to poll cp_fd
+	struct rte_mempool *pool;
+	uint32_t pool_size;
 	unsigned promisc;
 	bool user_promisc;
 	vec struct iface_mac *macs;

--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -3,6 +3,7 @@
 
 #include "_cmocka.h"
 #include "config.h"
+#include "control_queue.h"
 #include "event.h"
 #include "iface.h"
 #include "log.h"

--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -16,6 +16,8 @@
 #include "vrf.h"
 #include "worker.h"
 
+#include <control_queue.h>
+
 // mocked types/functions
 int gr_rte_log_type;
 struct log_types log_types = STAILQ_HEAD_INITIALIZER(log_types);

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -163,8 +163,8 @@ static void iface_loopback_poll(evutil_socket_t, short reason, void *ev_iface) {
 	e->iface = iface;
 	e->domain = ETH_DOMAIN_LOOPBACK;
 
-	if (post_to_stack(loopback_get_control_id(), mbuf) < 0) {
-		LOG(ERR, "post_to_stack: %s", strerror(errno));
+	if (loopback_input_send(mbuf) < 0) {
+		LOG(ERR, "loopback_input_send: %s", strerror(errno));
 		goto err;
 	}
 

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -34,7 +34,6 @@ LOG_TYPE("loopback");
 // TUN device naming pattern: gr-loop{iface_id}
 #define GR_LOOPBACK_TUN_NAME_PATTERN GR_LOOPBACK_TUN_NAME_PREFIX "%d"
 
-static struct rte_mempool *loopback_pool;
 static struct event_base *ev_base;
 
 static void finalize_fd(struct event *ev, void * /*priv*/) {
@@ -120,7 +119,7 @@ static void iface_loopback_poll(evutil_socket_t, short reason, void *ev_iface) {
 		return;
 	}
 
-	mbuf = rte_pktmbuf_alloc(loopback_pool);
+	mbuf = rte_pktmbuf_alloc(iface->pool);
 	if (!mbuf) {
 		LOG(ERR, "rte_pktmbuf_alloc %s", rte_strerror(rte_errno));
 		goto err;
@@ -246,6 +245,13 @@ int iface_loopback_create(struct iface *iface) {
 		goto err;
 	}
 
+	iface->pool = gr_pktmbuf_pool_get(SOCKET_ID_ANY, RTE_GRAPH_BURST_SIZE);
+	if (iface->pool == NULL) {
+		LOG(ERR, "gr_pktmbuf_pool_get: %s", strerror(errno));
+		goto err;
+	}
+	iface->pool_size = RTE_GRAPH_BURST_SIZE;
+
 	iface->cp_ev = event_new(
 		ev_base,
 		iface->cp_fd,
@@ -268,6 +274,10 @@ err:
 	}
 	if (iface->cp_fd > 0)
 		close(iface->cp_fd);
+	if (iface->pool != NULL) {
+		gr_pktmbuf_pool_release(iface->pool, iface->pool_size);
+		iface->pool = NULL;
+	}
 	if (ioctl_sock > 0)
 		close(ioctl_sock);
 	return errno_set(err_save);
@@ -275,25 +285,21 @@ err:
 
 int iface_loopback_destroy(struct iface *iface) {
 	event_free_finalize(0, iface->cp_ev, finalize_fd);
+	if (iface->pool != NULL) {
+		gr_pktmbuf_pool_release(iface->pool, iface->pool_size);
+		iface->pool = NULL;
+	}
 	return 0;
 }
 
 static void loopback_module_init(struct event_base *base) {
-	loopback_pool = gr_pktmbuf_pool_get(SOCKET_ID_ANY, RTE_GRAPH_BURST_SIZE);
-	if (!loopback_pool)
-		ABORT("pktmbuf_pool returned NULL");
 	ev_base = base;
-}
-
-static void loopback_module_fini(struct event_base *) {
-	gr_pktmbuf_pool_release(loopback_pool, RTE_GRAPH_BURST_SIZE);
 }
 
 static struct module loopback_module = {
 	.name = "iface_loopback",
 	.depends_on = "mempool",
 	.init = loopback_module_init,
-	.fini = loopback_module_fini,
 };
 
 RTE_INIT(loopback_constructor) {

--- a/modules/infra/control/loopback.c
+++ b/modules/infra/control/loopback.c
@@ -10,7 +10,6 @@
 #include "mempool.h"
 #include "module.h"
 #include "netlink.h"
-#include "vrf.h"
 
 #include <gr_infra.h>
 #include <gr_string.h>
@@ -47,7 +46,6 @@ static void finalize_fd(struct event *ev, void * /*priv*/) {
 void loopback_tx(void *obj, uintptr_t, const struct control_queue_drain *drain) {
 	struct rte_mbuf *m = obj;
 	struct mbuf_data *d = mbuf_data(m);
-	struct iface_info_loopback *lo;
 	struct iface_stats *stats;
 	struct iovec iov[2];
 	char *data = NULL;
@@ -56,8 +54,6 @@ void loopback_tx(void *obj, uintptr_t, const struct control_queue_drain *drain) 
 	// Check if packet references deleted interface.
 	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE && d->iface == drain->obj)
 		goto end;
-
-	lo = &iface_info_vrf(d->iface)->lo;
 
 	if (rte_pktmbuf_linearize(m) == 0) {
 		data = rte_pktmbuf_mtod(m, char *);
@@ -88,7 +84,7 @@ void loopback_tx(void *obj, uintptr_t, const struct control_queue_drain *drain) 
 	iov[1].iov_base = data;
 	iov[1].iov_len = rte_pktmbuf_pkt_len(m);
 
-	if (writev(lo->fd, iov, ARRAY_DIM(iov)) < 0) {
+	if (writev(d->iface->cp_fd, iov, ARRAY_DIM(iov)) < 0) {
 		// The user messed up and removed gr-loopX
 		// release resources on our side to try to recover
 		if (errno == EBADFD) {
@@ -109,7 +105,6 @@ end:
 
 static void iface_loopback_poll(evutil_socket_t, short reason, void *ev_iface) {
 	struct iface *iface = ev_iface;
-	struct iface_info_loopback *lo;
 	struct eth_input_mbuf_data *e;
 	struct iface_stats *stats;
 	struct rte_mbuf *mbuf;
@@ -117,8 +112,6 @@ static void iface_loopback_poll(evutil_socket_t, short reason, void *ev_iface) {
 	struct tun_pi pi;
 	size_t len;
 	char *data;
-
-	lo = &iface_info_vrf(iface)->lo;
 
 	if (reason & EV_CLOSED) {
 		// The user messed up and removed gr-loopX
@@ -142,7 +135,7 @@ static void iface_loopback_poll(evutil_socket_t, short reason, void *ev_iface) {
 	iov[0].iov_len = sizeof(pi);
 	iov[1].iov_base = data;
 	iov[1].iov_len = iface->mtu;
-	if ((len = readv(lo->fd, iov, ARRAY_DIM(iov))) <= 0) {
+	if ((len = readv(iface->cp_fd, iov, ARRAY_DIM(iov))) <= 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK)
 			goto err;
 		LOG(ERR, "read from tun device %s failed %s", iface->name, strerror(errno));
@@ -187,15 +180,14 @@ err:
 }
 
 int iface_loopback_create(struct iface *iface) {
-	struct iface_info_vrf *vrf = iface_info_vrf(iface);
-	struct iface_info_loopback *lo = &vrf->lo;
 	char tun_name[IFNAMSIZ];
+	int ioctl_sock = -1;
 	struct ifreq ifr;
-	int ioctl_sock;
 	int err_save;
 	int flags;
 
-	lo->ev = NULL;
+	iface->cp_fd = -1;
+	iface->cp_ev = NULL;
 
 	if (iface->id == GR_VRF_DEFAULT_ID)
 		gr_strcpy(tun_name, sizeof(tun_name), iface->name);
@@ -211,12 +203,12 @@ int iface_loopback_create(struct iface *iface) {
 		goto err;
 	}
 
-	if ((lo->fd = open(TUN_TAP_DEV_PATH, O_RDWR)) < 0) {
+	if ((iface->cp_fd = open(TUN_TAP_DEV_PATH, O_RDWR)) < 0) {
 		LOG(ERR, "open(%s): %s", TUN_TAP_DEV_PATH, strerror(errno));
 		goto err;
 	}
 
-	if (ioctl(lo->fd, TUNSETIFF, &ifr) < 0) {
+	if (ioctl(iface->cp_fd, TUNSETIFF, &ifr) < 0) {
 		LOG(ERR, "ioctl(TUNSETIFF): %s", strerror(errno));
 		goto err;
 	}
@@ -227,14 +219,14 @@ int iface_loopback_create(struct iface *iface) {
 	}
 	iface->cp_id = ifr.ifr_ifindex;
 
-	flags = fcntl(lo->fd, F_GETFL);
+	flags = fcntl(iface->cp_fd, F_GETFL);
 	if (flags == -1) {
 		LOG(ERR, "fcntl(F_GETFL): %s", strerror(errno));
 		goto err;
 	}
 
 	flags |= O_NONBLOCK;
-	if (fcntl(lo->fd, F_SETFL, flags) < 0) {
+	if (fcntl(iface->cp_fd, F_SETFL, flags) < 0) {
 		LOG(ERR, "fcntl(F_SETFL): %s", strerror(errno));
 		goto err;
 	}
@@ -254,15 +246,15 @@ int iface_loopback_create(struct iface *iface) {
 		goto err;
 	}
 
-	lo->ev = event_new(
+	iface->cp_ev = event_new(
 		ev_base,
-		lo->fd,
+		iface->cp_fd,
 		EV_READ | EV_CLOSED | EV_PERSIST | EV_FINALIZE,
 		iface_loopback_poll,
 		iface
 	);
 
-	if (lo->ev == NULL || event_add(lo->ev, NULL) < 0)
+	if (iface->cp_ev == NULL || event_add(iface->cp_ev, NULL) < 0)
 		goto err;
 
 	close(ioctl_sock);
@@ -270,20 +262,19 @@ int iface_loopback_create(struct iface *iface) {
 
 err:
 	err_save = errno;
-	if (lo->ev) {
-		event_del(lo->ev);
-		event_free(lo->ev);
+	if (iface->cp_ev) {
+		event_del(iface->cp_ev);
+		event_free(iface->cp_ev);
 	}
-	if (lo->fd > 0)
-		close(lo->fd);
+	if (iface->cp_fd > 0)
+		close(iface->cp_fd);
 	if (ioctl_sock > 0)
 		close(ioctl_sock);
 	return errno_set(err_save);
 }
 
 int iface_loopback_destroy(struct iface *iface) {
-	struct iface_info_loopback *lo = &iface_info_vrf(iface)->lo;
-	event_free_finalize(0, lo->ev, finalize_fd);
+	event_free_finalize(0, iface->cp_ev, finalize_fd);
 	return 0;
 }
 

--- a/modules/infra/control/loopback.h
+++ b/modules/infra/control/loopback.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include "control_input.h"
 #include "control_queue.h"
 
 #include <rte_byteorder.h>
+#include <rte_mbuf.h>
 
 struct iface;
 
 void loopback_tx(void *obj, uintptr_t priv, const struct control_queue_drain *);
-rte_edge_t loopback_get_control_id(void);
+int loopback_input_send(struct rte_mbuf *);
 void loopback_input_add_type(rte_be16_t eth_type, const char *next_node);
 int iface_loopback_create(struct iface *iface);
 int iface_loopback_destroy(struct iface *iface);

--- a/modules/infra/control/loopback.h
+++ b/modules/infra/control/loopback.h
@@ -11,7 +11,7 @@
 struct iface;
 
 void loopback_tx(void *obj, uintptr_t priv, const struct control_queue_drain *);
-control_input_t loopback_get_control_id(void);
+rte_edge_t loopback_get_control_id(void);
 void loopback_input_add_type(rte_be16_t eth_type, const char *next_node);
 int iface_loopback_create(struct iface *iface);
 int iface_loopback_destroy(struct iface *iface);

--- a/modules/infra/control/loopback.h
+++ b/modules/infra/control/loopback.h
@@ -8,13 +8,7 @@
 
 #include <rte_byteorder.h>
 
-struct event;
 struct iface;
-
-struct iface_info_loopback {
-	int fd;
-	struct event *ev;
-};
 
 void loopback_tx(void *obj, uintptr_t priv, const struct control_queue_drain *);
 control_input_t loopback_get_control_id(void);

--- a/modules/infra/control/vrf.c
+++ b/modules/infra/control/vrf.c
@@ -3,6 +3,7 @@
 
 #include "iface.h"
 #include "log.h"
+#include "loopback.h"
 #include "netlink.h"
 #include "vrf.h"
 

--- a/modules/infra/control/vrf.h
+++ b/modules/infra/control/vrf.h
@@ -4,13 +4,11 @@
 #pragma once
 
 #include "iface.h"
-#include "loopback.h"
 
 #include <gr_infra.h>
 
 GR_IFACE_INFO(GR_IFACE_TYPE_VRF, iface_info_vrf, {
 	BASE(gr_iface_info_vrf);
-	struct iface_info_loopback lo;
 	uint16_t ref_count;
 	uint32_t vrf_ifindex;
 	void *fib4;

--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -6,7 +6,6 @@
 #include "graph.h"
 #include "log.h"
 #include "mbuf.h"
-#include "mempool.h"
 #include "trace.h"
 #include "worker.h"
 
@@ -18,31 +17,20 @@ enum {
 };
 
 struct gr_control_input_msg {
-	uint16_t type;
-	void *data;
-};
-
-struct control_input_edge {
 	rte_edge_t edge;
-	bool data_is_mbuf;
+	struct rte_mbuf *mbuf;
 };
 
 static struct rte_ring *control_input_ring;
 
-static control_input_t next_id = 0;
-static struct control_input_edge control_input_edges[1 << 8];
-
-control_input_t gr_control_input_register_handler(const char *node_name, bool data_is_mbuf) {
-	if (next_id == 0xff)
-		ABORT("control_input: max number of handlers reached");
-	LOG(DEBUG, "control_input: type=%hhu -> %s", next_id, node_name);
-	control_input_edges[next_id].edge = gr_node_attach_parent("control_input", node_name);
-	control_input_edges[next_id].data_is_mbuf = data_is_mbuf;
-	return next_id++;
+rte_edge_t gr_control_input_register_handler(const char *node_name) {
+	rte_edge_t edge = gr_node_attach_parent("control_input", node_name);
+	LOG(DEBUG, "control_input: edge=%u -> %s", edge, node_name);
+	return edge;
 }
 
-int post_to_stack(control_input_t type, void *data) {
-	struct gr_control_input_msg msg = {.type = type, .data = data};
+int post_to_stack(rte_edge_t edge, struct rte_mbuf *m) {
+	struct gr_control_input_msg msg = {.edge = edge, .mbuf = m};
 	int ret;
 
 	ret = rte_ring_enqueue_elem(control_input_ring, &msg, sizeof(msg));
@@ -67,7 +55,6 @@ static uint16_t control_input_process(
 	uint16_t /*nb_objs*/
 ) {
 	struct gr_control_input_msg msg[RTE_GRAPH_BURST_SIZE];
-	struct rte_mempool *mp;
 	struct rte_mbuf *mbuf;
 	rte_edge_t edge;
 	uint16_t n;
@@ -80,41 +67,16 @@ static uint16_t control_input_process(
 		NULL
 	);
 
-	mp = node->ctx_ptr;
-
 	for (unsigned i = 0; i < n; i++) {
-		if (control_input_edges[msg[i].type].data_is_mbuf) {
-			mbuf = msg[i].data;
-		} else {
-			mbuf = rte_pktmbuf_alloc(mp);
-			if (!mbuf) {
-				LOG(ERR, "rte_pktmbuf_alloc %s", rte_strerror(rte_errno));
-				continue;
-			}
-			control_input_mbuf_data(mbuf)->data = msg[i].data;
-		}
+		mbuf = msg[i].mbuf;
+		edge = msg[i].edge;
 
 		if (gr_trace_all_enabled())
 			gr_mbuf_trace_add(mbuf, node, 0); // no data
-		edge = control_input_edges[msg[i].type].edge;
 		rte_node_enqueue_x1(graph, node, edge, mbuf);
 	}
 
 	return n;
-}
-
-static int control_input_init(const struct rte_graph *graph, struct rte_node *node) {
-	node->ctx_ptr = gr_pktmbuf_pool_get(graph->socket, RTE_GRAPH_BURST_SIZE);
-
-	if (node->ctx_ptr == NULL)
-		return errno_log(errno, "gr_pktmbuf_pool_get(control_input)");
-
-	return 0;
-}
-
-static void control_input_fini(const struct rte_graph *, struct rte_node *node) {
-	gr_pktmbuf_pool_release(node->ctx_ptr, RTE_GRAPH_BURST_SIZE);
-	node->ctx_ptr = NULL;
 }
 
 static void control_input_register(void) {
@@ -126,7 +88,7 @@ static void control_input_register(void) {
 		RING_F_MP_RTS_ENQ | RING_F_MC_RTS_DEQ
 	);
 	if (control_input_ring == NULL)
-		ABORT("rte_ring_create(arp_output_request): %s", rte_strerror(rte_errno));
+		ABORT("rte_ring_create(control_input): %s", rte_strerror(rte_errno));
 }
 
 static void control_input_unregister(void) {
@@ -139,8 +101,6 @@ static struct rte_node_register control_input_node = {
 	.process = control_input_process,
 	.nb_edges = EDGE_COUNT,
 	.next_nodes = {[UNKNOWN_CONTROL_INPUT_TYPE] = "control_input_unknown_type"},
-	.init = control_input_init,
-	.fini = control_input_fini,
 };
 
 static struct gr_node_info info = {

--- a/modules/infra/datapath/control_input.h
+++ b/modules/infra/datapath/control_input.h
@@ -3,17 +3,13 @@
 
 #pragma once
 
-#include "mbuf.h"
-
 #include <rte_common.h>
+#include <rte_graph.h>
+#include <rte_mbuf.h>
 
-GR_MBUF_PRIV_DATA_TYPE(control_input_mbuf_data, { void *data; });
+rte_edge_t gr_control_input_register_handler(const char *node_name);
 
-typedef uint8_t control_input_t;
-
-control_input_t gr_control_input_register_handler(const char *node_name, bool data_is_mbuf);
-
-__rte_warn_unused_result int post_to_stack(control_input_t type, void *data);
+__rte_warn_unused_result int post_to_stack(rte_edge_t edge, struct rte_mbuf *m);
 
 // True if the control input ring has packets waiting to be drained by a worker.
 bool control_input_pending(void);

--- a/modules/infra/datapath/eth.h
+++ b/modules/infra/datapath/eth.h
@@ -29,6 +29,8 @@ GR_MBUF_PRIV_DATA_TYPE(eth_output_mbuf_data, {
 
 void gr_eth_input_add_type(rte_be16_t eth_type, const char *node_name);
 
+int eth_output_send(struct rte_mbuf *m);
+
 int eth_trace_format(char *buf, size_t len, const void *data, size_t /*data_len*/);
 
 #define GR_IPPROTO_EIGRP 88

--- a/modules/infra/datapath/eth_output.c
+++ b/modules/infra/datapath/eth_output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "control_input.h"
 #include "eth.h"
 #include "graph.h"
 #include "iface.h"
@@ -16,6 +17,12 @@ enum {
 	NO_MAC,
 	NB_EDGES,
 };
+
+static rte_edge_t control_to_eth_output;
+
+int eth_output_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_eth_output, m);
+}
 
 static uint16_t
 eth_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
@@ -69,6 +76,10 @@ next:
 	return nb_objs;
 }
 
+static void eth_output_register(void) {
+	control_to_eth_output = gr_control_input_register_handler("eth_output");
+}
+
 static struct rte_node_register node = {
 	.name = "eth_output",
 
@@ -85,6 +96,7 @@ static struct rte_node_register node = {
 static struct gr_node_info info = {
 	.node = &node,
 	.type = GR_NODE_T_L2,
+	.register_callback = eth_output_register,
 	.trace_format = eth_trace_format,
 };
 

--- a/modules/infra/datapath/iface_output.c
+++ b/modules/infra/datapath/iface_output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026 Robin Jarry
 
+#include "control_input.h"
 #include "graph.h"
 #include "iface.h"
 #include "log.h"
@@ -29,6 +30,12 @@ void iface_output_type_register(gr_iface_type_t type, const char *next_node) {
 		ABORT("next node already registered for iface type=%s", type_name);
 	LOG(DEBUG, "iface_output: iface_type=%s -> %s", type_name, next_node);
 	iface_type_edges[type] = gr_node_attach_parent("iface_output", next_node);
+}
+
+static rte_edge_t control_to_iface_output;
+
+int iface_output_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_iface_output, m);
 }
 
 struct iface_output_trace_data {
@@ -109,6 +116,10 @@ next:
 	return nb_objs;
 }
 
+static void iface_output_register(void) {
+	control_to_iface_output = gr_control_input_register_handler("iface_output");
+}
+
 static struct rte_node_register node = {
 	.name = "iface_output",
 
@@ -125,6 +136,7 @@ static struct rte_node_register node = {
 static struct gr_node_info info = {
 	.node = &node,
 	.type = GR_NODE_T_L1,
+	.register_callback = iface_output_register,
 	.trace_format = iface_output_trace_format,
 };
 

--- a/modules/infra/datapath/lacp_output.c
+++ b/modules/infra/datapath/lacp_output.c
@@ -12,65 +12,56 @@
 
 enum {
 	OUTPUT = 0,
-	ERROR,
 	EDGE_COUNT,
-};
-
-struct lacp_output_data {
-	const struct iface *iface;
-	struct lacp_pdu pdu;
 };
 
 static control_input_t lacp_output;
 
 int lacp_send_pdu(const struct iface *iface, const struct lacp_pdu *pdu) {
+	struct lacp_pdu *p;
+	struct rte_mbuf *m;
+
 	assert(iface != NULL);
 	assert(iface->type == GR_IFACE_TYPE_PORT);
 
-	struct lacp_output_data *data = malloc(sizeof(*data));
-	if (data == NULL)
+	m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
 		return errno_set(ENOMEM);
 
-	data->iface = iface;
-	data->pdu = *pdu;
+	p = (struct lacp_pdu *)rte_pktmbuf_append(m, sizeof(*p));
+	if (p == NULL) {
+		rte_pktmbuf_free(m);
+		return errno_set(ENOBUFS);
+	}
+	*p = *pdu;
+	mbuf_data(m)->iface = iface;
 
-	return post_to_stack(lacp_output, data);
+	if (post_to_stack(lacp_output, m) < 0) {
+		rte_pktmbuf_free(m);
+		return -errno;
+	}
+	return 0;
 }
 
 static uint16_t
 lacp_output_process(struct rte_graph *graph, struct rte_node *node, void **objs, uint16_t nb_objs) {
-	struct control_input_mbuf_data *ctrl_data;
 	struct eth_output_mbuf_data *eth_data;
-	struct lacp_output_data *lacp_data;
 	struct rte_mbuf *mbuf;
 	struct lacp_pdu *pdu;
-	rte_edge_t edge;
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
-		ctrl_data = control_input_mbuf_data(mbuf);
-		lacp_data = ctrl_data->data;
-
-		pdu = (struct lacp_pdu *)rte_pktmbuf_append(mbuf, sizeof(*pdu));
-		if (pdu == NULL) {
-			edge = ERROR;
-			goto next;
-		}
-		*pdu = lacp_data->pdu;
+		pdu = rte_pktmbuf_mtod(mbuf, struct lacp_pdu *);
 
 		eth_data = eth_output_mbuf_data(mbuf);
 		eth_data->dst = LACP_DST_MAC;
 		eth_data->ether_type = RTE_BE16(RTE_ETHER_TYPE_SLOW);
-		eth_data->iface = lacp_data->iface;
 
-		edge = OUTPUT;
-next:
 		if (gr_mbuf_is_traced(mbuf)) {
 			struct lacp_pdu *t = gr_mbuf_trace_add(mbuf, node, sizeof(*t));
-			*t = lacp_data->pdu;
+			*t = *pdu;
 		}
-		free(lacp_data);
-		rte_node_enqueue_x1(graph, node, edge, mbuf);
+		rte_node_enqueue_x1(graph, node, OUTPUT, mbuf);
 	}
 
 	return nb_objs;
@@ -82,12 +73,11 @@ static struct rte_node_register node = {
 	.nb_edges = EDGE_COUNT,
 	.next_nodes = {
 		[OUTPUT] = "eth_output",
-		[ERROR] = "lacp_output_error",
 	},
 };
 
 static void lacp_output_register(void) {
-	lacp_output = gr_control_input_register_handler("lacp_output", false);
+	lacp_output = gr_control_input_register_handler("lacp_output", true);
 }
 
 static struct gr_node_info info = {
@@ -98,5 +88,3 @@ static struct gr_node_info info = {
 };
 
 GR_NODE_REGISTER(info);
-
-GR_DROP_REGISTER(lacp_output_error);

--- a/modules/infra/datapath/lacp_output.c
+++ b/modules/infra/datapath/lacp_output.c
@@ -15,7 +15,7 @@ enum {
 	EDGE_COUNT,
 };
 
-static control_input_t lacp_output;
+static rte_edge_t lacp_output;
 
 int lacp_send_pdu(const struct iface *iface, const struct lacp_pdu *pdu) {
 	struct lacp_pdu *p;
@@ -77,7 +77,7 @@ static struct rte_node_register node = {
 };
 
 static void lacp_output_register(void) {
-	lacp_output = gr_control_input_register_handler("lacp_output", true);
+	lacp_output = gr_control_input_register_handler("lacp_output");
 }
 
 static struct gr_node_info info = {

--- a/modules/infra/datapath/loop_input.c
+++ b/modules/infra/datapath/loop_input.c
@@ -10,9 +10,9 @@
 
 LOG_TYPE("graph");
 
-static control_input_t control_to_loopback_input;
+static rte_edge_t control_to_loopback_input;
 
-control_input_t loopback_get_control_id(void) {
+rte_edge_t loopback_get_control_id(void) {
 	return control_to_loopback_input;
 }
 
@@ -75,7 +75,7 @@ static struct rte_node_register loopback_input_node = {
 };
 
 static void loopback_input_register(void) {
-	control_to_loopback_input = gr_control_input_register_handler("loopback_input", true);
+	control_to_loopback_input = gr_control_input_register_handler("loopback_input");
 }
 
 static struct gr_node_info info = {

--- a/modules/infra/datapath/loop_input.c
+++ b/modules/infra/datapath/loop_input.c
@@ -12,8 +12,8 @@ LOG_TYPE("graph");
 
 static rte_edge_t control_to_loopback_input;
 
-rte_edge_t loopback_get_control_id(void) {
-	return control_to_loopback_input;
+int loopback_input_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_loopback_input, m);
 }
 
 enum {

--- a/modules/infra/datapath/loop_output.c
+++ b/modules/infra/datapath/loop_output.c
@@ -4,6 +4,7 @@
 #include "control_output.h"
 #include "graph.h"
 #include "loopback.h"
+#include "mbuf.h"
 
 enum {
 	CONTROL_OUTPUT,

--- a/modules/infra/datapath/rxtx.h
+++ b/modules/infra/datapath/rxtx.h
@@ -54,6 +54,7 @@ void iface_input_mode_register(gr_iface_mode_t, const char *next_node);
 void iface_output_type_register(gr_iface_type_t, const char *next_node);
 
 void iface_cp_tx(void *obj, uintptr_t priv, const struct control_queue_drain *);
+int iface_output_send(struct rte_mbuf *);
 
 void rx_burst_histogram_get(uint16_t port_id, uint64_t *histogram, unsigned slots);
 void rx_burst_histogram_reset(void);

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
-#include "control_input.h"
 #include "iface.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "l3.h"
 #include "log.h"
-#include "module.h"
 
 #include <gr_clock.h>
 #include <gr_net_types.h>
@@ -19,13 +17,12 @@
 
 LOG_TYPE("nexthop");
 
-static rte_edge_t ip_output_node;
-
 static int ip_resubmit_cb(struct rte_mbuf *m, struct nexthop *nh) {
 	struct l3_mbuf_data *d = l3_mbuf_data(m);
 	d->nh = nh;
 	d->iface = NULL;
-	if (post_to_stack(ip_output_node, m) < 0) {
+
+	if (ip_output_send(m) < 0) {
 		LOG(ERR, "post_to_stack: %s", strerror(errno));
 		return -errno;
 	}
@@ -126,8 +123,6 @@ free:
 	rte_pktmbuf_free(m);
 }
 
-static rte_edge_t arp_output_reply_node;
-
 void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *drain) {
 	struct nexthop_info_l3 *l3;
 	const struct iface *iface;
@@ -192,7 +187,7 @@ void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *
 		struct arp_reply_mbuf_data *d = arp_reply_mbuf_data(m);
 		d->local = local;
 		d->iface = iface;
-		if (post_to_stack(arp_output_reply_node, m) < 0) {
+		if (arp_output_reply_send(m) < 0) {
 			LOG(ERR, "post_to_stack: %s", strerror(errno));
 			goto free;
 		}
@@ -215,17 +210,6 @@ free:
 	rte_pktmbuf_free(m);
 }
 
-static void nh4_init(struct event_base *) {
-	ip_output_node = gr_control_input_register_handler("ip_output");
-	arp_output_reply_node = gr_control_input_register_handler("arp_output_reply");
-}
-
-static struct module nh4_module = {
-	.name = "ip_nexthop",
-	.depends_on = "graph",
-	.init = nh4_init,
-};
-
 static struct nexthop_af_ops nh_ops = {
 	.resolve = nh4_resolve_cb,
 	.solicit = arp_output_request_solicit,
@@ -234,6 +218,5 @@ static struct nexthop_af_ops nh_ops = {
 };
 
 RTE_INIT(control_ip_init) {
-	module_register(&nh4_module);
 	nexthop_af_ops_register(GR_AF_IP4, &nh_ops);
 }

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -19,7 +19,7 @@
 
 LOG_TYPE("nexthop");
 
-static control_input_t ip_output_node;
+static rte_edge_t ip_output_node;
 
 static int ip_resubmit_cb(struct rte_mbuf *m, struct nexthop *nh) {
 	struct l3_mbuf_data *d = l3_mbuf_data(m);
@@ -126,7 +126,7 @@ free:
 	rte_pktmbuf_free(m);
 }
 
-static control_input_t arp_output_reply_node;
+static rte_edge_t arp_output_reply_node;
 
 void arp_probe_input_cb(void *obj, uintptr_t, const struct control_queue_drain *drain) {
 	struct nexthop_info_l3 *l3;
@@ -216,8 +216,8 @@ free:
 }
 
 static void nh4_init(struct event_base *) {
-	ip_output_node = gr_control_input_register_handler("ip_output", true);
-	arp_output_reply_node = gr_control_input_register_handler("arp_output_reply", true);
+	ip_output_node = gr_control_input_register_handler("ip_output");
+	arp_output_reply_node = gr_control_input_register_handler("arp_output_reply");
 }
 
 static struct module nh4_module = {

--- a/modules/ip/datapath/arp_output_reply.c
+++ b/modules/ip/datapath/arp_output_reply.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "control_input.h"
 #include "eth.h"
 #include "graph.h"
 #include "iface.h"
@@ -15,6 +16,12 @@ enum {
 	ERROR,
 	EDGE_COUNT,
 };
+
+static rte_edge_t control_to_arp_output_reply;
+
+int arp_output_reply_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_arp_output_reply, m);
+}
 
 static uint16_t arp_output_reply_process(
 	struct rte_graph *graph,
@@ -76,6 +83,10 @@ next:
 	return num;
 }
 
+static void arp_output_reply_register(void) {
+	control_to_arp_output_reply = gr_control_input_register_handler("arp_output_reply");
+}
+
 static struct rte_node_register node = {
 	.name = "arp_output_reply",
 	.process = arp_output_reply_process,
@@ -89,6 +100,7 @@ static struct rte_node_register node = {
 static struct gr_node_info info = {
 	.node = &node,
 	.type = GR_NODE_T_CONTROL | GR_NODE_T_L2,
+	.register_callback = arp_output_reply_register,
 	.trace_format = (gr_trace_format_cb_t)trace_arp_format,
 };
 

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -7,6 +7,7 @@
 #include "iface.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
+#include "l3.h"
 #include "trace.h"
 
 #include <gr_clock.h>
@@ -26,6 +27,9 @@ enum {
 static control_input_t arp_solicit;
 
 int arp_output_request_solicit(struct nexthop *nh) {
+	struct iface *iface;
+	struct rte_mbuf *m;
+
 	if (nh == NULL || nh->type != GR_NH_T_L3)
 		return errno_set(EINVAL);
 
@@ -42,7 +46,22 @@ int arp_output_request_solicit(struct nexthop *nh) {
 			l3->bcast_probes++;
 	}
 
-	return post_to_stack(arp_solicit, nh);
+	iface = iface_from_id(nh->iface_id);
+	if (iface == NULL)
+		return errno_set(ENODEV);
+
+	m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
+		return errno_set(ENOMEM);
+
+	l3_mbuf_data(m)->nh = nh;
+
+	if (post_to_stack(arp_solicit, m) < 0) {
+		rte_pktmbuf_free(m);
+		return -errno;
+	}
+
+	return 0;
 }
 
 static uint16_t arp_output_request_process(
@@ -65,7 +84,7 @@ static uint16_t arp_output_request_process(
 
 	for (unsigned i = 0; i < n_objs; i++) {
 		mbuf = objs[i];
-		nh = control_input_mbuf_data(mbuf)->data;
+		nh = l3_mbuf_data(mbuf)->nh;
 
 		if (nh->type == GR_NH_T_BLACKHOLE) {
 			edge = BLACKHOLE;
@@ -137,7 +156,7 @@ next:
 }
 
 static void arp_output_request_register(void) {
-	arp_solicit = gr_control_input_register_handler("arp_output_request", false);
+	arp_solicit = gr_control_input_register_handler("arp_output_request", true);
 }
 
 static struct rte_node_register arp_output_request_node = {

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -24,7 +24,7 @@ enum {
 	EDGE_COUNT,
 };
 
-static control_input_t arp_solicit;
+static rte_edge_t arp_solicit;
 
 int arp_output_request_solicit(struct nexthop *nh) {
 	struct iface *iface;
@@ -156,7 +156,7 @@ next:
 }
 
 static void arp_output_request_register(void) {
-	arp_solicit = gr_control_input_register_handler("arp_output_request", true);
+	arp_solicit = gr_control_input_register_handler("arp_output_request");
 }
 
 static struct rte_node_register arp_output_request_node = {

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -3,6 +3,7 @@
 
 #include "control_input.h"
 #include "graph.h"
+#include "iface.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "mbuf.h"
@@ -18,14 +19,14 @@ enum {
 	EDGE_COUNT,
 };
 
-struct ctl_to_stack {
+GR_MBUF_PRIV_DATA_TYPE(icmp_send_mbuf_data, {
 	ip4_addr_t dst;
 	ip4_addr_t src;
 	uint16_t vrf_id;
 	uint16_t ident;
 	uint16_t seq_num;
 	uint8_t ttl;
-};
+});
 
 static control_input_t ip4_icmp_request;
 
@@ -38,35 +39,41 @@ int icmp_local_send(
 	uint8_t ttl
 ) {
 	const struct nexthop_info_l3 *l3;
+	struct icmp_send_mbuf_data *d;
 	const struct nexthop *local;
-	struct ctl_to_stack *msg;
+	struct iface *iface;
+	struct rte_mbuf *m;
 	int ret;
 
 	// FIXME
 	if (gw->type != GR_NH_T_L3)
 		return errno_set(ENONET);
 
-	if ((msg = calloc(1, sizeof(struct ctl_to_stack))) == NULL)
-		return errno_set(ENOMEM);
-
-	msg->seq_num = seq_num;
-	msg->vrf_id = vrf_id;
-	msg->ident = ident;
-	msg->ttl = ttl;
-	msg->dst = dst;
-
 	l3 = nexthop_info_l3(gw);
 
 	if ((local = addr4_get_preferred(gw->iface_id, l3->ipv4)) == NULL) {
-		free(msg);
 		return -errno;
 	}
 
-	l3 = nexthop_info_l3(local);
-	msg->src = l3->ipv4;
+	iface = iface_from_id(gw->iface_id);
+	if (iface == NULL)
+		return errno_set(ENODEV);
 
-	if ((ret = post_to_stack(ip4_icmp_request, msg)) < 0) {
-		free(msg);
+	m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
+		return errno_set(ENOMEM);
+
+	d = icmp_send_mbuf_data(m);
+	d->seq_num = seq_num;
+	d->vrf_id = vrf_id;
+	d->ident = ident;
+	d->ttl = ttl;
+	d->dst = dst;
+	d->src = nexthop_info_l3(local)->ipv4;
+	d->iface = iface;
+
+	if ((ret = post_to_stack(ip4_icmp_request, m)) < 0) {
+		rte_pktmbuf_free(m);
 		return ret;
 	}
 
@@ -80,15 +87,15 @@ static uint16_t icmp_local_send_process(
 	uint16_t n_objs
 ) {
 	struct ip_local_mbuf_data *data;
+	struct icmp_send_mbuf_data msg;
 	struct rte_icmp_hdr *icmp;
-	struct ctl_to_stack *msg;
 	gr_clock_ns_t *payload;
 	struct rte_mbuf *mbuf;
 	rte_edge_t next;
 
 	for (unsigned i = 0; i < n_objs; i++) {
 		mbuf = objs[i];
-		msg = control_input_mbuf_data(mbuf)->data;
+		msg = *icmp_send_mbuf_data(mbuf);
 		icmp = (struct rte_icmp_hdr *)rte_pktmbuf_append(
 			mbuf, sizeof(*icmp) + sizeof(gr_clock_ns_t)
 		);
@@ -99,21 +106,22 @@ static uint16_t icmp_local_send_process(
 		// Build ICMP packet
 		icmp->icmp_type = RTE_ICMP_TYPE_ECHO_REQUEST;
 		icmp->icmp_code = 0;
-		icmp->icmp_seq_nb = rte_cpu_to_be_16(msg->seq_num);
-		icmp->icmp_ident = rte_cpu_to_be_16(msg->ident);
+		icmp->icmp_seq_nb = rte_cpu_to_be_16(msg.seq_num);
+		icmp->icmp_ident = rte_cpu_to_be_16(msg.ident);
 
 		// Fake RSS to spread the traffic
 		// for ECMP routes or active/active bonds.
-		mbuf->hash.rss = msg->ident;
+		mbuf->hash.rss = msg.ident;
 		mbuf->ol_flags |= RTE_MBUF_F_RX_RSS_HASH;
 
 		data = ip_local_mbuf_data(mbuf);
 		data->proto = IPPROTO_ICMP;
 		data->len = sizeof(*icmp) + sizeof(gr_clock_ns_t);
-		data->dst = msg->dst;
-		data->src = msg->src;
-		data->vrf_id = msg->vrf_id;
-		data->ttl = msg->ttl;
+		data->dst = msg.dst;
+		data->src = msg.src;
+		data->vrf_id = msg.vrf_id;
+		data->ttl = msg.ttl;
+		data->iface = msg.iface;
 
 		next = OUTPUT;
 
@@ -122,14 +130,13 @@ static uint16_t icmp_local_send_process(
 			*t = *icmp;
 		}
 		rte_node_enqueue_x1(graph, node, next, mbuf);
-		free(msg);
 	}
 
 	return n_objs;
 }
 
 static void icmp_local_send_register(void) {
-	ip4_icmp_request = gr_control_input_register_handler("icmp_local_send", false);
+	ip4_icmp_request = gr_control_input_register_handler("icmp_local_send", true);
 }
 
 static struct rte_node_register icmp_local_send_node = {

--- a/modules/ip/datapath/icmp_local_send.c
+++ b/modules/ip/datapath/icmp_local_send.c
@@ -28,7 +28,7 @@ GR_MBUF_PRIV_DATA_TYPE(icmp_send_mbuf_data, {
 	uint8_t ttl;
 });
 
-static control_input_t ip4_icmp_request;
+static rte_edge_t ip4_icmp_request;
 
 int icmp_local_send(
 	uint16_t vrf_id,
@@ -136,7 +136,7 @@ static uint16_t icmp_local_send_process(
 }
 
 static void icmp_local_send_register(void) {
-	ip4_icmp_request = gr_control_input_register_handler("icmp_local_send", true);
+	ip4_icmp_request = gr_control_input_register_handler("icmp_local_send");
 }
 
 static struct rte_node_register icmp_local_send_node = {

--- a/modules/ip/datapath/ip4_datapath.h
+++ b/modules/ip/datapath/ip4_datapath.h
@@ -30,7 +30,9 @@ void ip_input_register_nexthop_type(gr_nh_type_t type, const char *next_node);
 void ip_input_local_add_proto(uint8_t proto, const char *next_node);
 void ip_output_register_interface_type(gr_iface_type_t type, const char *next_node);
 void ip_output_register_nexthop_type(gr_nh_type_t type, const char *next_node);
+int ip_output_send(struct rte_mbuf *m);
 int arp_output_request_solicit(struct nexthop *nh);
+int arp_output_reply_send(struct rte_mbuf *m);
 void arp_update_nexthop(
 	struct rte_graph *graph,
 	struct rte_node *node,

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "control_input.h"
 #include "eth.h"
 #include "graph.h"
 #include "iface.h"
@@ -50,6 +51,12 @@ void ip_output_register_nexthop_type(gr_nh_type_t type, const char *next_node) {
 		ABORT("next node already registered for nexthop type=%s", type_name);
 	LOG(DEBUG, "ip_output: nh_type=%s -> %s", type_name, next_node);
 	nh_type_edges[type] = gr_node_attach_parent("ip_output", next_node);
+}
+
+static rte_edge_t control_to_ip_output;
+
+int ip_output_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_ip_output, m);
 }
 
 static uint16_t
@@ -155,6 +162,10 @@ next:
 	return sent;
 }
 
+static void ip_output_register(void) {
+	control_to_ip_output = gr_control_input_register_handler("ip_output");
+}
+
 static struct rte_node_register output_node = {
 	.name = "ip_output",
 	.process = ip_output_process,
@@ -173,6 +184,7 @@ static struct rte_node_register output_node = {
 static struct gr_node_info info = {
 	.node = &output_node,
 	.type = GR_NODE_T_L3,
+	.register_callback = ip_output_register,
 	.trace_format = (gr_trace_format_cb_t)trace_ip_format,
 };
 

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -23,7 +23,7 @@
 
 LOG_TYPE("nexthop");
 
-static control_input_t ip6_output_node;
+static rte_edge_t ip6_output_node;
 
 static int ip6_resubmit_cb(struct rte_mbuf *m, struct nexthop *nh) {
 	struct l3_mbuf_data *d = l3_mbuf_data(m);
@@ -265,7 +265,7 @@ free:
 }
 
 static void nh6_init(struct event_base *) {
-	ip6_output_node = gr_control_input_register_handler("ip6_output", true);
+	ip6_output_node = gr_control_input_register_handler("ip6_output");
 }
 
 static struct module nh6_module = {

--- a/modules/ip6/control/nexthop.c
+++ b/modules/ip6/control/nexthop.c
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
-#include "control_input.h"
 #include "icmp6.h"
 #include "iface.h"
 #include "ip6.h"
 #include "ip6_datapath.h"
 #include "l3.h"
 #include "log.h"
-#include "module.h"
 
 #include <gr_clock.h>
 #include <gr_net_types.h>
@@ -23,13 +21,11 @@
 
 LOG_TYPE("nexthop");
 
-static rte_edge_t ip6_output_node;
-
 static int ip6_resubmit_cb(struct rte_mbuf *m, struct nexthop *nh) {
 	struct l3_mbuf_data *d = l3_mbuf_data(m);
 	d->nh = nh;
 	d->iface = NULL;
-	if (post_to_stack(ip6_output_node, m) < 0) {
+	if (ip6_output_send(m) < 0) {
 		LOG(ERR, "post_to_stack: %s", strerror(errno));
 		return -errno;
 	}
@@ -264,16 +260,6 @@ free:
 	rte_pktmbuf_free(m);
 }
 
-static void nh6_init(struct event_base *) {
-	ip6_output_node = gr_control_input_register_handler("ip6_output");
-}
-
-static struct module nh6_module = {
-	.name = "ip6_nexthop",
-	.depends_on = "graph",
-	.init = nh6_init,
-};
-
 static struct nexthop_af_ops nh_ops = {
 	.resolve = nh6_resolve_cb,
 	.solicit = nh6_solicit,
@@ -282,6 +268,5 @@ static struct nexthop_af_ops nh_ops = {
 };
 
 RTE_INIT(control_ip_init) {
-	module_register(&nh6_module);
 	nexthop_af_ops_register(GR_AF_IP6, &nh_ops);
 }

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -9,7 +9,6 @@
 #include "ip6_datapath.h"
 #include "l3.h"
 #include "log.h"
-#include "mempool.h"
 #include "module.h"
 #include "vec.h"
 
@@ -25,11 +24,6 @@ LOG_TYPE("ra");
 #define RA_DEFAULT_INTERVAL 600
 #define RA_DEFAULT_LIFETIME 1800
 
-struct ra_ctx {
-	struct rte_mempool *mp;
-};
-
-static struct ra_ctx ra_ctx;
 static control_input_t ra_output;
 static struct event_base *ev_base;
 
@@ -177,7 +171,7 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 			continue;
 		if (!rte_ipv6_addr_is_linklocal(&l3->ipv6))
 			continue;
-		if ((m = rte_pktmbuf_alloc(ra_ctx.mp)) == NULL) {
+		if ((m = rte_pktmbuf_alloc(iface->pool)) == NULL) {
 			LOG(ERR, "rte_pktmbuf_alloc");
 			return;
 		}
@@ -193,21 +187,12 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 static void ra_init(struct event_base *base) {
 	ev_base = base;
 	ra_output = gr_control_input_register_handler("ip6_output", true);
-	ra_ctx.mp = gr_pktmbuf_pool_get(SOCKET_ID_ANY, 512);
-	if (ra_ctx.mp == NULL) {
-		ABORT("gr_pktmbuf_pool_get ENOMEM");
-	}
-}
-
-static void ra_fini(struct event_base * /*ev_base*/) {
-	gr_pktmbuf_pool_release(ra_ctx.mp, 512);
 }
 
 static struct module ra_module = {
 	.name = "ip6_router_advert",
-	.depends_on = "graph,mempool",
+	.depends_on = "graph",
 	.init = ra_init,
-	.fini = ra_fini,
 };
 
 static void iface_event_handler(uint32_t event, const void *obj) {

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025 Christophe Fontaine
 
-#include "control_input.h"
 #include "event.h"
 #include "icmp6.h"
 #include "iface.h"
@@ -24,7 +23,6 @@ LOG_TYPE("ra");
 #define RA_DEFAULT_INTERVAL 600
 #define RA_DEFAULT_LIFETIME 1800
 
-static rte_edge_t ra_output;
 static struct event_base *ev_base;
 
 struct ra_iface_conf {
@@ -177,7 +175,7 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 		}
 		mbuf_data(m)->iface = iface;
 		build_ra_packet(m, &l3->ipv6);
-		if (post_to_stack(ra_output, m) < 0) {
+		if (ip6_output_send(m) < 0) {
 			rte_pktmbuf_free(m);
 			LOG(ERR, "post_to_stack: %s", strerror(errno));
 		}
@@ -186,7 +184,6 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 
 static void ra_init(struct event_base *base) {
 	ev_base = base;
-	ra_output = gr_control_input_register_handler("ip6_output");
 }
 
 static struct module ra_module = {

--- a/modules/ip6/control/router_advert.c
+++ b/modules/ip6/control/router_advert.c
@@ -24,7 +24,7 @@ LOG_TYPE("ra");
 #define RA_DEFAULT_INTERVAL 600
 #define RA_DEFAULT_LIFETIME 1800
 
-static control_input_t ra_output;
+static rte_edge_t ra_output;
 static struct event_base *ev_base;
 
 struct ra_iface_conf {
@@ -186,7 +186,7 @@ static void send_ra_cb(evutil_socket_t, short /*what*/, void *priv) {
 
 static void ra_init(struct event_base *base) {
 	ev_base = base;
-	ra_output = gr_control_input_register_handler("ip6_output", true);
+	ra_output = gr_control_input_register_handler("ip6_output");
 }
 
 static struct module ra_module = {

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -29,7 +29,7 @@ GR_MBUF_PRIV_DATA_TYPE(icmp6_send_mbuf_data, {
 	uint8_t hop_limit;
 });
 
-static control_input_t ctl_icmp6_request;
+static rte_edge_t ctl_icmp6_request;
 
 // called from control context
 int icmp6_local_send(
@@ -134,7 +134,7 @@ static uint16_t icmp6_local_send_process(
 }
 
 static void icmp6_local_send_register(void) {
-	ctl_icmp6_request = gr_control_input_register_handler("icmp6_local_send", true);
+	ctl_icmp6_request = gr_control_input_register_handler("icmp6_local_send");
 }
 
 static struct rte_node_register icmp6_local_send_node = {

--- a/modules/ip6/datapath/icmp6_local_send.c
+++ b/modules/ip6/datapath/icmp6_local_send.c
@@ -4,6 +4,7 @@
 #include "control_input.h"
 #include "graph.h"
 #include "icmp6.h"
+#include "iface.h"
 #include "ip6.h"
 #include "ip6_datapath.h"
 #include "mbuf.h"
@@ -19,15 +20,14 @@ enum {
 	EDGE_COUNT,
 };
 
-struct ctl_to_stack {
+GR_MBUF_PRIV_DATA_TYPE(icmp6_send_mbuf_data, {
 	struct rte_ipv6_addr dst;
 	struct rte_ipv6_addr src;
-	uint16_t iface_id;
 	uint16_t vrf_id;
 	uint16_t ident;
 	uint16_t seq_num;
 	uint8_t hop_limit;
-};
+});
 
 static control_input_t ctl_icmp6_request;
 
@@ -39,8 +39,10 @@ int icmp6_local_send(
 	uint16_t seq_num,
 	uint8_t hop_limit
 ) {
-	struct ctl_to_stack *msg;
+	struct icmp6_send_mbuf_data *d;
 	const struct nexthop *local;
+	struct iface *iface;
+	struct rte_mbuf *m;
 	int ret;
 
 	// FIXME
@@ -50,17 +52,25 @@ int icmp6_local_send(
 	if ((local = addr6_get_preferred(gw->iface_id, &nexthop_info_l3(gw)->ipv6)) == NULL)
 		return -errno;
 
-	if ((msg = calloc(1, sizeof(struct ctl_to_stack))) == NULL)
-		return errno_set(ENOMEM);
-	msg->iface_id = gw->iface_id;
-	msg->seq_num = seq_num;
-	msg->ident = ident;
-	msg->hop_limit = hop_limit;
-	msg->dst = *dst;
-	msg->src = nexthop_info_l3(local)->ipv6;
+	iface = iface_from_id(gw->iface_id);
+	if (iface == NULL)
+		return errno_set(ENODEV);
 
-	if ((ret = post_to_stack(ctl_icmp6_request, msg)) < 0) {
-		free(msg);
+	m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
+		return errno_set(ENOMEM);
+
+	d = icmp6_send_mbuf_data(m);
+	d->iface = iface;
+	d->seq_num = seq_num;
+	d->vrf_id = gw->vrf_id;
+	d->ident = ident;
+	d->hop_limit = hop_limit;
+	d->dst = *dst;
+	d->src = nexthop_info_l3(local)->ipv6;
+
+	if ((ret = post_to_stack(ctl_icmp6_request, m)) < 0) {
+		rte_pktmbuf_free(m);
 		return ret;
 	}
 
@@ -75,7 +85,7 @@ static uint16_t icmp6_local_send_process(
 ) {
 	struct icmp6_echo_request *icmp6_echo;
 	struct ip6_local_mbuf_data *data;
-	struct ctl_to_stack *msg;
+	struct icmp6_send_mbuf_data msg;
 	gr_clock_ns_t *payload;
 	struct rte_mbuf *mbuf;
 	struct icmp6 *icmp6;
@@ -84,7 +94,7 @@ static uint16_t icmp6_local_send_process(
 
 	for (unsigned i = 0; i < n_objs; i++) {
 		mbuf = objs[i];
-		msg = control_input_mbuf_data(mbuf)->data;
+		msg = *icmp6_send_mbuf_data(mbuf);
 		pkt_len = sizeof(*icmp6) + sizeof(*icmp6_echo) + sizeof(gr_clock_ns_t);
 		icmp6 = (struct icmp6 *)rte_pktmbuf_append(mbuf, pkt_len);
 
@@ -92,24 +102,24 @@ static uint16_t icmp6_local_send_process(
 		icmp6->code = 0;
 
 		icmp6_echo = PAYLOAD(icmp6);
-		icmp6_echo->ident = rte_cpu_to_be_16(msg->ident);
-		icmp6_echo->seqnum = rte_cpu_to_be_16(msg->seq_num);
+		icmp6_echo->ident = rte_cpu_to_be_16(msg.ident);
+		icmp6_echo->seqnum = rte_cpu_to_be_16(msg.seq_num);
 
 		// Fake RSS to spread the traffic
 		// for ECMP routes or active/active bonds.
-		mbuf->hash.rss = msg->ident;
+		mbuf->hash.rss = msg.ident;
 		mbuf->ol_flags |= RTE_MBUF_F_RX_RSS_HASH;
 
 		payload = PAYLOAD(icmp6_echo);
 		*payload = gr_clock_ns();
 
 		data = ip6_local_mbuf_data(mbuf);
-		data->iface = iface_from_id(msg->iface_id);
+		data->iface = msg.iface;
 		data->proto = IPPROTO_ICMPV6;
 		data->len = pkt_len;
-		data->dst = msg->dst;
-		data->src = msg->src;
-		data->hop_limit = msg->hop_limit;
+		data->dst = msg.dst;
+		data->src = msg.src;
+		data->hop_limit = msg.hop_limit;
 
 		next = OUTPUT;
 
@@ -118,14 +128,13 @@ static uint16_t icmp6_local_send_process(
 			*t = *icmp6;
 		}
 		rte_node_enqueue_x1(graph, node, next, mbuf);
-		free(msg);
 	}
 
 	return n_objs;
 }
 
 static void icmp6_local_send_register(void) {
-	ctl_icmp6_request = gr_control_input_register_handler("icmp6_local_send", false);
+	ctl_icmp6_request = gr_control_input_register_handler("icmp6_local_send", true);
 }
 
 static struct rte_node_register icmp6_local_send_node = {

--- a/modules/ip6/datapath/ip6_datapath.h
+++ b/modules/ip6/datapath/ip6_datapath.h
@@ -29,6 +29,7 @@ void ip6_input_local_add_proto(uint8_t proto, const char *next_node);
 void ip6_input_register_nexthop_type(gr_nh_type_t type, const char *next_node);
 void ip6_output_register_interface_type(gr_iface_type_t type, const char *next_node);
 void ip6_output_register_nexthop_type(gr_nh_type_t type, const char *next_node);
+int ip6_output_send(struct rte_mbuf *m);
 int nh6_solicit(struct nexthop *nh);
 int nh6_advertise(const struct nexthop *local, const struct nexthop *remote);
 

--- a/modules/ip6/datapath/ip6_output.c
+++ b/modules/ip6/datapath/ip6_output.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024 Robin Jarry
 
+#include "control_input.h"
 #include "eth.h"
 #include "graph.h"
 #include "iface.h"
@@ -46,6 +47,12 @@ void ip6_output_register_nexthop_type(gr_nh_type_t type, const char *next_node) 
 		ABORT("next node already registered for nexthop type=%s", type_name);
 	LOG(DEBUG, "ip6_output: nh_type=%s -> %s", type_name, next_node);
 	nh_type_edges[type] = gr_node_attach_parent("ip6_output", next_node);
+}
+
+static rte_edge_t control_to_ip6_output;
+
+int ip6_output_send(struct rte_mbuf *m) {
+	return post_to_stack(control_to_ip6_output, m);
 }
 
 static uint16_t
@@ -137,6 +144,10 @@ next:
 	return sent;
 }
 
+static void ip6_output_register(void) {
+	control_to_ip6_output = gr_control_input_register_handler("ip6_output");
+}
+
 static struct rte_node_register output_node = {
 	.name = "ip6_output",
 	.process = ip6_output_process,
@@ -153,6 +164,7 @@ static struct rte_node_register output_node = {
 static struct gr_node_info info = {
 	.node = &output_node,
 	.type = GR_NODE_T_L3,
+	.register_callback = ip6_output_register,
 	.trace_format = (gr_trace_format_cb_t)trace_ip6_format,
 };
 

--- a/modules/ip6/datapath/ndp_na_output.c
+++ b/modules/ip6/datapath/ndp_na_output.c
@@ -21,7 +21,7 @@ GR_MBUF_PRIV_DATA_TYPE(ndp_na_mbuf_data, {
 	const struct nexthop *remote;
 });
 
-static control_input_t na_output;
+static rte_edge_t na_output;
 
 int nh6_advertise(const struct nexthop *local, const struct nexthop *remote) {
 	struct ndp_na_mbuf_data *d;
@@ -121,7 +121,7 @@ static uint16_t ndp_na_output_process(
 }
 
 static void ndp_na_output_register(void) {
-	na_output = gr_control_input_register_handler("ndp_na_output", true);
+	na_output = gr_control_input_register_handler("ndp_na_output");
 }
 
 static struct rte_node_register node = {

--- a/modules/ip6/datapath/ndp_na_output.c
+++ b/modules/ip6/datapath/ndp_na_output.c
@@ -4,6 +4,7 @@
 #include "control_input.h"
 #include "graph.h"
 #include "icmp6.h"
+#include "iface.h"
 #include "ip6_datapath.h"
 #include "mbuf.h"
 #include "trace.h"
@@ -15,27 +16,36 @@ enum {
 	EDGE_COUNT,
 };
 
-struct advertise_context {
+GR_MBUF_PRIV_DATA_TYPE(ndp_na_mbuf_data, {
 	const struct nexthop *local;
 	const struct nexthop *remote;
-	const struct iface *iface;
-};
+});
 
 static control_input_t na_output;
 
 int nh6_advertise(const struct nexthop *local, const struct nexthop *remote) {
+	struct ndp_na_mbuf_data *d;
+	struct iface *iface;
+	struct rte_mbuf *m;
+
 	assert(local != NULL);
 	assert(local->type == GR_NH_T_L3);
-	struct advertise_context *ctx = malloc(sizeof(*ctx));
-	if (ctx == NULL)
+
+	iface = iface_from_id(local->iface_id);
+	assert(iface != NULL);
+
+	m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
 		return errno_set(ENOMEM);
-	ctx->local = local;
-	ctx->remote = remote;
-	ctx->iface = iface_from_id(local->iface_id);
-	assert(ctx->iface != NULL);
-	int ret = post_to_stack(na_output, ctx);
+
+	d = ndp_na_mbuf_data(m);
+	d->iface = iface;
+	d->local = local;
+	d->remote = remote;
+
+	int ret = post_to_stack(na_output, m);
 	if (ret < 0)
-		free(ctx);
+		rte_pktmbuf_free(m);
 	return ret;
 }
 
@@ -46,7 +56,7 @@ static uint16_t ndp_na_output_process(
 	uint16_t nb_objs
 ) {
 	const struct nexthop *local, *remote;
-	struct advertise_context *ctx;
+	struct ndp_na_mbuf_data *ctx;
 	struct ip6_local_mbuf_data *d;
 	struct icmp6_neigh_advert *na;
 	struct icmp6_opt_lladdr *ll;
@@ -59,11 +69,10 @@ static uint16_t ndp_na_output_process(
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
-		ctx = control_input_mbuf_data(mbuf)->data;
+		ctx = ndp_na_mbuf_data(mbuf);
 		local = ctx->local;
 		remote = ctx->remote;
 		iface = ctx->iface;
-		free(ctx);
 		l3 = nexthop_info_l3(local);
 
 		rte_pktmbuf_trim(mbuf, rte_pktmbuf_pkt_len(mbuf));
@@ -112,7 +121,7 @@ static uint16_t ndp_na_output_process(
 }
 
 static void ndp_na_output_register(void) {
-	na_output = gr_control_input_register_handler("ndp_na_output", false);
+	na_output = gr_control_input_register_handler("ndp_na_output", true);
 }
 
 static struct rte_node_register node = {

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -23,7 +23,7 @@ enum {
 	EDGE_COUNT,
 };
 
-static control_input_t ndp_solicit;
+static rte_edge_t ndp_solicit;
 
 int nh6_solicit(struct nexthop *nh) {
 	if (nh == NULL || nh->type != GR_NH_T_L3)
@@ -136,7 +136,7 @@ next:
 }
 
 static void ndp_output_solicit_register(void) {
-	ndp_solicit = gr_control_input_register_handler("ndp_ns_output", true);
+	ndp_solicit = gr_control_input_register_handler("ndp_ns_output");
 }
 
 static struct rte_node_register node = {

--- a/modules/ip6/datapath/ndp_ns_output.c
+++ b/modules/ip6/datapath/ndp_ns_output.c
@@ -7,6 +7,7 @@
 #include "iface.h"
 #include "ip6.h"
 #include "ip6_datapath.h"
+#include "l3.h"
 #include "trace.h"
 
 #include <gr_clock.h>
@@ -38,7 +39,22 @@ int nh6_solicit(struct nexthop *nh) {
 	else
 		l3->bcast_probes++;
 
-	return post_to_stack(ndp_solicit, nh);
+	struct iface *iface = iface_from_id(nh->iface_id);
+	if (iface == NULL)
+		return errno_set(ENODEV);
+
+	struct rte_mbuf *m = rte_pktmbuf_alloc(iface->pool);
+	if (m == NULL)
+		return errno_set(ENOBUFS);
+
+	l3_mbuf_data(m)->nh = nh;
+
+	if (post_to_stack(ndp_solicit, m) < 0) {
+		rte_pktmbuf_free(m);
+		return -errno;
+	}
+
+	return 0;
 }
 
 static uint16_t ndp_ns_output_process(
@@ -61,7 +77,7 @@ static uint16_t ndp_ns_output_process(
 	for (unsigned i = 0; i < nb_objs; i++) {
 		mbuf = objs[i];
 
-		nh = control_input_mbuf_data(mbuf)->data;
+		nh = l3_mbuf_data(mbuf)->nh;
 		if (nh == NULL) {
 			next = ERROR;
 			goto next;
@@ -120,7 +136,7 @@ next:
 }
 
 static void ndp_output_solicit_register(void) {
-	ndp_solicit = gr_control_input_register_handler("ndp_ns_output", false);
+	ndp_solicit = gr_control_input_register_handler("ndp_ns_output", true);
 }
 
 static struct rte_node_register node = {


### PR DESCRIPTION
Depends on #672 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added per-interface mbuf pools and control-plane file descriptors and events to `struct iface`.
- Reworked loopback and TAP paths to use interface-owned pools and resources.
- Replaced control-input type IDs and allocation flags with direct `rte_edge_t` registration and `(edge, mbuf)` queue entries.
- Added typed send helpers for Ethernet, interface, IPv4, IPv6, ARP, and loopback output.
- Updated DHCP, LACP, ICMP, ICMPv6, ARP, router advertisement, and NDP paths to allocate mbufs from the interface pool and store request context in mbuf metadata.
- Removed shared control-input and per-module mempools, heap-allocated control messages, obsolete output handlers, and related module dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->