### PR TITLE
bond: preserve configured MAC when attaching members

### DIFF
--- a/modules/infra/control/bond.c
+++ b/modules/infra/control/bond.c
@@ -172,9 +172,14 @@ static int bond_attach_member(struct iface *iface, struct iface *member) {
 	m->iface = member;
 	bond->n_members++;
 
-	if (bond_mac_set(iface, &zero) < 0) {
+	if (!bond->mac_explicit) {
+		if (bond_mac_set(iface, &zero) < 0) {
+			bond->n_members--;
+			return errno_log(errno, "bond_mac_set");
+		}
+	} else if (iface_add_eth_addr(member, &bond->mac) < 0) {
 		bond->n_members--;
-		return errno_log(errno, "bond_mac_set");
+		return errno_log(errno, "iface_add_eth_addr(member)");
 	}
 
 	bond_update_active_members(iface);
@@ -379,7 +384,13 @@ static int bond_reconfig(
 		bond_update_active_members(iface);
 	}
 
-	if (set_attrs & (GR_BOND_SET_MAC | GR_BOND_SET_PRIMARY)) {
+	if (set_attrs & GR_BOND_SET_MAC)
+		bond->mac_explicit = !rte_is_zero_ether_addr(&api->mac);
+
+	// Changing the primary member only re-derives the mac when the user did
+	// not configure one, otherwise the configured mac would be discarded.
+	if (set_attrs & GR_BOND_SET_MAC
+	    || (set_attrs & GR_BOND_SET_PRIMARY && !bond->mac_explicit)) {
 		if (iface_set_eth_addr(iface, &api->mac) < 0)
 			return -errno;
 	}

--- a/modules/infra/control/bond.h
+++ b/modules/infra/control/bond.h
@@ -28,6 +28,7 @@ GR_IFACE_INFO(GR_IFACE_TYPE_BOND, iface_info_bond, {
 	gr_bond_mode_t mode;
 	gr_bond_algo_t algo;
 	struct rte_ether_addr mac;
+	bool mac_explicit; // mac was configured by the user, do not derive it from members
 
 	uint8_t primary_member;
 	uint8_t active_member; // Active member index (for active-backup mode)

--- a/smoke/bond_active_backup_test.sh
+++ b/smoke/bond_active_backup_test.sh
@@ -27,9 +27,20 @@ port_add p0 domain bond0
 port_add p1 domain bond0
 port_add p2 domain bond0
 
+# without an explicit mac, the bond derives its address from the primary member
+p0_mac=$(grcli -j interface show name p0 | jq -r .mac)
+grcli -j interface show name bond0 | jq -e --arg mac "$p0_mac" 'select(.mac == $mac)' ||
+	fail "bond0 mac not derived from primary member p0"
+
 mac=02:f0:00:b4:44:44
 
 grcli interface set bond bond0 mac $mac primary p1
+
+# an explicitly configured mac must survive a primary member change
+grcli interface set bond bond0 primary p2
+grcli -j interface show name bond0 | jq -e --arg mac "$mac" 'select(.mac == $mac)' ||
+	fail "bond0 mac not preserved across primary member change"
+grcli interface set bond bond0 primary p1
 
 netns_add n0
 ip -n n0 link add br0 type bridge vlan_filtering 1

--- a/smoke/bond_lacp_test.sh
+++ b/smoke/bond_lacp_test.sh
@@ -22,10 +22,13 @@ wait_member_sync() {
 
 . $(dirname $0)/_init.sh
 
-grcli interface add bond bond0 mode lacp
+bond_mac=02:00:00:00:00:10
+grcli interface add bond bond0 mode lacp mac $bond_mac
 port_add p0 domain bond0
 port_add p1 domain bond0
 port_add p2 domain bond0
+grcli -j interface show name bond0 | \
+	jq -e --arg mac "$bond_mac" 'select(.mac == $mac)'
 grcli address add 172.16.0.1/24 iface bond0
 
 netns_add n0


### PR DESCRIPTION
Attaching a member to a bond unconditionally re-derives the bond MAC via
`bond_mac_set(iface, &zero)`, which discards an explicitly configured bond
MAC as soon as the first member arrives, and later members never get the
configured address programmed into their filters.

Keep an explicitly configured MAC when members are attached and program it
into each new member's filter instead. When no MAC was configured, the
existing re-derivation behaviour is unchanged.

Found while prototyping EVPN all-active multihoming (#698), where two
independent LACP instances must present one shared system identity, but the
bug is reproducible on any single bond.

## Testing

- Extended `smoke/bond_lacp_test.sh` to configure an explicit bond MAC and
  assert it survives all member attachments.
- Without the fix (test-only applied to `main`): the smoke test fails —
  after attach the bond MAC becomes the member-derived address
  (`02:09:e8:d0:db:1c`) instead of the configured `02:00:00:00:00:10`.
- With the fix: full unit suite and smoke suite pass (AlmaLinux 9
  container, arm64).

Related: #698
