### PR TITLE
vrf: fix loopback event leak on fini

### DIFF
--- a/modules/infra/control/vrf.c
+++ b/modules/infra/control/vrf.c
@@ -268,14 +268,21 @@ netlink_fail:
 }
 
 static int iface_vrf_fini(struct iface *iface) {
+	int ret = 0;
+
 	for (unsigned af = 0; af < ARRAY_DIM(fib_ops); af++)
 		if (fib_ops[af] != NULL)
 			fib_ops[af]->fini(iface);
 
+	// Always destroy the loopback, even if the netlink cleanup failed,
+	// otherwise its polling event would be leaked.
 	if (netlink_vrf_del(iface) < 0)
-		return -errno;
+		ret = -errno;
 
-	return iface_loopback_destroy(iface);
+	if (iface_loopback_destroy(iface) < 0 && ret == 0)
+		ret = -errno;
+
+	return ret;
 }
 
 static int iface_vrf_reconfig(


### PR DESCRIPTION
When `netlink_vrf_del()` fails, `iface_vrf_fini()` returns early and never calls `iface_loopback_destroy()`, leaking the loopback polling event allocated in `iface_loopback_create()`.

This is hit whenever an address is configured on a VRF loopback: by the time the VRF is deleted the route is already gone, `netlink_vrf_del()` fails with `ESRCH` and logs

```
INFO: delete route on main failed: No such process
```

and LeakSanitizer reports

```
Direct leak of 128 byte(s) in 1 object(s) allocated from:
    #1 in event_new
    #2 in iface_loopback_create modules/infra/control/loopback.c:257
```

Found while writing the smoke test in #658, which is the first test to configure an address on the `main` VRF loopback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix VRF finalization leak

- Preserve the first cleanup error in `iface_vrf_fini()`.
- Continue cleanup after `netlink_vrf_del()` fails.
- Always call `iface_loopback_destroy()` to release the polling event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->