### PR TITLE
trace: do not spin when the trace pool is exhausted

### DIFF
--- a/modules/infra/datapath/meson.build
+++ b/modules/infra/datapath/meson.build
@@ -25,3 +25,10 @@ src += files(
   'xconnect.c',
 )
 inc += include_directories('.')
+
+tests += [
+  {
+    'sources': files('trace_test.c'),
+    'link_args': [],
+  }
+]

--- a/modules/infra/datapath/trace.c
+++ b/modules/infra/datapath/trace.c
@@ -577,6 +577,7 @@ err:
 
 static struct rte_mempool *trace_pool;
 static struct rte_ring *traced_packets;
+static _Thread_local __rte_cache_aligned uint8_t trace_scratch[GR_TRACE_ITEM_MAX_LEN];
 
 static void free_trace(struct gr_trace_item *t) {
 	// free the whole chain of trace items
@@ -587,6 +588,28 @@ static void free_trace(struct gr_trace_item *t) {
 	}
 }
 
+// Reclaim a completed trace when possible. If every trace item is attached to
+// an in-flight packet there is nothing safe to reclaim: abandon tracing for
+// the current packet instead of spinning a datapath worker indefinitely while
+// it owns an mbuf. A worker stalled here can eventually exhaust the shared
+// packet pool and starve the FRR control-plane TAPs.
+static bool trace_item_get(struct rte_mbuf *m, void **data) {
+	while (rte_mempool_get(trace_pool, data) < 0) {
+		void *oldest = NULL;
+
+		if (rte_ring_dequeue(traced_packets, &oldest) < 0) {
+			struct gr_trace_head *traces = gr_mbuf_traces(m);
+
+			free_trace(STAILQ_FIRST(traces));
+			STAILQ_INIT(traces);
+			return false;
+		}
+		free_trace(oldest);
+	}
+
+	return true;
+}
+
 void *gr_mbuf_trace_add(struct rte_mbuf *m, struct rte_node *node, size_t data_len) {
 	struct gr_trace_head *traces = gr_mbuf_traces(m);
 	struct gr_trace_item *trace;
@@ -595,11 +618,8 @@ void *gr_mbuf_trace_add(struct rte_mbuf *m, struct rte_node *node, size_t data_l
 	// XXX: should we always abort even if -DNDEBUG is defined?
 	assert(data_len <= GR_TRACE_ITEM_MAX_LEN);
 
-	while (rte_mempool_get(trace_pool, &data) < 0) {
-		void *oldest = NULL;
-		rte_ring_dequeue(traced_packets, &oldest);
-		free_trace(oldest);
-	}
+	if (!trace_item_get(m, &data))
+		return trace_scratch;
 
 	trace = data;
 	trace->node_id = node->id;
@@ -629,11 +649,8 @@ void gr_mbuf_trace_copy(struct rte_mbuf *dst, struct rte_mbuf *src) {
 	// Copy each trace item from source to destination
 	STAILQ_FOREACH (src_trace, src_traces, next) {
 		// Allocate new trace item for destination
-		while (rte_mempool_get(trace_pool, &data) < 0) {
-			void *oldest = NULL;
-			rte_ring_dequeue(traced_packets, &oldest);
-			free_trace(oldest);
-		}
+		if (!trace_item_get(dst, &data))
+			return;
 
 		dst_trace = data;
 

--- a/modules/infra/datapath/trace_test.c
+++ b/modules/infra/datapath/trace_test.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Harrison Caldicott
+
+#include "_cmocka.h"
+#include "trace.c"
+
+#include <rte_eal.h>
+
+// mocked types/functions
+int gr_rte_log_type;
+struct log_types log_types = STAILQ_HEAD_INITIALIZER(log_types);
+void module_register(struct module *) { }
+const struct gr_node_info *gr_node_info_get(rte_node_t) {
+	return NULL;
+}
+
+// Pool sized so a single packet can exhaust it. Optimal mempool sizes are
+// 2^n - 1.
+#define TRACE_TEST_POOL_SIZE 7
+
+static struct test_mbuf {
+	struct rte_mbuf m;
+	uint8_t priv[GR_MBUF_PRIV_MAX_SIZE];
+} pkt;
+
+static struct rte_node fake_node;
+
+static int setup(void **) {
+	trace_pool = rte_mempool_create(
+		"trace_test_items",
+		TRACE_TEST_POOL_SIZE,
+		sizeof(struct gr_trace_item),
+		0, // cache size
+		0, // priv size
+		NULL, // mp_init
+		NULL, // mp_init_arg
+		NULL, // obj_init
+		NULL, // obj_init_arg
+		SOCKET_ID_ANY,
+		0 // flags
+	);
+	if (trace_pool == NULL)
+		return -1;
+	traced_packets = rte_ring_create(
+		"trace_test_packets", 8, SOCKET_ID_ANY, RING_F_MP_RTS_ENQ | RING_F_MC_RTS_DEQ
+	);
+	if (traced_packets == NULL)
+		return -1;
+	return 0;
+}
+
+static int teardown(void **) {
+	rte_ring_free(traced_packets);
+	rte_mempool_free(trace_pool);
+	return 0;
+}
+
+// All trace items are attached to a single in-flight packet: the
+// traced_packets ring is empty and nothing can be reclaimed. The next
+// allocation must abandon tracing for the packet instead of spinning forever.
+static void exhausted_pool_does_not_deadlock(void **) {
+	STAILQ_INIT(gr_mbuf_traces(&pkt.m));
+
+	for (unsigned i = 0; i < TRACE_TEST_POOL_SIZE; i++)
+		assert_non_null(gr_mbuf_trace_add(&pkt.m, &fake_node, 0));
+
+	assert_int_equal(rte_mempool_avail_count(trace_pool), 0);
+	assert_non_null(gr_mbuf_trace_add(&pkt.m, &fake_node, 0));
+
+	// Tracing for the packet was abandoned and its chain returned to the pool.
+	assert_true(STAILQ_EMPTY(gr_mbuf_traces(&pkt.m)));
+	assert_int_equal(rte_mempool_avail_count(trace_pool), TRACE_TEST_POOL_SIZE);
+}
+
+// When completed traces sit in the ring, exhaustion is resolved by recycling
+// the oldest completed trace, not by abandoning the current packet.
+static void exhausted_pool_recycles_completed_traces(void **) {
+	struct test_mbuf done;
+
+	STAILQ_INIT(gr_mbuf_traces(&done.m));
+	assert_non_null(gr_mbuf_trace_add(&done.m, &fake_node, 0));
+	gr_mbuf_trace_finish(&done.m);
+
+	STAILQ_INIT(gr_mbuf_traces(&pkt.m));
+	for (unsigned i = 0; i < TRACE_TEST_POOL_SIZE - 1; i++)
+		assert_non_null(gr_mbuf_trace_add(&pkt.m, &fake_node, 0));
+
+	assert_int_equal(rte_mempool_avail_count(trace_pool), 0);
+	assert_non_null(gr_mbuf_trace_add(&pkt.m, &fake_node, 0));
+
+	// The current packet kept its full chain by stealing the completed trace.
+	assert_false(STAILQ_EMPTY(gr_mbuf_traces(&pkt.m)));
+	assert_int_equal(rte_mempool_avail_count(trace_pool), 0);
+}
+
+int main(void) {
+	char arg0[] = "trace_test";
+	char arg1[] = "--no-huge";
+	char arg2[] = "--in-memory";
+	char arg3[] = "--lcores=0";
+	char arg4[] = "--no-pci";
+	char arg5[] = "--log-level=*:error";
+	char *argv[] = {arg0, arg1, arg2, arg3, arg4, arg5};
+
+	if (rte_eal_init(ARRAY_DIM(argv), argv) < 0)
+		return 1;
+
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test_setup_teardown(exhausted_pool_does_not_deadlock, setup, teardown),
+		cmocka_unit_test_setup_teardown(
+			exhausted_pool_recycles_completed_traces, setup, teardown
+		),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
When the trace item pool is exhausted and every allocated item is still
attached to an in-flight packet, the `traced_packets` ring is empty and
the reclaim loop in `gr_mbuf_trace_add()` can never make progress:
`rte_ring_dequeue()` keeps failing and the datapath worker spins forever
while owning an mbuf. Under sustained trace load this deadlocks the
worker and can starve the shared packet pool.

Abandon tracing for the current packet instead: free its partial trace
chain back to the pool and hand callers a thread-local scratch buffer so
they can write their trace data without a NULL check. Recycling completed
traces from the ring keeps working as before.

Found while stress-testing EVPN all-active multihoming (#698) with
tracing enabled, but the loop is reachable on `main` whenever tracing is
active under packet load.

## Testing

- New `trace_test.c` exercises the exhaustion paths with a deliberately
  tiny pool. It initializes EAL with `--no-huge --in-memory` so real
  mempool/ring objects work without hugepages (first unit test in the
  tree to do so — feedback welcome if there is a preferred approach).
- Without the fix: the first test spins forever in the reclaim loop and
  is killed by the 30s test timeout.
- With the fix: both tests pass, and the full unit and smoke suites pass
  (AlmaLinux 9 container, arm64).

Related: #698
