### PR TITLE
smoke: fix random so_bindtodevice test failure

### DIFF
--- a/smoke/so_bindtodevice_test.sh
+++ b/smoke/so_bindtodevice_test.sh
@@ -58,8 +58,8 @@ ip -n peer1 addr add 172.19.0.2/24 dev x-p1.43
 ip -n peer1 addr add fd03::2/64    dev x-p1.43
 
 for ns in peer0 peer1; do
-	ip netns exec $ns socat UDP4-LISTEN:9001,fork EXEC:'/bin/cat' &
-	ip netns exec $ns socat UDP6-LISTEN:9000,fork EXEC:'/bin/cat' &
+	ip netns exec $ns socat UDP4-RECVFROM:9001,fork EXEC:'/bin/cat' &
+	ip netns exec $ns socat UDP6-RECVFROM:9000,fork EXEC:'/bin/cat' &
 	ip netns exec $ns socat TCP4-LISTEN:9003,fork EXEC:'/bin/cat' &
 	ip netns exec $ns socat TCP6-LISTEN:9002,fork EXEC:'/bin/cat' &
 done
@@ -78,16 +78,16 @@ run_scenario() {
 	local src4="${5:-}"
 	local src6="${6:-}"
 	local proto dst port reply src_opt
-	for proto_port in "UDP4:9001" "UDP6:9000" "TCP4:9003" "TCP6:9002"; do
+	for proto_port in "UDP4-SENDTO:9001" "UDP6-SENDTO:9000" "TCP4:9003" "TCP6:9002"; do
 		proto=${proto_port%:*}
 		port=${proto_port#*:}
 		src_opt=""
 		case "$proto" in
-		*4)
+		*4*)
 			dst=$dst4
 			[ -n "$src4" ] && src_opt=",bind=$src4"
 			;;
-		*6)
+		*6*)
 			dst="[$dst6]"
 			[ -n "$src6" ] && src_opt=",bind=[$src6]"
 			;;
@@ -138,7 +138,7 @@ grout0_ll=$(llocal_addr p0)
 [ -z "$peer0_ll" ] && fail "peer0 link-local not found on x-p0"
 [ -z "$grout0_ll" ] && fail "grout link-local not found on p0"
 wait_kernel_addr "$grout0_ll" p0
-for proto_port in "UDP6:9000" "TCP6:9002"; do
+for proto_port in "UDP6-SENDTO:9000" "TCP6:9002"; do
 	proto=${proto_port%:*}
 	port=${proto_port#*:}
 	reply=$(echo "ping" | timeout 3 socat - \


### PR DESCRIPTION
socat unconditionally writes a zero-length buffer to the UDP socket when its stdin reaches EOF (write(fd, "", 0)). On a connected UDP socket the kernel turns this into a real 0-byte datagram on the wire.

The peer echo servers use socat with the fork option. When the data datagram and the empty datagram arrive before the first forked child has set up its connected socket, the parent forks a second child for the empty datagram. The second child has no work to do and finishes first, sending its empty reply before the first child sends the actual echo. When the test-side socat receives the 0-byte reply first, it treats it as EOF and exits with an empty result.

This is not a grout bug. Grout packet traces from both a passing and failing run show that grout forwards and delivers both packets correctly and in order. The reordering is visible at the port_rx level, meaning it originates from the peer side:

  Passing run (replies in order, test succeeds):

    [rx p1] fd03::2 > fd03::1 proto=UDP(17), (pkt_len=67)
    [rx p1] fd03::2 > fd03::1 proto=UDP(17), (pkt_len=62)

  Failing run (empty reply first, socat treats it as EOF):

    [rx p1] fd03::2 > fd03::1 proto=UDP(17), (pkt_len=62)
    [rx p1] fd03::2 > fd03::1 proto=UDP(17), (pkt_len=67)

Fix with two changes:

On the server side, replace UDP-LISTEN with UDP-RECVFROM. UDP-LISTEN closes and recreates the socket after each fork, leaving the port  temporarily unbound. UDP-RECVFROM keeps the same socket open and uses a trigger socketpair to synchronize packet consumption. Adding
max-children=1 serializes child handling so replies always go out in the correct order.

On the client side, replace UDP with UDP-SENDTO. The default UDP address type uses read() on a connected socket where a 0-byte read is indistinguishable from EOF. UDP-SENDTO uses recvfrom() instead, and socat's null_eof defaults to false so a 0-byte datagram returns EAGAIN and socat retries until a non-empty reply arrives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
The `so_bindtodevice_test.sh` smoke test can fail when `socat` sends a zero-length UDP datagram at stdin EOF. Concurrent peer handlers can return this datagram before the actual echo response, which makes the client-side `socat` treat it as EOF.

Use `UDP4/UDP6-RECVFROM` with `max-children=1` for peer UDP listeners to serialize datagram handling. Use `UDP-SENDTO` and `UDP6-SENDTO` for clients so zero-length datagrams are ignored while the client retries until it receives the non-empty response. TCP handling remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->