### PR TITLE
infra: use IFA_F_NODAD for control plane tap addresses

### DIFF
--- a/modules/infra/control/ctlplane.c
+++ b/modules/infra/control/ctlplane.c
@@ -327,12 +327,6 @@ static void cp_create(struct iface *iface) {
 	// would then fail to bind() sockets on those addresses.
 	sysctl_write("net/ipv6/conf", iface, "keep_addr_on_down", "1");
 
-	// Disable DAD on the control plane tap. Grout owns the addresses
-	// and DAD is meaningless on a local tap. Without this, the kernel
-	// re-runs DAD after link flaps, putting addresses in tentative state
-	// and causing sendmsg() to fail with EINVAL.
-	sysctl_write("net/ipv6/conf", iface, "accept_dad", "0");
-
 	if (gr_config.override_rp_filter) {
 		// Set loose reverse path filtering on the TAP so that packets
 		// delivered by grout are not dropped by rp_filter. The effective

--- a/modules/infra/control/netlink.c
+++ b/modules/infra/control/netlink.c
@@ -14,6 +14,7 @@
 
 #include <libmnl/libmnl.h>
 #include <linux/fib_rules.h>
+#include <linux/if_addr.h>
 #include <linux/if_link.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -483,6 +484,11 @@ static int netlink_add_del_addr(uint32_t ifindex, const void *addr, size_t addr_
 	ifa = mnl_nlmsg_put_extra_header(nlh, sizeof(*ifa));
 	ifa->ifa_family = is_ipv4 ? AF_INET : AF_INET6;
 	ifa->ifa_prefixlen = is_ipv4 ? 32 : 128;
+	// Disable DAD on control plane taps. Grout owns the addresses
+	// and DAD is meaningless on a local tap. Without this, the kernel
+	// re-runs DAD after link flaps, putting addresses in tentative state
+	// and causing sendmsg() to fail with EINVAL.
+	ifa->ifa_flags = is_ipv4 ? 0 : IFA_F_NODAD;
 	ifa->ifa_scope = RT_SCOPE_UNIVERSE;
 	ifa->ifa_index = ifindex;
 


### PR DESCRIPTION
The accept_dad sysctl set on the control plane tap is ineffective because the kernel evaluates max(conf/all/accept_dad, conf/<iface>/accept_dad). Since conf/all/accept_dad defaults to 1, DAD still runs after link flaps.

When DAD runs, the kernel sends a NS probe on the control plane tap. Grout's datapath answers with a NA (it owns the same address), and the kernel marks the address as dadfailed. The address never recovers, sendmsg() returns EINVAL permanently and OSPF6 never converges.

Set IFA_F_NODAD in the netlink RTM_NEWADDR message when adding IPv6 addresses to the control plane tap. This is a per-address flag that unconditionally prevents DAD regardless of any sysctl setting.

Fixes: 0480bdffd3c2 ("infra: disable DAD on control plane TAPs")