### PR TITLE
icmp6: fix NDP and RA flag bit positions

### DIFF
--- a/api/gr_bitops.h
+++ b/api/gr_bitops.h
@@ -5,8 +5,11 @@
 
 #include <stdint.h>
 
-// Bit manipulation utilities for flags and bitmasks.
+// Bit manipulation utilities for flags and bitmasks *in host order*.
 #define GR_BIT8(n) (UINT8_C(1) << (n))
 #define GR_BIT16(n) (UINT16_C(1) << (n))
 #define GR_BIT32(n) (UINT32_C(1) << (n))
 #define GR_BIT64(n) (UINT64_C(1) << (n))
+
+// 8-bit flag in RFC order (0 is the most significant bit).
+#define GR_MSB_BIT8(n) (UINT8_C(1) << (7 - (n)))

--- a/modules/infra/datapath/icmp6.h
+++ b/modules/infra/datapath/icmp6.h
@@ -76,8 +76,8 @@ struct icmp6_router_solicit {
 } __attribute__((packed));
 
 typedef enum : uint8_t {
-	ICMP6_RA_F_MANAGED_ADDR = GR_BIT8(0),
-	ICMP6_RA_F_OTHER_CONFIG = GR_BIT8(1),
+	ICMP6_RA_F_MANAGED_ADDR = GR_MSB_BIT8(0),
+	ICMP6_RA_F_OTHER_CONFIG = GR_MSB_BIT8(1),
 } icmp6_ra_flags_t;
 
 // ICMP6_TYPE_ROUTER_ADVERT
@@ -96,9 +96,9 @@ struct icmp6_neigh_solicit {
 } __attribute__((packed));
 
 typedef enum : uint8_t {
-	ICMP6_NA_F_ROUTER = GR_BIT8(0),
-	ICMP6_NA_F_SOLICITED = GR_BIT8(1),
-	ICMP6_NA_F_OVERRIDE = GR_BIT8(2),
+	ICMP6_NA_F_ROUTER = GR_MSB_BIT8(0),
+	ICMP6_NA_F_SOLICITED = GR_MSB_BIT8(1),
+	ICMP6_NA_F_OVERRIDE = GR_MSB_BIT8(2),
 } icmp6_na_flags_t;
 
 // ICMP6_TYPE_NEIGH_ADVERT

--- a/smoke/ip6_forward_test.sh
+++ b/smoke/ip6_forward_test.sh
@@ -32,8 +32,17 @@ ip netns exec n1 ping6 -i0.01 -c3 -n fd00:f00:2::2
 ip netns exec n2 ping6 -i0.01 -c3 -n fd00:f00:1::2
 ip netns exec n1 ping6 -i0.01 -c3 -n fd00:ba4:2::2
 ip netns exec n2 ping6 -i0.01 -c3 -n fd00:ba4:1::2
-ip netns exec n1 ping6 -i0.01 -c3 -n fd00:ba4:1::1
-ip netns exec n2 ping6 -i0.01 -c3 -n fd00:ba4:2::1
+# Verify that NDP neighbor advertisement flags are correct (RFC 4861 §4.4).
+# The Solicited flag must be set in NA replies, otherwise Linux never
+# transitions the neighbor entry to REACHABLE.
+for n in 1 2; do
+	ip -n n$n neigh flush dev x-p$n
+	ip netns exec n$n ping6 -i0.01 -c3 -n fd00:ba4:$n::1
+	ip -n n$n -6 neigh show dev x-p$n fd00:ba4:$n::1 | grep -qw REACHABLE || {
+		ip -n n$n -6 neigh show dev x-p$n
+		fail "n$n: neighbor fd00:ba4:$n::1 not REACHABLE"
+	}
+done
 ip netns exec n1 traceroute -N1 -n fd00:ba4:2::2
 ip netns exec n2 traceroute -N1 -n fd00:ba4:1::2
 ip netns exec n1 traceroute -N1 -n fd00:f00:2::2


### PR DESCRIPTION
The conversion from bit fields to GR_BIT8() enums placed the R/S/O flags of neighbor advertisements in bits 0-2 instead of bits 7-5 as required by RFC 4861 section 4.4. The same mistake affects the M/O flags of router advertisements (section 4.2).

This means every NA that grout sends has R=0, S=0, O=0 on the wire. Without the Solicited flag, Linux peers never transition the neighbor entry to REACHABLE, causing IPv6 next-hop resolution to fail permanently.

Fix the enums with explicit bit values to avoid confusion. Also add a REACHABLE check in the IPv6 forwarding smoke test.

Fixes: 7a40a4087484 ("icmp6: replace endian-dependent bitfields with flag enums")
Closes: https://github.com/DPDK/grout/issues/682
Link: https://datatracker.ietf.org/doc/html/rfc4861#section-4.2
Link: https://datatracker.ietf.org/doc/html/rfc4861#section-4.4