### PR TITLE
frr: fix IPv4-mapped IPv6 VTEPs

### DIFF
--- a/frr/l3vni_map.c
+++ b/frr/l3vni_map.c
@@ -126,8 +126,22 @@ static uint32_t rmac_hashfn(const struct rmac_entry *e) {
 DECLARE_HASH(rmac_hash, struct rmac_entry, item, rmac_cmp, rmac_hashfn);
 static struct rmac_hash_head rmac_entries = INIT_HASH(rmac_entries);
 
+static void rmac_vtep_entry(const struct ipaddr *vtep, struct ipaddr *key) {
+	*key = *vtep;
+
+	if (vtep->ipa_type == IPADDR_V6 && IS_MAPPED_IPV6(&vtep->ipaddr_v6)) {
+		struct in_addr v4;
+
+		ipv4_mapped_ipv6_to_ipv4(&vtep->ipaddr_v6, &v4);
+		memset(key, 0, sizeof(*key));
+		key->ipa_type = IPADDR_V4;
+		key->ipaddr_v4 = v4;
+	}
+}
+
 void l3vni_rmac_set(uint16_t vrf_id, const struct ipaddr *vtep, const struct ethaddr *mac) {
-	struct rmac_entry *e, key = {.vrf_id = vrf_id, .vtep = *vtep};
+	struct rmac_entry *e, key = {.vrf_id = vrf_id};
+	rmac_vtep_entry(vtep, &key.vtep);
 
 	e = rmac_hash_find(&rmac_entries, &key);
 	if (e != NULL) {
@@ -136,13 +150,15 @@ void l3vni_rmac_set(uint16_t vrf_id, const struct ipaddr *vtep, const struct eth
 	}
 	e = XCALLOC(MTYPE_GROUT_MEM, sizeof(*e));
 	e->vrf_id = vrf_id;
-	e->vtep = *vtep;
+	e->vtep = key.vtep;
 	e->mac = *mac;
 	rmac_hash_add(&rmac_entries, e);
 }
 
 void l3vni_rmac_del(uint16_t vrf_id, const struct ipaddr *vtep) {
-	struct rmac_entry key = {.vrf_id = vrf_id, .vtep = *vtep};
+	struct rmac_entry key = {.vrf_id = vrf_id};
+	rmac_vtep_entry(vtep, &key.vtep);
+
 	struct rmac_entry *e = rmac_hash_find(&rmac_entries, &key);
 
 	if (e != NULL) {
@@ -152,7 +168,8 @@ void l3vni_rmac_del(uint16_t vrf_id, const struct ipaddr *vtep) {
 }
 
 const struct ethaddr *l3vni_rmac_get(uint16_t vrf_id, const struct ipaddr *vtep) {
-	struct rmac_entry key = {.vrf_id = vrf_id, .vtep = *vtep};
+	struct rmac_entry key = {.vrf_id = vrf_id};
+	rmac_vtep_entry(vtep, &key.vtep);
 	struct rmac_entry *e = rmac_hash_find(&rmac_entries, &key);
 	return e ? &e->mac : NULL;
 }

--- a/frr/rt_grout.c
+++ b/frr/rt_grout.c
@@ -737,12 +737,32 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 		switch (nh->type) {
 		case NEXTHOP_TYPE_IPV4:
 		case NEXTHOP_TYPE_IPV4_IFINDEX:
+		case NEXTHOP_TYPE_IPV6:
+		case NEXTHOP_TYPE_IPV6_IFINDEX: {
+			struct l3_addr gate;
+
 			l3 = (struct gr_nexthop_info_l3 *)req->nh.info;
-			l3->af = GR_AF_IP4;
-			memcpy(&l3->ipv4, &nh->gate.ipv4, sizeof(l3->ipv4));
+
+			if (nh->type == NEXTHOP_TYPE_IPV4
+			    || nh->type == NEXTHOP_TYPE_IPV4_IFINDEX) {
+				vtep.ipa_type = IPADDR_V4;
+				vtep.ipaddr_v4 = nh->gate.ipv4;
+			} else {
+				vtep.ipa_type = IPADDR_V6;
+				vtep.ipaddr_v6 = nh->gate.ipv6;
+			}
+
+			// EVPN may advertise an IPv4 VTEP as an IPv4-mapped IPv6
+			// address; ipaddr_to_l3_addr() canonicalizes it so that
+			// vxlan_output builds IPv4 encapsulation.
+			ipaddr_to_l3_addr(&gate, &vtep);
+			l3->af = gate.af;
+			if (gate.af == GR_AF_IP4)
+				l3->ipv4 = gate.ipv4;
+			else
+				l3->ipv6 = gate.ipv6;
+
 			// Apply cached RMAC from EVPN NEIGH install if available.
-			vtep.ipa_type = IPADDR_V4;
-			vtep.ipaddr_v4 = nh->gate.ipv4;
 			rmac = l3vni_rmac_get(req->nh.vrf_id, &vtep);
 			if (rmac != NULL) {
 				memcpy(&l3->mac, rmac, sizeof(l3->mac));
@@ -752,35 +772,7 @@ grout_add_nexthop(uint32_t nh_id, gr_nh_origin_t origin, const struct nexthop *n
 					req->nh.iface_id = vxlan_iface_id;
 			}
 			break;
-		case NEXTHOP_TYPE_IPV6:
-		case NEXTHOP_TYPE_IPV6_IFINDEX:
-			l3 = (struct gr_nexthop_info_l3 *)req->nh.info;
-			// EVPN type-5 IPv6 prefixes use v4-mapped nexthops
-			// (::ffff:X.X.X.X) because the VTEP is always IPv4.
-			// Store as native IPv4 so vxlan_output uses IPv4
-			// encapsulation to reach the remote VTEP.
-			if (IS_MAPPED_IPV6(&nh->gate.ipv6)) {
-				struct in_addr v4;
-				ipv4_mapped_ipv6_to_ipv4(&nh->gate.ipv6, &v4);
-				l3->af = GR_AF_IP4;
-				l3->ipv4 = v4.s_addr;
-				vtep.ipa_type = IPADDR_V4;
-				vtep.ipaddr_v4 = v4;
-			} else {
-				l3->af = GR_AF_IP6;
-				memcpy(&l3->ipv6, &nh->gate.ipv6, sizeof(l3->ipv6));
-				vtep.ipa_type = IPADDR_V6;
-				vtep.ipaddr_v6 = nh->gate.ipv6;
-			}
-			// Apply cached RMAC from EVPN NEIGH install if available.
-			rmac = l3vni_rmac_get(req->nh.vrf_id, &vtep);
-			if (rmac != NULL) {
-				memcpy(&l3->mac, rmac, sizeof(l3->mac));
-				l3->flags |= GR_NH_F_REMOTE;
-				if (vxlan_iface_id != GR_IFACE_ID_UNDEF)
-					req->nh.iface_id = vxlan_iface_id;
-			}
-			break;
+		}
 		case NEXTHOP_TYPE_IFINDEX:
 			l3 = (struct gr_nexthop_info_l3 *)req->nh.info;
 			l3->af = GR_AF_UNSPEC;

--- a/frr/zebra_dplane_grout.c
+++ b/frr/zebra_dplane_grout.c
@@ -100,6 +100,14 @@ void ipaddr_to_l3_addr(struct l3_addr *dst, const struct ipaddr *src) {
 		memcpy(&dst->ipv4, &src->ipaddr_v4, sizeof(dst->ipv4));
 		break;
 	case IPADDR_V6:
+		if (IS_MAPPED_IPV6(&src->ipaddr_v6)) {
+			struct in_addr v4;
+
+			ipv4_mapped_ipv6_to_ipv4(&src->ipaddr_v6, &v4);
+			dst->af = GR_AF_IP4;
+			memcpy(&dst->ipv4, &v4, sizeof(dst->ipv4));
+			break;
+		}
 		dst->af = GR_AF_IP6;
 		memcpy(&dst->ipv6, &src->ipaddr_v6, sizeof(dst->ipv6));
 		break;


### PR DESCRIPTION
The handling of IPv4-mapped IPv6 VTEPs was inconsistent across the frr plugin.

1. IPv4-mapped IPv6 VTEPs are now tracked under their IPv4 address in the RMAC map
2. FDB/flood entries were incorrectly using an IPv6 nexthop (fixed through change in `ipaddr_to_l3_addr`)
3. Collapsed the different handling of IPv4 and IPv6 nexthops into a single branch