### PR TITLE
icmp,icmp6: replace response queue with hash-based session pool

### DIFF
--- a/modules/infra/control/icmp_session.c
+++ b/modules/infra/control/icmp_session.c
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Robin Jarry
+
+#include "icmp_session.h"
+
+#include <gr_clock.h>
+#include <gr_errno.h>
+#include <gr_infra.h>
+
+#include <event2/event.h>
+#include <rte_errno.h>
+#include <rte_hash.h>
+#include <rte_malloc.h>
+#include <rte_mbuf.h>
+
+#include <control_queue.h>
+#include <mbuf.h>
+#include <stdlib.h>
+
+struct icmp_session_key {
+	rte_be16_t ident;
+	rte_be16_t seq_num;
+};
+
+struct icmp_session {
+	struct rte_mbuf *mbuf;
+	gr_clock_ns_t created;
+	gr_clock_ns_t sent;
+	gr_clock_ns_t received;
+};
+
+struct icmp_session_pool {
+	struct rte_hash *hash;
+	struct event *gc_timer;
+	icmp_extract_info_t extract_info;
+};
+
+#define SESSION_TIMEOUT (10 * GR_NS_PER_S)
+
+static void session_free(struct icmp_session *s) {
+	if (s == NULL)
+		return;
+	rte_pktmbuf_free(s->mbuf);
+	free(s);
+}
+
+static void gc_cb(evutil_socket_t, short, void *arg) {
+	struct icmp_session_pool *pool = arg;
+	gr_clock_ns_t now = gr_clock_ns();
+	struct icmp_session *s;
+	uint32_t next = 0;
+	const void *key;
+	void *data;
+
+	while (rte_hash_iterate(pool->hash, &key, &data, &next) >= 0) {
+		s = data;
+		if (now - s->created >= SESSION_TIMEOUT) {
+			rte_hash_del_key(pool->hash, key);
+			session_free(s);
+		}
+	}
+}
+
+void icmp_session_input(
+	struct icmp_session_pool *pool,
+	void *m,
+	uintptr_t timestamp,
+	const struct control_queue_drain *drain
+) {
+	gr_clock_ns_t sent_timestamp;
+	struct icmp_session_key k;
+	struct icmp_session *s;
+	void *data;
+
+	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE
+	    && mbuf_data(m)->iface == drain->obj)
+		goto drop;
+
+	if (pool->extract_info(m, &k.ident, &k.seq_num, &sent_timestamp) < 0)
+		goto drop;
+
+	if (rte_hash_lookup_data(pool->hash, &k, &data) < 0)
+		goto drop;
+
+	s = data;
+	if (s->mbuf != NULL)
+		goto drop; // duplicate packet
+	s->mbuf = m;
+	s->sent = sent_timestamp;
+	s->received = timestamp;
+	return;
+
+drop:
+	rte_pktmbuf_free(m);
+}
+
+void icmp_session_iface_remove(struct icmp_session_pool *pool, const void *iface) {
+	struct icmp_session *s;
+	uint32_t next = 0;
+	const void *key;
+	void *data;
+
+	while (rte_hash_iterate(pool->hash, &key, &data, &next) >= 0) {
+		s = data;
+		if (s->mbuf != NULL && mbuf_data(s->mbuf)->iface == iface) {
+			rte_hash_del_key(pool->hash, key);
+			session_free(s);
+		}
+	}
+}
+
+int icmp_session_add(struct icmp_session_pool *pool, uint16_t ident, uint16_t seq_num) {
+	struct icmp_session_key k = {
+		.ident = rte_cpu_to_be_16(ident),
+		.seq_num = rte_cpu_to_be_16(seq_num),
+	};
+	struct icmp_session *s;
+
+	if (rte_hash_lookup(pool->hash, &k) >= 0)
+		return errno_set(EEXIST);
+
+	s = calloc(1, sizeof(*s));
+	if (s == NULL)
+		return errno_set(ENOMEM);
+
+	s->created = gr_clock_ns();
+
+	if (rte_hash_add_key_data(pool->hash, &k, s) < 0) {
+		free(s);
+		return errno_set(rte_errno);
+	}
+
+	return 0;
+}
+
+void icmp_session_del(struct icmp_session_pool *pool, uint16_t ident, uint16_t seq_num) {
+	struct icmp_session_key k = {
+		.ident = rte_cpu_to_be_16(ident),
+		.seq_num = rte_cpu_to_be_16(seq_num),
+	};
+	void *data;
+
+	if (rte_hash_lookup_data(pool->hash, &k, &data) >= 0) {
+		rte_hash_del_key(pool->hash, &k);
+		session_free(data);
+	}
+}
+
+struct rte_mbuf *icmp_session_recv(
+	struct icmp_session_pool *pool,
+	uint16_t ident,
+	uint16_t seq_num,
+	gr_clock_ns_t *response_time
+) {
+	struct icmp_session_key k = {
+		.ident = rte_cpu_to_be_16(ident),
+		.seq_num = rte_cpu_to_be_16(seq_num),
+	};
+	struct icmp_session *s;
+	struct rte_mbuf *m;
+	void *data;
+
+	if (rte_hash_lookup_data(pool->hash, &k, &data) < 0)
+		return errno_set_null(ENOENT);
+
+	s = data;
+	if (s->mbuf == NULL)
+		return errno_set_null(ENOENT);
+
+	m = s->mbuf;
+	*response_time = s->received - (s->sent ?: s->created);
+
+	rte_hash_del_key(pool->hash, &k);
+	free(s);
+
+	return m;
+}
+
+struct icmp_session_pool *icmp_session_pool_new(
+	const char *name,
+	unsigned max_sessions,
+	icmp_extract_info_t extract_info,
+	struct event_base *ev_base
+) {
+	struct icmp_session_pool *pool;
+
+	pool = calloc(1, sizeof(*pool));
+	if (pool == NULL) {
+		errno_set(ENOMEM);
+		return NULL;
+	}
+
+	struct rte_hash_parameters params = {
+		.name = name,
+		.socket_id = SOCKET_ID_ANY,
+		.key_len = sizeof(struct icmp_session_key),
+		.entries = max_sessions,
+	};
+
+	pool->hash = rte_hash_create(&params);
+	if (pool->hash == NULL) {
+		free(pool);
+		errno_set(rte_errno);
+		return NULL;
+	}
+
+	pool->extract_info = extract_info;
+
+	pool->gc_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, gc_cb, pool);
+	if (pool->gc_timer == NULL) {
+		rte_hash_free(pool->hash);
+		free(pool);
+		errno_set(ENOMEM);
+		return NULL;
+	}
+	event_add(pool->gc_timer, &(struct timeval) {.tv_sec = 1});
+
+	return pool;
+}
+
+void icmp_session_pool_free(struct icmp_session_pool *pool) {
+	uint32_t next = 0;
+	const void *key;
+	void *data;
+
+	if (pool == NULL)
+		return;
+
+	if (pool->gc_timer)
+		event_free(pool->gc_timer);
+
+	if (pool->hash) {
+		while (rte_hash_iterate(pool->hash, &key, &data, &next) >= 0)
+			session_free(data);
+		rte_hash_free(pool->hash);
+	}
+
+	free(pool);
+}

--- a/modules/infra/control/icmp_session.h
+++ b/modules/infra/control/icmp_session.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Robin Jarry
+
+#pragma once
+
+#include "control_queue.h"
+
+#include <gr_clock.h>
+
+#include <event2/event.h>
+#include <rte_mbuf.h>
+
+#include <stdint.h>
+
+// Extract ident, seq_num and timestamp from an ICMP response or error.
+// The sent timestamp will be set to 0 for ICMP errors.
+// Returns 0 on success, < 0 if the packet cannot be parsed.
+typedef int (*icmp_extract_info_t)(
+	struct rte_mbuf *m,
+	rte_be16_t *ident,
+	rte_be16_t *seq_num,
+	gr_clock_ns_t *timestamp
+);
+
+struct icmp_session_pool;
+
+struct icmp_session_pool *icmp_session_pool_new(
+	const char *name,
+	unsigned max_sessions,
+	icmp_extract_info_t extract_info,
+	struct event_base *ev_base
+);
+void icmp_session_pool_free(struct icmp_session_pool *pool);
+
+// control_queue callback: extract key via get_key, store mbuf if session
+// exists, drop otherwise. Handles iface removal drain.
+void icmp_session_input(
+	struct icmp_session_pool *pool,
+	void *m,
+	uintptr_t timestamp,
+	const struct control_queue_drain *drain
+);
+
+// Purge sessions referencing a removed interface.
+void icmp_session_iface_remove(struct icmp_session_pool *pool, const void *iface);
+
+// Create a session. Sets sent timestamp. Returns 0 or errno.
+int icmp_session_add(struct icmp_session_pool *pool, uint16_t ident, uint16_t seq_num);
+
+// Delete a session (on send failure).
+void icmp_session_del(struct icmp_session_pool *pool, uint16_t ident, uint16_t seq_num);
+
+// Claim a response. Returns mbuf, sets *response_time. Deletes session.
+// Returns NULL + errno on failure.
+struct rte_mbuf *icmp_session_recv(
+	struct icmp_session_pool *pool,
+	uint16_t ident,
+	uint16_t seq_num,
+	gr_clock_ns_t *response_time
+);

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -4,6 +4,7 @@
 src += files(
   'bond.c',
   'ctlplane.c',
+  'icmp_session.c',
   'graph.c',
   'group_nexthop.c',
   'iface.c',

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -135,8 +135,8 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_recv_req *icmp_req = request;
 	gr_clock_ns_t *pkt_timestamp, rcv_timestamp;
 	struct gr_ip4_icmp_recv_resp *resp = NULL;
+	struct ip_local_mbuf_data *ip_data;
 	struct rte_icmp_hdr *icmp;
-	struct rte_ipv4_hdr *ip;
 	struct rte_mbuf *m;
 	size_t len = 0;
 	int ret = 0;
@@ -150,12 +150,10 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		goto out;
 	}
 
-	// Ugly, there is no guarantee that the outer packet is actually IPv4
-	ip = rte_pktmbuf_mtod_offset(m, struct rte_ipv4_hdr *, -sizeof(*ip));
-
+	ip_data = ip_local_mbuf_data(m);
 	icmp = rte_pktmbuf_mtod(m, struct rte_icmp_hdr *);
-	resp->src_addr = ip->src_addr;
-	resp->ttl = ip->time_to_live;
+	resp->src_addr = ip_data->src;
+	resp->ttl = ip_data->ttl;
 	resp->type = icmp->icmp_type;
 	resp->code = icmp->icmp_code;
 
@@ -163,7 +161,7 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		// RFC 792: Destination Unreachable or Time Exceeded
 		// The icmp_seq_nb and icmp_ident fields are unused.
 		// Jump to the next header which contains the original IP header
-		ip = PAYLOAD(icmp);
+		struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
 		// Skip the original IP header to find the original ICMP payload
 		icmp = PAYLOAD(ip);
 	}

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -2,168 +2,130 @@
 // Copyright (c) 2024 Christophe Fontaine
 
 #include "event.h"
+#include "icmp_session.h"
 #include "ip4.h"
 #include "ip4_datapath.h"
 #include "log.h"
 #include "module.h"
-#include "sys_queue.h"
 
 #include <gr_ip4.h>
+#include <gr_macro.h>
 
 #include <rte_icmp.h>
+#include <rte_ip.h>
 
-struct icmp_queue_item {
-	struct rte_mbuf *mbuf;
-	gr_clock_ns_t timestamp;
-	STAILQ_ENTRY(icmp_queue_item) next;
-};
+static struct icmp_session_pool *sessions;
 
-static STAILQ_HEAD(, icmp_queue_item) icmp_queue = STAILQ_HEAD_INITIALIZER(icmp_queue);
-static struct rte_mempool *pool;
+// Navigate to the inner ICMP header carrying ident+seq_num.
+// For echo replies, that is the outer header itself.
+// For error messages (Destination Unreachable, Time Exceeded), the original
+// echo request is embedded after the outer ICMP header + original IP header.
+static struct rte_icmp_hdr *icmp_inner_hdr(struct rte_mbuf *m) {
+	struct rte_icmp_hdr *icmp = rte_pktmbuf_mtod(m, struct rte_icmp_hdr *);
+	struct ip_local_mbuf_data *data = ip_local_mbuf_data(m);
 
-static void icmp_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
-	STAILQ_REMOVE(&icmp_queue, i, icmp_queue_item, next);
-	if (free_mbuf)
-		rte_pktmbuf_free(i->mbuf);
-	rte_mempool_put(pool, i);
+	if (icmp->icmp_type == RTE_ICMP_TYPE_ECHO_REPLY)
+		return icmp;
+
+	// RFC 792: Destination Unreachable or Time Exceeded
+	// The icmp_seq_nb and icmp_ident fields are unused.
+	// Jump to the next header which contains the original IP header.
+	struct rte_ipv4_hdr *ip;
+	size_t inner_ip_len;
+
+	// RFC 792: ICMP error header (8) + original IP
+	// header (20 min) + 8 bytes of original data.
+	if (data->len < sizeof(*icmp) + sizeof(*ip) + sizeof(*icmp))
+		return errno_set_null(EMSGSIZE);
+
+	ip = PAYLOAD(icmp);
+
+	if (ip->next_proto_id != IPPROTO_ICMP)
+		return errno_set_null(EBADMSG);
+
+	inner_ip_len = rte_ipv4_hdr_len(ip);
+	if (data->len < sizeof(*icmp) + inner_ip_len + sizeof(*icmp))
+		return errno_set_null(EMSGSIZE);
+
+	// Skip the original IP header (may have options) to
+	// find the original ICMP echo request.
+	icmp = RTE_PTR_ADD(ip, inner_ip_len);
+
+	if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST)
+		return errno_set_null(EBADMSG);
+
+	return icmp;
 }
 
-// Callback invoked by control plane for each ICMP packet received for a local address.
-// The packet is added at the end of a linked list.
-static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
-	struct icmp_queue_item *i;
-	void *data;
-
-	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE
-	    && mbuf_data(m)->iface == drain->obj) {
-		rte_pktmbuf_free(m);
-		return;
+// The echo reply payload contains the timestamp from the original request.
+// ICMP errors only carry 8 bytes of the original packet data (the ICMP
+// header) so the timestamp is not available.
+static int icmp_extract_info(
+	struct rte_mbuf *m,
+	rte_be16_t *ident,
+	rte_be16_t *seq_num,
+	gr_clock_ns_t *timestamp
+) {
+	struct rte_icmp_hdr *outer = rte_pktmbuf_mtod(m, struct rte_icmp_hdr *);
+	struct rte_icmp_hdr *inner = icmp_inner_hdr(m);
+	if (inner == NULL)
+		return errno_set(EBADMSG);
+	*ident = inner->icmp_ident;
+	*seq_num = inner->icmp_seq_nb;
+	if (outer->icmp_type == RTE_ICMP_TYPE_ECHO_REPLY) {
+		gr_clock_ns_t *ts = PAYLOAD(inner);
+		*timestamp = *ts;
+	} else {
+		*timestamp = 0;
 	}
+	return 0;
+}
 
-	while (rte_mempool_get(pool, &data) < 0)
-		icmp_queue_pop(STAILQ_FIRST(&icmp_queue), true);
-
-	i = data;
-	i->mbuf = m;
-	i->timestamp = timestamp;
-	STAILQ_INSERT_TAIL(&icmp_queue, i, next);
+static void icmp_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
+	icmp_session_input(sessions, m, timestamp, drain);
 }
 
 static void icmp_event_cb(uint32_t ev_type, const void *obj) {
-	struct icmp_queue_item *i, *tmp;
-
-	if (ev_type == GR_EVENT_IFACE_REMOVE) {
-		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-			if (mbuf_data(i->mbuf)->iface == obj)
-				icmp_queue_pop(i, true);
-		}
-	}
-}
-
-#define ICMP_QUEUE_TIMEOUT (10 * GR_NS_PER_S)
-
-static void icmp_queue_gc(evutil_socket_t, short, void *) {
-	gr_clock_ns_t now = gr_clock_ns();
-	struct icmp_queue_item *i, *tmp;
-
-	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-		if (now - i->timestamp >= ICMP_QUEUE_TIMEOUT)
-			icmp_queue_pop(i, true);
-	}
-}
-
-// Search for the oldest ICMP response matching the given identifier.
-// If found, the packet is removed from the queue.
-static struct rte_mbuf *
-get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
-	struct icmp_queue_item *i, *tmp;
-	struct rte_mbuf *mbuf = NULL;
-
-	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-		struct rte_icmp_hdr *icmp = rte_pktmbuf_mtod(i->mbuf, struct rte_icmp_hdr *);
-		struct ip_local_mbuf_data *data = ip_local_mbuf_data(i->mbuf);
-
-		if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REPLY) {
-			// RFC 792: Destination Unreachable or Time Exceeded
-			// The icmp_seq_nb and icmp_ident fields are unused.
-			// Jump to the next header which contains the original IP header
-			struct rte_ipv4_hdr *ip;
-			size_t inner_ip_len;
-
-			// RFC 792: ICMP error header (8) + original IP
-			// header (20 min) + 8 bytes of original data.
-			if (data->len < sizeof(*icmp) + sizeof(*ip) + sizeof(*icmp)) {
-				icmp_queue_pop(i, true);
-				continue;
-			}
-
-			ip = PAYLOAD(icmp);
-
-			if (ip->next_proto_id != IPPROTO_ICMP) {
-				// should not happen, but let's be safe.
-				icmp_queue_pop(i, true);
-				continue;
-			}
-
-			inner_ip_len = rte_ipv4_hdr_len(ip);
-			if (data->len < sizeof(*icmp) + inner_ip_len + sizeof(*icmp)) {
-				icmp_queue_pop(i, true);
-				continue;
-			}
-
-			icmp = RTE_PTR_ADD(ip, inner_ip_len);
-
-			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
-				// should not happen, but let's be safe.
-				icmp_queue_pop(i, true);
-				continue;
-			}
-		}
-
-		if (rte_be_to_cpu_16(icmp->icmp_ident) == ident
-		    && rte_be_to_cpu_16(icmp->icmp_seq_nb) == seq_num) {
-			mbuf = i->mbuf;
-			*timestamp = i->timestamp;
-			icmp_queue_pop(i, false);
-			return mbuf;
-		}
-	}
-
-	return errno_set_null(ENOENT);
+	if (ev_type == GR_EVENT_IFACE_REMOVE)
+		icmp_session_iface_remove(sessions, obj);
 }
 
 static struct api_out icmp_send(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_send_req *req = request;
 	const struct nexthop *nh;
-	int ret = 0;
+	int ret;
 
-	if ((nh = fib4_lookup(req->vrf, req->addr, req->ident)) == NULL) {
-		ret = -errno;
-		goto out;
-	}
+	if ((nh = fib4_lookup(req->vrf, req->addr, req->ident)) == NULL)
+		return api_out(errno, 0, NULL);
+
+	ret = icmp_session_add(sessions, req->ident, req->seq_num);
+	if (ret < 0)
+		return api_out(-ret, 0, NULL);
 
 	ret = icmp_local_send(req->vrf, req->addr, nh, req->ident, req->seq_num, req->ttl);
-out:
-	return api_out(-ret, 0, NULL);
+	if (ret != 0) {
+		icmp_session_del(sessions, req->ident, req->seq_num);
+		return api_out(ret, 0, NULL);
+	}
+
+	return api_out(0, 0, NULL);
 }
 
 static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_recv_req *icmp_req = request;
 	struct gr_ip4_icmp_recv_resp *resp = NULL;
 	struct ip_local_mbuf_data *ip_data;
-	gr_clock_ns_t rcv_timestamp;
+	gr_clock_ns_t response_time;
 	struct rte_icmp_hdr *icmp;
 	struct rte_mbuf *m;
-	size_t len = 0;
-	int ret = 0;
 
-	m = get_icmp_response(icmp_req->ident, icmp_req->seq_num, &rcv_timestamp);
+	m = icmp_session_recv(sessions, icmp_req->ident, icmp_req->seq_num, &response_time);
 	if (m == NULL)
 		return api_out(errno, 0, NULL);
 
 	if ((resp = calloc(1, sizeof(*resp))) == NULL) {
-		ret = ENOMEM;
-		goto out;
+		rte_pktmbuf_free(m);
+		return api_out(ENOMEM, 0, NULL);
 	}
 
 	ip_data = ip_local_mbuf_data(m);
@@ -172,74 +134,31 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	resp->ttl = ip_data->ttl;
 	resp->type = icmp->icmp_type;
 	resp->code = icmp->icmp_code;
+	resp->response_time = response_time;
 
-	if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REPLY) {
-		// RFC 792: Destination Unreachable or Time Exceeded
-		// The icmp_seq_nb and icmp_ident fields are unused.
-		// Jump to the next header which contains the original IP header
-		struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
-		// Skip the original IP header (may have options) to
-		// find the original ICMP payload.
-		icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
-	}
-
-	// icmp either points to an echo request or reply (checked in get_icmp_response())
+	// icmp_inner_hdr() navigates to the inner header carrying ident+seq_num
+	// (checked by icmp_get_key in icmp_session_input)
+	icmp = icmp_inner_hdr(m);
 	resp->ident = rte_be_to_cpu_16(icmp->icmp_ident);
 	resp->seq_num = rte_be_to_cpu_16(icmp->icmp_seq_nb);
 
-	if (resp->type == RTE_ICMP_TYPE_ECHO_REPLY) {
-		// The echo reply payload contains the timestamp from the
-		// original request. ICMP errors only carry 8 bytes of the
-		// original packet data (the ICMP header) so the timestamp
-		// is not available.
-		gr_clock_ns_t *pkt_timestamp = PAYLOAD(icmp);
-		resp->response_time = rcv_timestamp - *pkt_timestamp;
-	}
-
-	len = sizeof(*resp);
-out:
 	rte_pktmbuf_free(m);
-	return api_out(ret, len, resp);
+	return api_out(0, sizeof(*resp), resp);
 }
 
-#define ICMP_LOCAL_QUEUE_SIZE 1024
-static struct event *gc_timer;
+#define ICMP_MAX_SESSIONS 1024
 
 static void icmp_init(struct event_base *ev_base) {
-	pool = rte_mempool_create(
-		"icmp_queue", // name
-		ICMP_LOCAL_QUEUE_SIZE,
-		sizeof(struct icmp_queue_item),
-		0, // cache size
-		0, // priv size
-		NULL, // mp_init
-		NULL, // mp_init_arg
-		NULL, // obj_init
-		NULL, // obj_init_arg
-		SOCKET_ID_ANY,
-		0 // flags
+	sessions = icmp_session_pool_new(
+		"icmp_sessions", ICMP_MAX_SESSIONS, icmp_extract_info, ev_base
 	);
-	if (pool == NULL)
-		ABORT("rte_mempool_create(icmp_queue) failed");
-
-	gc_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, icmp_queue_gc, NULL);
-	if (gc_timer == NULL)
-		ABORT("event_new() failed");
-	if (event_add(gc_timer, &(struct timeval) {.tv_sec = 1}) < 0)
-		ABORT("event_add() failed");
+	if (sessions == NULL)
+		ABORT("icmp_session_pool_new() failed");
 }
 
 static void icmp_fini(struct event_base *) {
-	if (gc_timer)
-		event_free(gc_timer);
-
-	if (pool != NULL) {
-		struct icmp_queue_item *i, *tmp;
-		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)
-			icmp_queue_pop(i, true);
-		rte_mempool_free(pool);
-		pool = NULL;
-	}
+	icmp_session_pool_free(sessions);
+	sessions = NULL;
 }
 
 static struct module icmp_module = {

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -81,12 +81,23 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 
 	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
 		struct rte_icmp_hdr *icmp = rte_pktmbuf_mtod(i->mbuf, struct rte_icmp_hdr *);
+		struct ip_local_mbuf_data *data = ip_local_mbuf_data(i->mbuf);
 
 		if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REPLY) {
 			// RFC 792: Destination Unreachable or Time Exceeded
 			// The icmp_seq_nb and icmp_ident fields are unused.
 			// Jump to the next header which contains the original IP header
-			struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
+			struct rte_ipv4_hdr *ip;
+			size_t inner_ip_len;
+
+			// RFC 792: ICMP error header (8) + original IP
+			// header (20 min) + 8 bytes of original data.
+			if (data->len < sizeof(*icmp) + sizeof(*ip) + sizeof(*icmp)) {
+				icmp_queue_pop(i, true);
+				continue;
+			}
+
+			ip = PAYLOAD(icmp);
 
 			if (ip->next_proto_id != IPPROTO_ICMP) {
 				// should not happen, but let's be safe.
@@ -94,9 +105,13 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 				continue;
 			}
 
-			// Skip the original IP header (may have options) to
-			// find the original ICMP payload.
-			icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
+			inner_ip_len = rte_ipv4_hdr_len(ip);
+			if (data->len < sizeof(*icmp) + inner_ip_len + sizeof(*icmp)) {
+				icmp_queue_pop(i, true);
+				continue;
+			}
+
+			icmp = RTE_PTR_ADD(ip, inner_ip_len);
 
 			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
 				// should not happen, but let's be safe.

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -134,9 +134,9 @@ out:
 
 static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip4_icmp_recv_req *icmp_req = request;
-	gr_clock_ns_t *pkt_timestamp, rcv_timestamp;
 	struct gr_ip4_icmp_recv_resp *resp = NULL;
 	struct ip_local_mbuf_data *ip_data;
+	gr_clock_ns_t rcv_timestamp;
 	struct rte_icmp_hdr *icmp;
 	struct rte_mbuf *m;
 	size_t len = 0;
@@ -171,8 +171,15 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 	// icmp either points to an echo request or reply (checked in get_icmp_response())
 	resp->ident = rte_be_to_cpu_16(icmp->icmp_ident);
 	resp->seq_num = rte_be_to_cpu_16(icmp->icmp_seq_nb);
-	pkt_timestamp = PAYLOAD(icmp);
-	resp->response_time = rcv_timestamp - *pkt_timestamp;
+
+	if (resp->type == RTE_ICMP_TYPE_ECHO_REPLY) {
+		// The echo reply payload contains the timestamp from the
+		// original request. ICMP errors only carry 8 bytes of the
+		// original packet data (the ICMP header) so the timestamp
+		// is not available.
+		gr_clock_ns_t *pkt_timestamp = PAYLOAD(icmp);
+		resp->response_time = rcv_timestamp - *pkt_timestamp;
+	}
 
 	len = sizeof(*resp);
 out:

--- a/modules/ip/control/icmp.c
+++ b/modules/ip/control/icmp.c
@@ -94,8 +94,9 @@ get_icmp_response(uint16_t ident, uint16_t seq_num, gr_clock_ns_t *timestamp) {
 				continue;
 			}
 
-			// Skip the original IP header to find the original ICMP payload
-			icmp = PAYLOAD(ip);
+			// Skip the original IP header (may have options) to
+			// find the original ICMP payload.
+			icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
 
 			if (icmp->icmp_type != RTE_ICMP_TYPE_ECHO_REQUEST) {
 				// should not happen, but let's be safe.
@@ -162,8 +163,9 @@ static struct api_out icmp_recv(const void *request, struct api_ctx *) {
 		// The icmp_seq_nb and icmp_ident fields are unused.
 		// Jump to the next header which contains the original IP header
 		struct rte_ipv4_hdr *ip = PAYLOAD(icmp);
-		// Skip the original IP header to find the original ICMP payload
-		icmp = PAYLOAD(ip);
+		// Skip the original IP header (may have options) to
+		// find the original ICMP payload.
+		icmp = RTE_PTR_ADD(ip, rte_ipv4_hdr_len(ip));
 	}
 
 	// icmp either points to an echo request or reply (checked in get_icmp_response())

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -98,12 +98,14 @@ static struct rte_mbuf *get_icmp6_echo_reply(
 		// icmpv6 error packet: find embedded origin ipv6 packet, and use
 		// it if it's our original echo request
 		if (icmp6->type != ICMP6_TYPE_ECHO_REPLY) {
+			if (rte_pktmbuf_pkt_len(mbuf) < ICMP6_ERROR_PKT_LEN)
+				goto free_and_skip;
 			ip6 = PAYLOAD(icmp6_echo);
+			if (ip6->proto != IPPROTO_ICMPV6)
+				goto free_and_skip;
 			icmp6 = PAYLOAD(ip6);
 			icmp6_echo = PAYLOAD(icmp6);
-			if (rte_pktmbuf_pkt_len(mbuf) < ICMP6_ERROR_PKT_LEN
-			    || ip6->proto != IPPROTO_ICMPV6
-			    || icmp6->type != ICMP6_TYPE_ECHO_REQUEST)
+			if (icmp6->type != ICMP6_TYPE_ECHO_REQUEST)
 				goto free_and_skip;
 		}
 

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -2,127 +2,92 @@
 // Copyright (c) 2025 Olivier Gournet
 
 #include "event.h"
-#include "icmp6.h"
+#include "icmp_session.h"
 #include "ip6.h"
 #include "ip6_datapath.h"
 #include "log.h"
 #include "module.h"
-#include "sys_queue.h"
 
 #include <gr_api.h>
 #include <gr_ip6.h>
+#include <gr_macro.h>
 
-struct icmp_queue_item {
-	struct rte_mbuf *mbuf;
-	gr_clock_ns_t timestamp;
-	STAILQ_ENTRY(icmp_queue_item) next;
-};
+#include <icmp6.h>
 
-static STAILQ_HEAD(, icmp_queue_item) icmp_queue = STAILQ_HEAD_INITIALIZER(icmp_queue);
-static struct rte_mempool *pool;
+static struct icmp_session_pool *sessions;
 
-static void icmp6_queue_pop(struct icmp_queue_item *i, bool free_mbuf) {
-	STAILQ_REMOVE(&icmp_queue, i, icmp_queue_item, next);
-	if (free_mbuf)
-		rte_pktmbuf_free(i->mbuf);
-	rte_mempool_put(pool, i);
-}
+// Navigate to the inner ICMPv6 echo header carrying ident+seqnum.
+// For echo replies, that is the echo body right after the outer ICMPv6 header.
+// For error messages, the original echo request is embedded after the outer
+// ICMPv6 header + error body + original IPv6 header.
+static struct icmp6_echo_reply *icmp6_inner_echo(struct rte_mbuf *m, struct icmp6 **outer) {
+	struct ip6_local_mbuf_data *data = ip6_local_mbuf_data(m);
+	struct icmp6 *hdr = rte_pktmbuf_mtod(m, struct icmp6 *);
+	struct icmp6_echo_reply *echo;
 
-// called from dataplane context
-static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
-	struct icmp_queue_item *i;
-	void *data;
+	*outer = hdr;
 
-	if (drain != NULL && drain->event == GR_EVENT_IFACE_REMOVE
-	    && mbuf_data(m)->iface == drain->obj) {
-		rte_pktmbuf_free(m);
-		return;
+	if (hdr->type == ICMP6_TYPE_ECHO_REPLY) {
+		// GR_ICMP6_HDR_LEN already covers the echo ident+seqnum.
+		if (data->len < GR_ICMP6_HDR_LEN + sizeof(gr_clock_ns_t))
+			return errno_set_null(EMSGSIZE);
+		return PAYLOAD(hdr);
 	}
 
-	while (rte_mempool_get(pool, &data) < 0)
-		icmp6_queue_pop(STAILQ_FIRST(&icmp_queue), true);
+	// ICMPv6 error packet: find embedded original IPv6 packet, and use
+	// it if it's our original echo request.
+	// ICMPv6 error header (8) + original IPv6 header (40) + inner
+	// ICMPv6 header (8, includes echo ident+seqnum).
+	if (data->len < GR_ICMP6_HDR_LEN + sizeof(struct rte_ipv6_hdr) + GR_ICMP6_HDR_LEN)
+		return errno_set_null(EMSGSIZE);
 
-	i = data;
-	i->mbuf = m;
-	i->timestamp = timestamp;
-	STAILQ_INSERT_TAIL(&icmp_queue, i, next);
+	echo = PAYLOAD(hdr);
+	struct rte_ipv6_hdr *ip6 = PAYLOAD(echo);
+	if (ip6->proto != IPPROTO_ICMPV6)
+		return errno_set_null(EBADMSG);
+
+	hdr = PAYLOAD(ip6);
+	if (hdr->type != ICMP6_TYPE_ECHO_REQUEST)
+		return errno_set_null(EBADMSG);
+
+	return PAYLOAD(hdr);
+}
+
+// The echo reply payload contains the timestamp from the original request.
+// ICMPv6 errors only carry the original packet header + 8 bytes of data
+// (the ICMPv6 + echo header) so the timestamp is not available.
+static int icmp6_extract_info(
+	struct rte_mbuf *m,
+	rte_be16_t *ident,
+	rte_be16_t *seq_num,
+	gr_clock_ns_t *timestamp
+) {
+	struct icmp6_echo_reply *echo;
+	struct icmp6 *outer = NULL;
+
+	echo = icmp6_inner_echo(m, &outer);
+	if (echo == NULL)
+		return errno_set(EBADMSG);
+
+	*ident = echo->ident;
+	*seq_num = echo->seqnum;
+
+	if (outer->type == ICMP6_TYPE_ECHO_REPLY) {
+		gr_clock_ns_t *ts = PAYLOAD(echo);
+		*timestamp = *ts;
+	} else {
+		*timestamp = 0;
+	}
+	return 0;
+}
+
+static void icmp6_input_cb(void *m, uintptr_t timestamp, const struct control_queue_drain *drain) {
+	icmp_session_input(sessions, m, timestamp, drain);
 }
 
 static void icmp6_event_cb(uint32_t ev_type, const void *obj) {
-	struct icmp_queue_item *i, *tmp;
-
-	if (ev_type == GR_EVENT_IFACE_REMOVE) {
-		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-			if (mbuf_data(i->mbuf)->iface == obj)
-				icmp6_queue_pop(i, true);
-		}
-	}
-}
-
-#define ICMP6_QUEUE_TIMEOUT (10 * GR_NS_PER_S)
-
-static void icmp6_queue_gc(evutil_socket_t, short, void *) {
-	gr_clock_ns_t now = gr_clock_ns();
-	struct icmp_queue_item *i, *tmp;
-
-	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-		if (now - i->timestamp >= ICMP6_QUEUE_TIMEOUT)
-			icmp6_queue_pop(i, true);
-	}
-}
-
-#define ICMP6_ERROR_PKT_LEN                                                                        \
-	(GR_ICMP6_HDR_LEN + sizeof(struct rte_ipv6_hdr) + GR_ICMP6_HDR_LEN + sizeof(gr_clock_ns_t))
-
-static struct rte_mbuf *get_icmp6_echo_reply(
-	uint16_t ident,
-	uint16_t seq_num,
-	struct icmp6 **out_icmp6,
-	gr_clock_ns_t *timestamp
-) {
-	struct icmp_queue_item *i, *tmp;
-	struct rte_mbuf *mbuf;
-	struct icmp6 *icmp6;
-	struct icmp6_echo_reply *icmp6_echo;
-	struct rte_ipv6_hdr *ip6;
-
-	STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp) {
-		mbuf = i->mbuf;
-
-		if (rte_pktmbuf_pkt_len(mbuf) < GR_ICMP6_HDR_LEN + sizeof(gr_clock_ns_t))
-			goto free_and_skip;
-
-		icmp6 = rte_pktmbuf_mtod(mbuf, struct icmp6 *);
-		icmp6_echo = PAYLOAD(icmp6);
-
-		// icmpv6 error packet: find embedded origin ipv6 packet, and use
-		// it if it's our original echo request
-		if (icmp6->type != ICMP6_TYPE_ECHO_REPLY) {
-			if (rte_pktmbuf_pkt_len(mbuf) < ICMP6_ERROR_PKT_LEN)
-				goto free_and_skip;
-			ip6 = PAYLOAD(icmp6_echo);
-			if (ip6->proto != IPPROTO_ICMPV6)
-				goto free_and_skip;
-			icmp6 = PAYLOAD(ip6);
-			icmp6_echo = PAYLOAD(icmp6);
-			if (icmp6->type != ICMP6_TYPE_ECHO_REQUEST)
-				goto free_and_skip;
-		}
-
-		if (rte_be_to_cpu_16(icmp6_echo->ident) == ident
-		    && rte_be_to_cpu_16(icmp6_echo->seqnum) == seq_num) {
-			icmp6_queue_pop(i, false);
-			*out_icmp6 = icmp6;
-			*timestamp = i->timestamp;
-			return mbuf;
-		}
-
-		continue;
-free_and_skip:
-		icmp6_queue_pop(i, true);
-	}
-
-	return errno_set_null(ENOENT);
+	if (ev_type == GR_EVENT_IFACE_REMOVE)
+		icmp_session_iface_remove(sessions, obj);
 }
 
 static struct api_out icmp6_send(const void *request, struct api_ctx *) {
@@ -133,91 +98,74 @@ static struct api_out icmp6_send(const void *request, struct api_ctx *) {
 	if ((nh = fib6_lookup(req->vrf, req->iface, &req->addr, req->ident)) == NULL)
 		return api_out(errno, 0, NULL);
 
+	ret = icmp_session_add(sessions, req->ident, req->seq_num);
+	if (ret < 0)
+		return api_out(-ret, 0, NULL);
+
 	ret = icmp6_local_send(&req->addr, nh, req->ident, req->seq_num, req->ttl);
-	return api_out(ret, 0, NULL);
+	if (ret != 0) {
+		icmp_session_del(sessions, req->ident, req->seq_num);
+		return api_out(ret, 0, NULL);
+	}
+
+	return api_out(0, 0, NULL);
 }
 
 static struct api_out icmp6_recv(const void *request, struct api_ctx *) {
 	const struct gr_ip6_icmp_recv_req *recvreq = request;
-	gr_clock_ns_t *pkt_timestamp, rcv_timestamp;
-	struct icmp6_echo_reply *icmp6_echo;
 	struct gr_ip6_icmp_recv_resp *resp;
 	struct ip6_local_mbuf_data *d_ip6;
-	struct icmp6 *icmp6;
+	struct icmp6_echo_reply *echo;
+	gr_clock_ns_t response_time;
+	struct icmp6 *outer;
 	struct rte_mbuf *m;
-	int ret = 0;
 
-	m = get_icmp6_echo_reply(recvreq->ident, recvreq->seq_num, &icmp6, &rcv_timestamp);
+	m = icmp_session_recv(sessions, recvreq->ident, recvreq->seq_num, &response_time);
 	if (m == NULL)
 		return api_out(errno, 0, NULL);
 
-	d_ip6 = ip6_local_mbuf_data(m);
-	icmp6_echo = PAYLOAD(icmp6);
-	pkt_timestamp = PAYLOAD(icmp6_echo);
-
-	if ((resp = calloc(1, sizeof(*resp))) == NULL)
+	if ((resp = calloc(1, sizeof(*resp))) == NULL) {
+		rte_pktmbuf_free(m);
 		return api_out(ENOMEM, 0, NULL);
+	}
+
+	d_ip6 = ip6_local_mbuf_data(m);
+	echo = icmp6_inner_echo(m, &outer);
+
 	resp->src_addr = d_ip6->src;
 	resp->ttl = d_ip6->hop_limit;
-	resp->ident = rte_be_to_cpu_16(icmp6_echo->ident);
-	resp->seq_num = rte_be_to_cpu_16(icmp6_echo->seqnum);
-	resp->response_time = rcv_timestamp - *pkt_timestamp;
-	icmp6 = rte_pktmbuf_mtod(m, struct icmp6 *);
-	resp->type = icmp6->type;
-	resp->code = icmp6->code;
+	resp->type = outer->type;
+	resp->code = outer->code;
+	resp->ident = rte_be_to_cpu_16(echo->ident);
+	resp->seq_num = rte_be_to_cpu_16(echo->seqnum);
+	resp->response_time = response_time;
 
 	rte_pktmbuf_free(m);
-
-	return api_out(ret, sizeof(*resp), resp);
+	return api_out(0, sizeof(*resp), resp);
 }
 
-#define ICMP6_LOCAL_QUEUE_SIZE 1024
-static struct event *gc_timer;
+#define ICMP6_MAX_SESSIONS 1024
 
-static void icmp_init(struct event_base *ev_base) {
-	pool = rte_mempool_create(
-		"icmp6_queue",
-		ICMP6_LOCAL_QUEUE_SIZE,
-		sizeof(struct icmp_queue_item),
-		0, // cache size
-		0, // priv size
-		NULL, // mp_init
-		NULL, // mp_init_arg
-		NULL, // obj_init
-		NULL, // obj_init_arg
-		SOCKET_ID_ANY,
-		0 // flags
+static void icmp6_init(struct event_base *ev_base) {
+	sessions = icmp_session_pool_new(
+		"icmp6_sessions", ICMP6_MAX_SESSIONS, icmp6_extract_info, ev_base
 	);
-	if (pool == NULL)
-		ABORT("rte_mempool_create(icmp6_queue) failed");
-
-	gc_timer = event_new(ev_base, -1, EV_PERSIST | EV_FINALIZE, icmp6_queue_gc, NULL);
-	if (gc_timer == NULL)
-		ABORT("event_new() failed");
-	if (event_add(gc_timer, &(struct timeval) {.tv_sec = 1}) < 0)
-		ABORT("event_add() failed");
+	if (sessions == NULL)
+		ABORT("icmp_session_pool_new() failed");
 }
 
-static void icmp_fini(struct event_base *) {
-	if (gc_timer)
-		event_free(gc_timer);
-
-	if (pool != NULL) {
-		struct icmp_queue_item *i, *tmp;
-		STAILQ_FOREACH_SAFE (i, &icmp_queue, next, tmp)
-			icmp6_queue_pop(i, true);
-		rte_mempool_free(pool);
-		pool = NULL;
-	}
+static void icmp6_fini(struct event_base *) {
+	icmp_session_pool_free(sessions);
+	sessions = NULL;
 }
 
 static struct module icmp6_module = {
 	.name = "icmp6",
-	.init = icmp_init,
-	.fini = icmp_fini,
+	.init = icmp6_init,
+	.fini = icmp6_fini,
 };
 
-RTE_INIT(icmp_module_init) {
+RTE_INIT(icmp6_module_init) {
 	module_register(&icmp6_module);
 	api_handler(GR_IP6_ICMP6_SEND, icmp6_send);
 	api_handler(GR_IP6_ICMP6_RECV, icmp6_recv);

--- a/modules/ip6/control/icmp6.c
+++ b/modules/ip6/control/icmp6.c
@@ -117,6 +117,7 @@ static struct rte_mbuf *get_icmp6_echo_reply(
 			return mbuf;
 		}
 
+		continue;
 free_and_skip:
 		icmp6_queue_pop(i, true);
 	}


### PR DESCRIPTION
The IPv4 and IPv6 ICMP ping handlers share the same pattern: a linked list with linear scan and a mempool to match responses to requests. This series first fixes several issues in the ICMP response parsing (IP options, length validation, timestamp handling, use of ip_local_mbuf_data) then extracts the common logic into a reusable icmp_session_pool backed by rte_hash for O(1) lookup by (ident, seq_num).

The session pool uses a create-before-send model: the send handler registers a session, and incoming responses are matched and stored by a get_key callback. A periodic GC timer reaps stale sessions. Both IPv4 and IPv6 modules are converted to use it, removing significant code duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a reusable `icmp_session_pool` backed by `rte_hash` for O(1) lookup by `(ident, seq_num)`.
- Added session lifecycle APIs for registration, deletion, response retrieval, timeout cleanup, and interface removal.
- Replaced separate IPv4 and IPv6 linked-list queues, mempools, and garbage-collection timers with the shared session pool.
- Registered sessions before transmission and removed them when transmission fails.
- Added IPv4 and IPv6 response parsing for embedded echo requests and ICMP errors.
- Validated embedded packet lengths, protocols, ICMP types, and IPv4 options.
- Preserved IPv6 packets and corrected outer-header and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->