### PR TITLE
infra: tolerate unsupported all-multicast mode

### DIFF
--- a/modules/infra/control/iface_test.c
+++ b/modules/infra/control/iface_test.c
@@ -57,6 +57,7 @@ mock_func(int, port_plug(struct iface_info_port *));
 mock_func(unsigned, worker_count(void));
 mock_func(int, worker_queue_distribute(const cpu_set_t *, vec struct iface_info_port **));
 mock_func(int, __wrap_rte_eth_allmulticast_enable(uint16_t));
+mock_func(int, __wrap_rte_eth_allmulticast_get(uint16_t));
 mock_func(int, __wrap_rte_eth_dev_mac_addr_add(uint16_t, struct rte_ether_addr *, uint32_t));
 mock_func(int, __wrap_rte_eth_dev_mac_addr_remove(uint16_t, struct rte_ether_addr *));
 mock_func(int, __wrap_rte_eth_promiscuous_disable(uint16_t));
@@ -185,6 +186,37 @@ static void port_mac_del_unicast(void **) {
 	assert_true(iface->macs[1].hardware);
 }
 
+static void port_allmulticast_supported(void **) {
+	iface->state &= ~GR_IFACE_S_ALLMULTI;
+	will_return(__wrap_rte_eth_allmulticast_enable, 0);
+	will_return(__wrap_rte_eth_allmulticast_get, 1);
+	assert_return_code(port_allmulticast_enable(iface), errno);
+	assert_true(iface->state & GR_IFACE_S_ALLMULTI);
+}
+
+static void port_allmulticast_unsupported(void **) {
+	iface->state &= ~GR_IFACE_S_ALLMULTI;
+	will_return(__wrap_rte_eth_allmulticast_enable, -ENOTSUP);
+	will_return(__wrap_rte_eth_allmulticast_get, 0);
+	assert_return_code(port_allmulticast_enable(iface), errno);
+	assert_false(iface->state & GR_IFACE_S_ALLMULTI);
+}
+
+static void port_allmulticast_unsupported_but_on(void **) {
+	iface->state &= ~GR_IFACE_S_ALLMULTI;
+	will_return(__wrap_rte_eth_allmulticast_enable, -ENOTSUP);
+	will_return(__wrap_rte_eth_allmulticast_get, 1);
+	assert_return_code(port_allmulticast_enable(iface), errno);
+	assert_true(iface->state & GR_IFACE_S_ALLMULTI);
+}
+
+static void port_allmulticast_error(void **) {
+	iface->state &= ~GR_IFACE_S_ALLMULTI;
+	will_return(__wrap_rte_eth_allmulticast_enable, -EIO);
+	assert_int_equal(port_allmulticast_enable(iface), -EIO);
+	assert_false(iface->state & GR_IFACE_S_ALLMULTI);
+}
+
 static void vlan_mac_add_multicast(void **) {
 	assert_return_code(iface_add_eth_addr(vlan_iface, &mcast1), errno);
 	assert_int_equal(vec_len(vlan_iface->macs), 0);
@@ -273,6 +305,10 @@ int main(void) {
 		cmocka_unit_test(port_mac_add_multicast),
 		cmocka_unit_test(port_mac_add_unicast),
 		cmocka_unit_test(port_mac_del_unicast),
+		cmocka_unit_test(port_allmulticast_supported),
+		cmocka_unit_test(port_allmulticast_unsupported),
+		cmocka_unit_test(port_allmulticast_unsupported_but_on),
+		cmocka_unit_test(port_allmulticast_error),
 		cmocka_unit_test(vlan_mac_add_multicast),
 		cmocka_unit_test(vlan_mac_add_unicast),
 		cmocka_unit_test(vlan_mac_del_unicast),

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -53,6 +53,7 @@ tests += [
     'link_args': [
       '-Wl,--wrap=iface_from_id',
       '-Wl,--wrap=rte_eth_allmulticast_enable',
+      '-Wl,--wrap=rte_eth_allmulticast_get',
       '-Wl,--wrap=rte_eth_dev_mac_addr_add',
       '-Wl,--wrap=rte_eth_dev_mac_addr_remove',
       '-Wl,--wrap=rte_eth_promiscuous_disable',

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -280,6 +280,33 @@ static int port_mtu_set(struct iface *iface, uint16_t mtu) {
 	return 0;
 }
 
+int port_allmulticast_enable(struct iface *iface) {
+	struct iface_info_port *p = iface_info_port(iface);
+	int ret;
+
+	ret = rte_eth_allmulticast_enable(p->port_id);
+	switch (ret) {
+	case 0:
+	case -ENOSYS:
+	case -EOPNOTSUPP:
+		break;
+	default:
+		return errno_log(-ret, "rte_eth_allmulticast_enable");
+	}
+
+	if (rte_eth_allmulticast_get(p->port_id) == 1) {
+		iface->state |= GR_IFACE_S_ALLMULTI;
+	} else {
+		LOG(WARNING,
+		    "%s: cannot enable ALLMULTI: %s",
+		    iface->name,
+		    strerror(-ret ?: EPERM));
+		iface->state &= ~GR_IFACE_S_ALLMULTI;
+	}
+
+	return 0;
+}
+
 static int iface_port_reconfig(
 	struct iface *iface,
 	uint64_t set_attrs,
@@ -348,10 +375,9 @@ static int iface_port_reconfig(
 		if (ret < 0)
 			return ret;
 
-		// always enable allmulti
-		if ((ret = rte_eth_allmulticast_enable(p->port_id)) < 0)
-			return errno_log(-ret, "rte_eth_allmulticast_enable");
-		iface->state |= GR_IFACE_S_ALLMULTI;
+		// Virtual PMDs may be inherently unfiltered and have no allmulti toggle.
+		if ((ret = port_allmulticast_enable(iface)) < 0)
+			return ret;
 
 		if ((ret = port_plug(p)) < 0)
 			return ret;

--- a/modules/infra/control/port.h
+++ b/modules/infra/control/port.h
@@ -30,3 +30,4 @@ GR_IFACE_INFO(GR_IFACE_TYPE_PORT, iface_info_port, {
 });
 
 const struct iface *port_get_iface(uint16_t port_id);
+int port_allmulticast_enable(struct iface *iface);


### PR DESCRIPTION
`rte_eth_allmulticast_enable()` returns `-ENOTSUP` for drivers that have
no all-multicast toggle — virtual PMDs in particular can be inherently
unfiltered and expose nothing to switch. `iface_port_reconfig()` treats
any error from it as fatal, so a port backed by such a driver cannot be
configured at all.

Extract the call into a `port_allmulticast_enable()` helper that follows
the same pattern as the existing link, promiscuous and MTU handlers:
tolerate `-ENOSYS`/`-EOPNOTSUPP`, derive `GR_IFACE_S_ALLMULTI` from
`rte_eth_allmulticast_get()` so the flag reflects the actual device
state, and log a warning when all-multicast could not be enabled. Real
failures from drivers that do support the toggle remain fatal.

Found during the same EVPN multihoming bring-up as #698, but reproducible
on any port whose PMD lacks the toggle since ec4cbdc7f18f made allmulti
unconditional.

## Testing

- Four unit tests in `iface_test` mock `rte_eth_allmulticast_enable()`
  and `rte_eth_allmulticast_get()`: success sets `GR_IFACE_S_ALLMULTI`,
  `-ENOTSUP` succeeds with the flag tracking the device state read-back
  (both off and already-on cases), and a real error (`-EIO`) still fails
  reconfiguration.
- A red test for the pre-fix behaviour was judged impractical: the
  failure sits inside `iface_port_reconfig()`, which needs the full port
  setup path mocked out. The failure mode is established by inspection —
  the DPDK API documents the `-ENOTSUP` return, and the old code returned
  it as fatal unconditionally.
- With the fix: full unit suite passes (AlmaLinux 9 container, arm64).

Related: #698
