### PR TITLE
srv6: fix SRH generation for multi-segment and reduced encapsulation

### DIFF
--- a/modules/srv6/datapath/srv6_output.c
+++ b/modules/srv6/datapath/srv6_output.c
@@ -92,7 +92,7 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 		optlen = 0;
 		reduc = d->encap == SR_H_ENCAPS_RED ? 1 : 0;
 		if (d->n_seglist > reduc)
-			optlen += sizeof(*srh) + (d->n_seglist * sizeof(d->seglist[0]));
+			optlen += sizeof(*srh) + ((d->n_seglist - reduc) * sizeof(d->seglist[0]));
 
 		outer_ip6 = gr_mbuf_prepend(m, outer_ip6, optlen);
 		if (unlikely(outer_ip6 == NULL)) {
@@ -111,7 +111,7 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			srh->segments_left = d->n_seglist - 1;
 			// flags aliases the whole word: last_entry, flag and tag
 			srh->flags = 0;
-			srh->last_entry = d->n_seglist - 1;
+			srh->last_entry = d->n_seglist - 1 - reduc;
 
 			segments = PAYLOAD(srh);
 			for (k = reduc; k < d->n_seglist; k++)

--- a/modules/srv6/datapath/srv6_output.c
+++ b/modules/srv6/datapath/srv6_output.c
@@ -109,9 +109,9 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			srh->hdr_len = optlen / 8 - 1;
 			srh->type = RTE_IPV6_SRCRT_TYPE_4;
 			srh->segments_left = d->n_seglist - 1;
-			srh->last_entry = d->n_seglist - 1;
+			// flags aliases the whole word: last_entry, flag and tag
 			srh->flags = 0;
-			srh->tag = 0;
+			srh->last_entry = d->n_seglist - 1;
 
 			segments = PAYLOAD(srh);
 			for (k = reduc; k < d->n_seglist; k++)

--- a/modules/srv6/datapath/srv6_output.c
+++ b/modules/srv6/datapath/srv6_output.c
@@ -53,7 +53,7 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 	const struct nexthop *nh;
 	uint32_t optlen, plen;
 	struct rte_mbuf *m;
-	uint8_t proto, reduc;
+	uint8_t proto, n_omitted_segs;
 	rte_edge_t edge;
 
 	for (uint16_t i = 0; i < nb_objs; i++) {
@@ -90,9 +90,10 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 
 		// Encapsulate with another IPv6 header
 		optlen = 0;
-		reduc = d->encap == SR_H_ENCAPS_RED ? 1 : 0;
-		if (d->n_seglist > reduc)
-			optlen += sizeof(*srh) + ((d->n_seglist - reduc) * sizeof(d->seglist[0]));
+		n_omitted_segs = d->encap == SR_H_ENCAPS_RED ? 1 : 0;
+		if (d->n_seglist > n_omitted_segs)
+			optlen += sizeof(*srh)
+				+ ((d->n_seglist - n_omitted_segs) * sizeof(d->seglist[0]));
 
 		outer_ip6 = gr_mbuf_prepend(m, outer_ip6, optlen);
 		if (unlikely(outer_ip6 == NULL)) {
@@ -100,7 +101,7 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			goto next;
 		}
 
-		if (d->n_seglist > reduc) {
+		if (d->n_seglist > n_omitted_segs) {
 			struct rte_ipv6_addr *segments;
 			uint16_t k;
 
@@ -111,10 +112,10 @@ srv6_output_process(struct rte_graph *graph, struct rte_node *node, void **objs,
 			srh->segments_left = d->n_seglist - 1;
 			// flags aliases the whole word: last_entry, flag and tag
 			srh->flags = 0;
-			srh->last_entry = d->n_seglist - 1 - reduc;
+			srh->last_entry = d->n_seglist - 1 - n_omitted_segs;
 
 			segments = PAYLOAD(srh);
-			for (k = reduc; k < d->n_seglist; k++)
+			for (k = n_omitted_segs; k < d->n_seglist; k++)
 				segments[d->n_seglist - k - 1] = d->seglist[k];
 			proto = IPPROTO_ROUTING;
 			plen += optlen;

--- a/smoke/bgp6_srv6_frr_test.sh
+++ b/smoke/bgp6_srv6_frr_test.sh
@@ -170,6 +170,7 @@ router bgp 64512
 
  segment-routing srv6
   locator loc1
+  encap-behavior H_Encaps_Red
  exit
 exit
 
@@ -194,6 +195,7 @@ EOF
 wait_event -t 20 'route4 add: vrf=gr-vrf1 16.0.0.0/24 origin=bgp'
 nh_id=$(route_nh_id 16.0.0.0/24 gr-vrf1 SRv6)
 assert_nexthop "$nh_id" '.vrf == "main" and .seglist[0] == "2001:db8:1:1:100::"'
+assert_nexthop "$nh_id" '.encap == "h.encaps.red"'
 wait_event -t 20 'route6 add: vrf=main 2001:db8:2:2:100::/128 origin=bgp'
 nh_id=$(route_nh_id 2001:db8:2:2:100::/128 main SRv6-local)
 assert_nexthop "$nh_id" '.vrf == "gr-vrf1" and .behavior == "end.dt4"'
@@ -211,6 +213,29 @@ while ! vtysh -N bgp-peer -c "show ipv6 route" | grep -q "B>\* 2001:db8:1:1:100:
 	attempts=$((attempts + 1))
 done
 
+# A single SID leaves nothing to put in an SRH, so the outer header must point
+# straight at the encapsulated IPv4 packet. The second capture is only there to
+# report what was really sent when the first one fails.
+ip netns exec bgp-peer timeout 10 tcpdump -c1 -pnnli x-p0 \
+	'ip6 dst 2001:db8:1:1:100:: and ip6[6] = 4' >$tmp/vpn4_nosrh 2>&1 &
+tcpdump_pid=$!
+ip netns exec bgp-peer timeout 10 tcpdump -c1 -pnnvli x-p0 ip6 dst 2001:db8:1:1:100:: \
+	>$tmp/vpn4_any 2>&1 &
+tcpdump_any_pid=$!
+for _ in $(seq 50); do
+	if grep -q "listening on" $tmp/vpn4_nosrh && grep -q "listening on" $tmp/vpn4_any; then
+		break
+	fi
+	sleep 0.1
+done
+
 # Verify host-a can ping host-b
 ip netns exec ns-a ping -i0.01 -c3 -n 16.1.0.2
 ip netns exec ns-b ping -i0.01 -c3 -n 16.0.0.2
+
+if ! wait $tcpdump_pid; then
+	wait $tcpdump_any_pid || true
+	cat $tmp/vpn4_any
+	fail "H_Encaps_Red on a single SID still pushed an SRH"
+fi
+wait $tcpdump_any_pid || true

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -156,3 +156,39 @@ seglist="fd00:202:a00:: fd00:202:b00:: fd00:202:c00::"
 grcli nexthop add srv6 seglist $seglist id 44
 grcli route add 192.168.0.0/16 via id 44
 ip netns exec n0 ping -i0.01 -c3 -n 192.168.60.1
+
+# h.encaps.red leaves the first segment out of the SRH, it is already carried
+# in the outer destination address. Only two entries remain: hdr_len=4,
+# last_entry=1 and segments_left=2, which RFC 8986 4.1 allows to exceed
+# last_entry by one.
+grcli nexthop add srv6 seglist $seglist encap h.encaps.red id 45
+grcli route add 192.168.0.0/16 via id 45
+
+# Start the captures before the traffic. ping -i0.2 -c5 is done emitting after
+# 0.8s, which tcpdump may not beat to opening its capture. The second capture
+# is only there to report what was really sent when the first one fails.
+ip netns exec n1 timeout 5 tcpdump -c1 -pnnli x-p1 \
+	'ip6 dst fd00:202:a00:: and ip6[41] = 4 and ip6[43] = 2 and ip6[44] = 1' \
+	>$tmp/srh_reduced 2>&1 &
+tcpdump_pid=$!
+ip netns exec n1 timeout 5 tcpdump -c1 -pnnvli x-p1 ip6 dst fd00:202:a00:: \
+	>$tmp/srh_any 2>&1 &
+tcpdump_any_pid=$!
+for _ in $(seq 50); do
+	if grep -q "listening on" $tmp/srh_reduced && grep -q "listening on" $tmp/srh_any; then
+		break
+	fi
+	sleep 0.1
+done
+
+ip netns exec n0 ping -i0.2 -c5 -n 192.168.60.1 >/dev/null 2>&1 &
+ping_pid=$!
+
+if ! wait $tcpdump_pid; then
+	wait $tcpdump_any_pid || true
+	wait $ping_pid || true
+	cat $tmp/srh_any
+	fail "h.encaps.red did not produce a reduced SRH"
+fi
+wait $tcpdump_any_pid || true
+wait $ping_pid || fail "h.encaps.red did not forward"

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -192,3 +192,53 @@ if ! wait $tcpdump_pid; then
 fi
 wait $tcpdump_any_pid || true
 wait $ping_pid || fail "h.encaps.red did not forward"
+
+#
+# uSID headend test
+#
+# fd00:202:0d00:0e00:: is a CSID container packing the uSIDs 0d00 and 0e00
+# with block-bits=32, csid-bits=16. grout only copies segment list entries, so
+# a container goes through both encap behaviors untouched. With h.encaps.red
+# and a single container no SRH is left at all, which is the usual uSID
+# deployment.
+#
+
+ip -n n1 -6 route add fd00:202:0d00::/48 encap seg6local action End \
+	flavors next-csid lblen 32 nflen 16 dev x-p1
+ip -n n1 -6 route add fd00:202:0e00:: encap seg6local action End.DX4 \
+	nh4 192.168.60.1 count dev x-p1
+
+# h.encaps still emits an SRH holding the container alone, segments_left=0
+grcli nexthop add srv6 seglist fd00:202:0d00:0e00:: id 46
+grcli route add 192.168.0.0/16 via id 46
+ip netns exec n0 ping -i0.01 -c3 -n 192.168.60.1
+
+# h.encaps.red has nothing left to put in an SRH, so the outer header must
+# point straight at the inner packet instead of a routing header.
+grcli nexthop add srv6 seglist fd00:202:0d00:0e00:: encap h.encaps.red id 47
+grcli route add 192.168.0.0/16 via id 47
+
+ip netns exec n1 timeout 5 tcpdump -c1 -pnnli x-p1 \
+	'ip6 dst fd00:202:0d00:0e00:: and ip6[6] = 4' >$tmp/usid_nosrh 2>&1 &
+tcpdump_pid=$!
+ip netns exec n1 timeout 5 tcpdump -c1 -pnnvli x-p1 ip6 dst fd00:202:0d00:0e00:: \
+	>$tmp/usid_any 2>&1 &
+tcpdump_any_pid=$!
+for _ in $(seq 50); do
+	if grep -q "listening on" $tmp/usid_nosrh && grep -q "listening on" $tmp/usid_any; then
+		break
+	fi
+	sleep 0.1
+done
+
+ip netns exec n0 ping -i0.2 -c5 -n 192.168.60.1 >/dev/null 2>&1 &
+ping_pid=$!
+
+if ! wait $tcpdump_pid; then
+	wait $tcpdump_any_pid || true
+	wait $ping_pid || true
+	cat $tmp/usid_any
+	fail "h.encaps.red on a single container still pushed an SRH"
+fi
+wait $tcpdump_any_pid || true
+wait $ping_pid || fail "uSID container encapsulation did not forward"

--- a/smoke/srv6_test.sh
+++ b/smoke/srv6_test.sh
@@ -135,3 +135,24 @@ ip -n n1 -6 route add fd00:202::/32 via fd00:102::1 dev x-p1 table 10
 
 # test
 ip netns exec n0 ping6 -i0.01 -c3 -n fd00:60::1
+
+#
+# Multi-segment encapsulation test
+#
+# fd00:202:a00:: and fd00:202:b00:: are plain transit nodes, fd00:202:c00::
+# decaps back into the public network. Linux validates the SRH of every
+# packet it receives, so an SRH advertising the wrong number of entries
+# breaks forwarding outright.
+#
+
+ip -n n1 -6 route add fd00:202:a00:: encap seg6local action End count dev x-p1
+ip -n n1 -6 route add fd00:202:b00:: encap seg6local action End count dev x-p1
+ip -n n1 -6 route add fd00:202:c00:: encap seg6local action End.DX4 \
+	nh4 192.168.60.1 count dev x-p1
+
+seglist="fd00:202:a00:: fd00:202:b00:: fd00:202:c00::"
+
+# h.encaps carries the three segments in the SRH: last_entry=2, segments_left=2
+grcli nexthop add srv6 seglist $seglist id 44
+grcli route add 192.168.0.0/16 via id 44
+ip netns exec n0 ping -i0.01 -c3 -n 192.168.60.1


### PR DESCRIPTION
Two independent bugs in the SRv6 headend, both from 7d88a1443587
("srv6: add srv6 module"). Every test so far used a single segment with
the default encap behavior, which is why neither showed up.

`struct rte_ipv6_routing_ext` has a 32 bit `flags` field aliasing
`last_entry`, so clearing `flags` after assigning `last_entry` wipes it.
Encapsulated packets always advertise a last entry of 0, and Linux drops
such an SRH beyond two segments. This hits `h.encaps`, FRR's default, so
a three segment policy does not forward at all.

In `h.encaps.red` the SRH was sized for the full segment list while the
fill loop skips the first segment. The last slot was never written, so 16
bytes of stale mbuf headroom went on the wire:

```
RT6 (len=4, type=4, segleft=1, last-entry=0,
     [0]fd00:202:900::, [1]fd00:a68f:c1ce:4839:2e3:ad74:509b:800)
```

Those trailing bytes are the MAC addresses of previously handled packets.
Forwarding still works, hence the wire level assertion in the tests
rather than a ping.

The four combinations of encap behavior and segment count are now
covered, including the reduced single segment case where no SRH is
emitted at all. Each fix ships with the test section it makes pass, so
every commit is green on its own.
